### PR TITLE
Faster Biot Savart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,14 @@ jobs:
       run: |
         pip install mpi4py
 
+    - name: Install gcc 11
+      run: sudo apt-get install gcc-11 g++-11
+
     - name: Install simsopt package
       run: pip install -v .
+      env:
+        CC: gcc-11
+        CXX: g++-11
 
     - name: Run mpi unit tests
       if: "contains(matrix.test-type, 'unit')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,14 +170,8 @@ jobs:
       run: |
         pip install mpi4py
 
-    - name: Install gcc 11
-      run: sudo apt-get install gcc-11 g++-11
-
     - name: Install simsopt package
       run: pip install -v .
-      env:
-        CC: gcc-11
-        CXX: g++-11
 
     - name: Run mpi unit tests
       if: "contains(matrix.test-type, 'unit')"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ set(XTENSOR_USE_OPENMP 0)
 
 
 pybind11_add_module(${PROJECT_NAME}
-    src/simsgeopp/python.cpp src/simsgeopp/biot_savart.cpp src/simsgeopp/biot_savart_derivative.cpp
+    src/simsgeopp/python.cpp src/simsgeopp/biot_savart_py.cpp src/simsgeopp/biot_savart_vjp_py.cpp
     )
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
@@ -52,13 +52,12 @@ set_target_properties(${PROJECT_NAME}
     CXX_STANDARD_REQUIRED ON)
 target_include_directories(${PROJECT_NAME} PRIVATE "thirdparty/xtensor/include" "thirdparty/xtensor-python/include" "thirdparty/xsimd/include" "thirdparty/xtl/include" "thirdparty/eigen" ${Python_NumPy_INCLUDE_DIRS} "src/simsgeopp/")
 
-add_executable(profiling profiling/profiling.cpp src/simsgeopp/biot_savart.cpp src/simsgeopp/biot_savart_derivative.cpp)
+add_executable(profiling profiling/profiling.cpp src/simsgeopp/biot_savart_c.cpp src/simsgeopp/biot_savart_vjp_c.cpp)
 set_target_properties(profiling
     PROPERTIES
     CXX_STANDARD 14
     CXX_STANDARD_REQUIRED ON)
-target_include_directories(profiling PRIVATE  "thirdparty/xtensor/include" "thirdparty/xtensor-python/include" "thirdparty/xsimd/include" "thirdparty/xtl/include" "thirdparty/eigen" ${PYTHON_INCLUDE_DIRS} ${Python_NumPy_INCLUDE_DIRS} "src/simsgeopp/" ${PYBIND11_INCLUDE_DIR})
-target_link_libraries(profiling PRIVATE ${PYTHON_LIBRARIES})
+target_include_directories(profiling PRIVATE  "thirdparty/xtensor/include" "thirdparty/xsimd/include" "thirdparty/xtl/include" "thirdparty/eigen" "src/simsgeopp/")
 
 
 if(OpenMP_CXX_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,10 @@ endif()
 
 IF(DEFINED ENV{CI})
     message(STATUS "CI environment detected. Set compilation flags accordingly (target ivybridge which supports avx).")
-    set(CMAKE_CXX_FLAGS "-O3 -march=ivybridge")
+    set(CMAKE_CXX_FLAGS "-O3 -march=ivybridge -mfma -ffp-contract=fast")
 else()
     message(STATUS "Local build detected. Set compilation flags accordingly (march=native).")
-    set(CMAKE_CXX_FLAGS "-O3 -march=native")
+    set(CMAKE_CXX_FLAGS "-O3 -march=native -mfma -ffp-contract=fast")
 endif()
 
 add_subdirectory(thirdparty/pybind11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,13 @@ if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
     endif()
 endif()
 
-set(CMAKE_CXX_FLAGS "-O2 -march=x86-64")
+IF(DEFINED ENV{CI})
+    message(STATUS "CI environment detected. Set compilation flags accordingly (target ivybridge which supports avx).")
+    set(CMAKE_CXX_FLAGS "-O3 -march=ivybridge")
+else()
+    message(STATUS "Local build detected. Set compilation flags accordingly (march=native).")
+    set(CMAKE_CXX_FLAGS "-O3 -march=native")
+endif()
 
 add_subdirectory(thirdparty/pybind11)
 set(XTENSOR_USE_OPENMP 0)
@@ -46,6 +52,13 @@ set_target_properties(${PROJECT_NAME}
     CXX_STANDARD_REQUIRED ON)
 target_include_directories(${PROJECT_NAME} PRIVATE "thirdparty/xtensor/include" "thirdparty/xtensor-python/include" "thirdparty/xsimd/include" "thirdparty/xtl/include" "thirdparty/eigen" ${Python_NumPy_INCLUDE_DIRS} "src/simsgeopp/")
 
+add_executable(profiling profiling/profiling.cpp src/simsgeopp/biot_savart.cpp src/simsgeopp/biot_savart_derivative.cpp)
+set_target_properties(profiling
+    PROPERTIES
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED ON)
+target_include_directories(profiling PRIVATE  "thirdparty/xtensor/include" "thirdparty/xtensor-python/include" "thirdparty/xsimd/include" "thirdparty/xtl/include" "thirdparty/eigen" ${PYTHON_INCLUDE_DIRS} ${Python_NumPy_INCLUDE_DIRS} "src/simsgeopp/" ${PYBIND11_INCLUDE_DIR})
+target_link_libraries(profiling PRIVATE ${PYTHON_LIBRARIES})
 
 
 if(OpenMP_CXX_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 
 IF(DEFINED ENV{CI})
     message(STATUS "CI environment detected. Set compilation flags accordingly (target ivybridge which supports avx).")
-    set(CMAKE_CXX_FLAGS "-O3 -march=x86-64-v3 -mfma -ffp-contract=fast")
+    set(CMAKE_CXX_FLAGS "-O3 -march=ivybridge -mfma -ffp-contract=fast")
 else()
     message(STATUS "Local build detected. Set compilation flags accordingly (march=native).")
     set(CMAKE_CXX_FLAGS "-O3 -march=native -mfma -ffp-contract=fast")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 
 IF(DEFINED ENV{CI})
     message(STATUS "CI environment detected. Set compilation flags accordingly (target ivybridge which supports avx).")
-    set(CMAKE_CXX_FLAGS "-O3 -march=ivybridge -mfma -ffp-contract=fast")
+    set(CMAKE_CXX_FLAGS "-O3 -march=x86-64-v3 -mfma -ffp-contract=fast")
 else()
     message(STATUS "Local build detected. Set compilation flags accordingly (march=native).")
     set(CMAKE_CXX_FLAGS "-O3 -march=native -mfma -ffp-contract=fast")

--- a/profiling/profiling.cpp
+++ b/profiling/profiling.cpp
@@ -72,10 +72,10 @@ void profile_biot_savart_vjp(int nsources, int ntargets, int nderivatives){
         pointsz[i] = points(i, 2);
     }
 
-    auto res_gamma = xt::xarray<double>::from_shape({points.shape(0), 3});
-    auto res_dgamma_by_dphi = xt::xarray<double>::from_shape({points.shape(0), 3});
-    auto res_grad_gamma = xt::xarray<double>::from_shape({points.shape(0), 3});
-    auto res_grad_dgamma_by_dphi = xt::xarray<double>::from_shape({points.shape(0), 3});
+    xt::xarray<double> res_gamma = xt::zeros<double>({nsources, 3});
+    xt::xarray<double> res_dgamma_by_dphi = xt::zeros<double>({nsources, 3});
+    xt::xarray<double> res_grad_gamma = xt::zeros<double>({nsources, 3});
+    xt::xarray<double> res_grad_dgamma_by_dphi = xt::zeros<double>({nsources, 3});
 
 
     int n = int(1e8/(nsources*ntargets));

--- a/profiling/profiling.cpp
+++ b/profiling/profiling.cpp
@@ -1,0 +1,66 @@
+#define FORCE_IMPORT_ARRAY
+#include "xtensor/xnpy.hpp"
+#include "xtensor/xrandom.hpp"
+#include "biot_savart.h"
+#include <chrono>
+#include <iostream>
+#include <cstdlib>
+#include <stdint.h>
+uint64_t rdtsc(){
+    unsigned int lo,hi;
+    __asm__ __volatile__ ("rdtsc" : "=a" (lo), "=d" (hi));
+    return ((uint64_t)hi << 32) | lo;
+}
+
+void profile_biot_savart(int nsources, int ntargets, int nderivatives){ 
+    xt::xarray<double> points         = xt::random::randn<double>({ntargets, 3});
+    xt::xarray<double> gamma          = xt::random::randn<double>({nsources, 3});
+    xt::xarray<double> dgamma_by_dphi = xt::random::randn<double>({nsources, 3});
+
+    auto pointsx = vector_type(points.shape(0), 0);
+    auto pointsy = vector_type(points.shape(0), 0);
+    auto pointsz = vector_type(points.shape(0), 0);
+    for (int i = 0; i < points.shape(0); ++i) {
+        pointsx[i] = points(i, 0);
+        pointsy[i] = points(i, 1);
+        pointsz[i] = points(i, 2);
+    }
+    auto B = xt::xarray<double>::from_shape({points.shape(0), 3});
+    auto dB_by_dX = xt::xarray<double>::from_shape({points.shape(0), 3, 3});
+    auto d2B_by_dXdX = xt::xarray<double>::from_shape({points.shape(0), 3, 3, 3});
+    int n = int(1e9/(nsources*ntargets));
+
+    uint64_t tick = rdtsc();  // tick before
+    auto t1 = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < n; ++i) {
+        if(nderivatives == 0)
+            biot_savart_kernel<xt::xarray<double>, 0>(pointsx, pointsy, pointsz, gamma, dgamma_by_dphi, B, dB_by_dX, d2B_by_dXdX);
+        else if(nderivatives == 1)
+            biot_savart_kernel<xt::xarray<double>, 1>(pointsx, pointsy, pointsz, gamma, dgamma_by_dphi, B, dB_by_dX, d2B_by_dXdX);
+        else
+            biot_savart_kernel<xt::xarray<double>, 2>(pointsx, pointsy, pointsz, gamma, dgamma_by_dphi, B, dB_by_dX, d2B_by_dXdX);
+        //if(i==0){
+        //    std::cout << B(0, 0) << " " << B(8, 0) << std::endl;
+        //    std::cout << dB_by_dX(0, 0, 0) << " " << dB_by_dX(8, 0, 0) << std::endl;
+        //    std::cout << d2B_by_dXdX(0, 0, 0, 0) << " " << d2B_by_dXdX(8, 0, 0, 0) << std::endl;
+        //}
+    }
+    auto t2 = std::chrono::high_resolution_clock::now();
+    auto clockcycles = rdtsc() - tick;
+    double simdtime = std::chrono::duration_cast<std::chrono::milliseconds>( t2 - t1 ).count();
+    double interactions = points.shape(0) * gamma.shape(0) * n;
+    std::cout << std::setw (10) << nsources*ntargets 
+        << std::setw (13) << simdtime/n 
+        << std::setw (19) << std::setprecision(5) << (interactions/(1e9 * simdtime/1000.)) << std::endl;
+}
+
+
+int main() {
+    for(int nd=0; nd<3; nd++) {
+        std::cout << "Number of derivatives: " << nd << std::endl;
+        std::cout << "         N" << " Time (in ms)" << " Gigainteractions/s" << std::endl;
+        for(int nst=100; nst<=10000; nst*=10)
+            profile_biot_savart(nst, nst, nd);
+    }
+    return 0;
+}

--- a/profiling/profiling.cpp
+++ b/profiling/profiling.cpp
@@ -28,7 +28,7 @@ void profile_biot_savart(int nsources, int ntargets, int nderivatives){
     auto B = xt::xarray<double>::from_shape({points.shape(0), 3});
     auto dB_by_dX = xt::xarray<double>::from_shape({points.shape(0), 3, 3});
     auto d2B_by_dXdX = xt::xarray<double>::from_shape({points.shape(0), 3, 3, 3});
-    int n = int(1e9/(nsources*ntargets));
+    int n = int(1e8/(nsources*ntargets));
 
     uint64_t tick = rdtsc();  // tick before
     auto t1 = std::chrono::high_resolution_clock::now();
@@ -51,15 +51,16 @@ void profile_biot_savart(int nsources, int ntargets, int nderivatives){
     double interactions = points.shape(0) * gamma.shape(0) * n;
     std::cout << std::setw (10) << nsources*ntargets 
         << std::setw (13) << simdtime/n 
-        << std::setw (19) << std::setprecision(5) << (interactions/(1e9 * simdtime/1000.)) << std::endl;
+        << std::setw (19) << std::setprecision(5) << (interactions/(1e9 * simdtime/1000.)) 
+        << std::setw (19)<< clockcycles/interactions << std::endl;
 }
 
 
 int main() {
     for(int nd=0; nd<3; nd++) {
         std::cout << "Number of derivatives: " << nd << std::endl;
-        std::cout << "         N" << " Time (in ms)" << " Gigainteractions/s" << std::endl;
-        for(int nst=100; nst<=10000; nst*=10)
+        std::cout << "         N" << " Time (in ms)" << " Gigainteractions/s" << " cycles/interaction" << std::endl;
+        for(int nst=10; nst<=10000; nst*=10)
             profile_biot_savart(nst, nst, nd);
     }
     return 0;

--- a/profiling/profiling.cpp
+++ b/profiling/profiling.cpp
@@ -18,19 +18,19 @@ void profile_biot_savart(int nsources, int ntargets, int nderivatives){
     xt::xarray<double> gamma          = xt::random::randn<double>({nsources, 3});
     xt::xarray<double> dgamma_by_dphi = xt::random::randn<double>({nsources, 3});
 
-    auto pointsx = vector_type(points.shape(0), 0);
-    auto pointsy = vector_type(points.shape(0), 0);
-    auto pointsz = vector_type(points.shape(0), 0);
-    for (int i = 0; i < points.shape(0); ++i) {
-        pointsx[i] = points(i, 0);
-        pointsy[i] = points(i, 1);
-        pointsz[i] = points(i, 2);
-    }
     auto B = xt::xarray<double>::from_shape({points.shape(0), 3});
     auto dB_by_dX = xt::xarray<double>::from_shape({points.shape(0), 3, 3});
     auto d2B_by_dXdX = xt::xarray<double>::from_shape({points.shape(0), 3, 3, 3});
     int n = int(1e8/(nsources*ntargets));
 
+    auto pointsx = vector_type(ntargets, 0);
+    auto pointsy = vector_type(ntargets, 0);
+    auto pointsz = vector_type(ntargets, 0);
+    for (int j = 0; j < ntargets; ++j) {
+        pointsx[j] = points(j, 0);
+        pointsy[j] = points(j, 1);
+        pointsz[j] = points(j, 2);
+    }
     uint64_t tick = rdtsc();  // tick before
     auto t1 = std::chrono::high_resolution_clock::now();
     for (int i = 0; i < n; ++i) {

--- a/profiling/profiling.cpp
+++ b/profiling/profiling.cpp
@@ -1,12 +1,10 @@
-//#define FORCE_IMPORT_ARRAY
-#include "xtensor/xnpy.hpp"
 #include "xtensor/xrandom.hpp"
-
 #include "biot_savart_c.h"
 #include "biot_savart_vjp_c.h"
 
 #include <chrono>
 #include <iostream>
+#include <iomanip>
 #include <cstdlib>
 #include <stdint.h>
 uint64_t rdtsc(){

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ class CMakeBuild(build_ext):
             ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp
         )
         subprocess.check_call(
-            ["cmake", "--build", "."] + build_args, cwd=self.build_temp
+            ["cmake", "--build", ".", "--target", "simsgeopp"] + build_args, cwd=self.build_temp
         )
 
 

--- a/src/simsgeopp/biot_savart.cpp
+++ b/src/simsgeopp/biot_savart.cpp
@@ -99,7 +99,7 @@ void biot_savart_kernel(vector_type& pointsx, vector_type& pointsy, vector_type&
                     auto norm_diff_5_inv = norm_diff_4_inv*norm_diff_inv;;
                     auto norm_diff_7_inv = norm_diff_4_inv*norm_diff_3_inv;
                     auto term124fak = (-3.)*norm_diff_5_inv;
-                    auto norm_diff_7_inv_15 = norm_diff_5_inv*15.;
+                    auto norm_diff_7_inv_15 = norm_diff_7_inv*15.;
 #pragma unroll
                     for(int k1=0; k1<3; k1++) {
 #pragma unroll

--- a/src/simsgeopp/biot_savart.cpp
+++ b/src/simsgeopp/biot_savart.cpp
@@ -67,8 +67,6 @@ void biot_savart_kernel(vector_type& pointsx, vector_type& pointsy, vector_type&
 
             auto dgamma_by_dphi_j_simd = Vec3dSimd(dgamma_by_dphi(j, 0), dgamma_by_dphi(j, 1), dgamma_by_dphi(j, 2));
             auto dgamma_by_dphi_j_cross_diff = cross(dgamma_by_dphi_j_simd, diff);
-            //auto temp = dgamma_by_dphi_j_simd*norm_diff_3_inv;
-            //cross(temp, diff, B_i.x, B_i.y, B_i.z);
             B_i.x = xsimd::fma(dgamma_by_dphi_j_cross_diff.x, norm_diff_3_inv, B_i.x);
             B_i.y = xsimd::fma(dgamma_by_dphi_j_cross_diff.y, norm_diff_3_inv, B_i.y);
             B_i.z = xsimd::fma(dgamma_by_dphi_j_cross_diff.z, norm_diff_3_inv, B_i.z);

--- a/src/simsgeopp/biot_savart.h
+++ b/src/simsgeopp/biot_savart.h
@@ -184,7 +184,7 @@ inline Vec3dSimd cross(int i, Vec3dSimd& b){
 }
 
 inline simd_t normsq(Vec3dSimd& a){
-    return a.x*a.x+a.y*a.y+a.z*a.z;
+    return xsimd::fma(a.x, a.x, xsimd::fma(a.y, a.y, a.z*a.z));
 }
 
 template<class T, int derivs>

--- a/src/simsgeopp/biot_savart.h
+++ b/src/simsgeopp/biot_savart.h
@@ -156,15 +156,6 @@ inline Vec3dSimd cross(Vec3dSimd& a, Vec3dSimd& b){
             );
 }
 
-inline void cross(Vec3dSimd& a, Vec3dSimd& b, simd_t& cx, simd_t& cy, simd_t& cz){
-    cx = xsimd::fma(a.y, b.z, cx);
-    cx = xsimd::fnma(a.z, b.y, cx);
-    cy = xsimd::fma(a.z, b.x, cy);
-    cy = xsimd::fnma(a.x, b.z, cy);
-    cz = xsimd::fma(a.x, b.y, cz);
-    cz = xsimd::fnma(a.y, b.x, cz);
-}
-
 inline Vec3dSimd cross(Vec3dSimd& a, Vec3d& b){
     return Vec3dSimd(a.y * b[2] - a.z * b[1], a.z * b[0] - a.x * b[2], a.x * b[1] - a.y * b[0]);
 

--- a/src/simsgeopp/biot_savart.h
+++ b/src/simsgeopp/biot_savart.h
@@ -156,6 +156,15 @@ inline Vec3dSimd cross(Vec3dSimd& a, Vec3dSimd& b){
             );
 }
 
+inline void cross(Vec3dSimd& a, Vec3dSimd& b, simd_t& cx, simd_t& cy, simd_t& cz){
+    cx = xsimd::fma(a.y, b.z, cx);
+    cx = xsimd::fnma(a.z, b.y, cx);
+    cy = xsimd::fma(a.z, b.x, cy);
+    cy = xsimd::fnma(a.x, b.z, cy);
+    cz = xsimd::fma(a.x, b.y, cz);
+    cz = xsimd::fnma(a.y, b.x, cz);
+}
+
 inline Vec3dSimd cross(Vec3dSimd& a, Vec3d& b){
     return Vec3dSimd(a.y * b[2] - a.z * b[1], a.z * b[0] - a.x * b[2], a.x * b[1] - a.y * b[0]);
 

--- a/src/simsgeopp/biot_savart_c.cpp
+++ b/src/simsgeopp/biot_savart_c.cpp
@@ -1,0 +1,8 @@
+#include "biot_savart_impl.h"
+#include "biot_savart_c.h"
+#include "xtensor/xarray.hpp"
+
+
+template void biot_savart_kernel<xt::xarray<double>, 0>(vector_type&, vector_type&, vector_type&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&);
+template void biot_savart_kernel<xt::xarray<double>, 1>(vector_type&, vector_type&, vector_type&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&);
+template void biot_savart_kernel<xt::xarray<double>, 2>(vector_type&, vector_type&, vector_type&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&);

--- a/src/simsgeopp/biot_savart_c.h
+++ b/src/simsgeopp/biot_savart_c.h
@@ -1,0 +1,5 @@
+#pragma once
+#include "simdhelpers.h"
+
+template<class T, int derivs>
+void biot_savart_kernel(vector_type& pointsx, vector_type& pointsy, vector_type& pointsz, T& gamma, T& dgamma_by_dphi, T& B, T& dB_by_dX, T& d2B_by_dXdX);

--- a/src/simsgeopp/biot_savart_impl.h
+++ b/src/simsgeopp/biot_savart_impl.h
@@ -39,9 +39,12 @@ void biot_savart_kernel(vector_type& pointsx, vector_type& pointsy, vector_type&
             Vec3dSimd(), Vec3dSimd(), Vec3dSimd() 
         };
     }
+    double fak = (1e-7/num_quad_points);
     double* gamma_j_ptr = &(gamma(0, 0));
     double* dgamma_j_by_dphi_ptr = &(dgamma_by_dphi(0, 0));
-    for(int i = 0; i < num_points-num_points%simd_size; i += simd_size) {
+    // out vectors pointsx, pointsy, and pointsz are added and aligned, so we
+    // don't have to worry about going out of bounds here
+    for(int i = 0; i < num_points; i += simd_size) {
         auto point_i = Vec3dSimd(&(pointsx[i]), &(pointsy[i]), &(pointsz[i]));
         auto B_i   = Vec3dSimd();
         MYIF(derivs > 0) {
@@ -120,94 +123,39 @@ void biot_savart_kernel(vector_type& pointsx, vector_type& pointsy, vector_type&
                 }
             }
         }
-
-        for(int j=0; j<simd_size; j++){
-            B(i+j, 0) = B_i.x[j];
-            B(i+j, 1) = B_i.y[j];
-            B(i+j, 2) = B_i.z[j];
+        // in the last iteration of the loop over i, we might overshoot. e.g.
+        // consider num_points=11.  then in the first two iterations we deal
+        // with 0-3, 4-7, in the final iteration we only want 8-10, but have
+        // actually computed for i from 8-11 since we always work on full simd
+        // vectors. so we have to ignore those results. Disgarding the unneeded
+        // entries is actually faster than falling back to scalar operations
+        // (which would require treat i = 8, 9, 10 all individually).
+        int jlimit = std::min(simd_size, num_points-i);
+        for(int j=0; j<jlimit; j++){
+            B(i+j, 0) = fak * B_i.x[j];
+            B(i+j, 1) = fak * B_i.y[j];
+            B(i+j, 2) = fak * B_i.z[j];
             MYIF(derivs > 0) {
                 for(int k=0; k<3; k++) {
-                    dB_by_dX(i+j, k, 0) = dB_dX_i[k].x[j];
-                    dB_by_dX(i+j, k, 1) = dB_dX_i[k].y[j];
-                    dB_by_dX(i+j, k, 2) = dB_dX_i[k].z[j];
+                    dB_by_dX(i+j, k, 0) = fak*dB_dX_i[k].x[j];
+                    dB_by_dX(i+j, k, 1) = fak*dB_dX_i[k].y[j];
+                    dB_by_dX(i+j, k, 2) = fak*dB_dX_i[k].z[j];
                 }
             }
             MYIF(derivs > 1) {
                 for(int k1=0; k1<3; k1++) {
                     for(int k2=0; k2<=k1; k2++) {
-                        d2B_by_dXdX(i+j, k1, k2, 0) = d2B_dXdX_i[3*k1 + k2].x[j];
-                        d2B_by_dXdX(i+j, k1, k2, 1) = d2B_dXdX_i[3*k1 + k2].y[j];
-                        d2B_by_dXdX(i+j, k1, k2, 2) = d2B_dXdX_i[3*k1 + k2].z[j];
+                        d2B_by_dXdX(i+j, k1, k2, 0) = fak*d2B_dXdX_i[3*k1 + k2].x[j];
+                        d2B_by_dXdX(i+j, k1, k2, 1) = fak*d2B_dXdX_i[3*k1 + k2].y[j];
+                        d2B_by_dXdX(i+j, k1, k2, 2) = fak*d2B_dXdX_i[3*k1 + k2].z[j];
                         if(k2 < k1){
-                            d2B_by_dXdX(i+j, k2, k1, 0) = d2B_dXdX_i[3*k1 + k2].x[j];
-                            d2B_by_dXdX(i+j, k2, k1, 1) = d2B_dXdX_i[3*k1 + k2].y[j];
-                            d2B_by_dXdX(i+j, k2, k1, 2) = d2B_dXdX_i[3*k1 + k2].z[j];
+                            d2B_by_dXdX(i+j, k2, k1, 0) = fak*d2B_dXdX_i[3*k1 + k2].x[j];
+                            d2B_by_dXdX(i+j, k2, k1, 1) = fak*d2B_dXdX_i[3*k1 + k2].y[j];
+                            d2B_by_dXdX(i+j, k2, k1, 2) = fak*d2B_dXdX_i[3*k1 + k2].z[j];
                         }
                     }
                 }
             }
         }
     }
-    for (int i = num_points - num_points % simd_size; i < num_points; ++i) {
-        auto point_i = Vec3d{pointsx[i], pointsy[i], pointsz[i]};
-        B(i, 0) = 0;
-        B(i, 1) = 0;
-        B(i, 2) = 0;
-        for (int j = 0; j < num_quad_points; ++j) {
-            Vec3d diff = point_i - Vec3d{gamma_j_ptr[3*j+0], gamma_j_ptr[3*j+1], gamma_j_ptr[3*j+2]};
-            Vec3d dgamma_by_dphi_j = Vec3d{dgamma_j_by_dphi_ptr[3*j+0], dgamma_j_by_dphi_ptr[3*j+1], dgamma_j_by_dphi_ptr[3*j+2]};
-            double norm_diff_2 = diff.coeff(0)*diff.coeff(0) + diff.coeff(1)*diff.coeff(1) + diff.coeff(2)*diff.coeff(2);
-            double norm_diff = sqrt(norm_diff_2);
-            double norm_diff_inv = 1./norm_diff;
-            double norm_diff_2_inv = norm_diff_inv*norm_diff_inv;
-            double norm_diff_3_inv = norm_diff_2_inv*norm_diff_inv;
-            Vec3d dgamma_by_dphi_j_cross_diff = cross(dgamma_by_dphi_j, diff);
-            Vec3d B_i = dgamma_by_dphi_j_cross_diff*norm_diff_3_inv;
-
-            B(i, 0) += B_i.coeff(0);
-            B(i, 1) += B_i.coeff(1);
-            B(i, 2) += B_i.coeff(2);
-            MYIF(derivs > 0) {
-                double norm_diff_4_inv = norm_diff_2_inv*norm_diff_2_inv;
-                Vec3d three_dgamma_by_dphi_cross_diff_by_norm_diff = dgamma_by_dphi_j_cross_diff * 3 * norm_diff_inv;
-                Vec3d dgamma_by_dphi_j_norm_diff = dgamma_by_dphi_j*norm_diff;
-#pragma unroll
-                for(int k=0; k<3; k++) {
-                    Vec3d numerator1 = cross(dgamma_by_dphi_j_norm_diff, k);
-                    Vec3d numerator2 = three_dgamma_by_dphi_cross_diff_by_norm_diff * diff[k];
-                    Vec3d temp = (numerator1-numerator2) * norm_diff_4_inv;
-                    dB_by_dX(i, k, 0) += temp.coeff(0);
-                    dB_by_dX(i, k, 1) += temp.coeff(1);
-                    dB_by_dX(i, k, 2) += temp.coeff(2);
-                }
-                MYIF(derivs > 1) {
-                    double norm_diff_5_inv = norm_diff_4_inv*norm_diff_inv;
-                    double norm_diff_7_inv = norm_diff_5_inv*norm_diff_2_inv;
-#pragma unroll
-                    for(int k1=0; k1<3; k1++) {
-#pragma unroll
-                        for(int k2=0; k2<3; k2++) {
-                            Vec3d term1 = -3 * (diff[k1]*norm_diff_5_inv) * cross(dgamma_by_dphi_j, k2);
-                            Vec3d term2 = -3 * (diff[k2]*norm_diff_5_inv) * cross(dgamma_by_dphi_j, k1);
-                            Vec3d term3 = 15 * (diff[k1] * diff[k2] * norm_diff_7_inv) * dgamma_by_dphi_j_cross_diff;
-                            Vec3d term4 = Vec3d{0., 0., 0.};
-                            if(k1 == k2) {
-                                term4 = -3 * norm_diff_5_inv * dgamma_by_dphi_j_cross_diff;
-                            }
-                            Vec3d temp = (term1 + term2 + term3 + term4);
-                            d2B_by_dXdX(i, k1, k2, 0) += temp.coeff(0);
-                            d2B_by_dXdX(i, k1, k2, 1) += temp.coeff(1);
-                            d2B_by_dXdX(i, k1, k2, 2) += temp.coeff(2);
-                        }
-                    }
-                }
-            }
-        }
-    }
-    double fak = (1e-7/num_quad_points);
-    B *= fak;
-    MYIF(derivs > 0)
-        dB_by_dX *= fak;
-    MYIF(derivs > 1)
-        d2B_by_dXdX *= fak;
 }

--- a/src/simsgeopp/biot_savart_impl.h
+++ b/src/simsgeopp/biot_savart_impl.h
@@ -72,7 +72,7 @@ void biot_savart_kernel(vector_type& pointsx, vector_type& pointsy, vector_type&
             MYIF(derivs > 0) {
                 auto norm_diff_4_inv = norm_diff_3_inv*norm_diff_inv;
                 auto three_dgamma_by_dphi_cross_diff_by_norm_diff = dgamma_by_dphi_j_cross_diff*(3.*norm_diff_inv);
-                auto norm_diff = 1./norm_diff_inv;
+                auto norm_diff = norm_diff_2*norm_diff_inv;
                 auto dgamma_by_dphi_j_simd_norm_diff = dgamma_by_dphi_j_simd * norm_diff;
 #pragma unroll
                 for(int k=0; k<3; k++) {

--- a/src/simsgeopp/biot_savart_py.cpp
+++ b/src/simsgeopp/biot_savart_py.cpp
@@ -1,0 +1,54 @@
+#include "biot_savart_impl.h"
+#include "biot_savart_py.h"
+
+void biot_savart(Array& points, vector<Array>& gammas, vector<Array>& dgamma_by_dphis, vector<Array>& B, vector<Array>& dB_by_dX, vector<Array>& d2B_by_dXdX) {
+    auto pointsx = vector_type(points.shape(0), 0);
+    auto pointsy = vector_type(points.shape(0), 0);
+    auto pointsz = vector_type(points.shape(0), 0);
+    int num_points = points.shape(0);
+    for (int i = 0; i < num_points; ++i) {
+        pointsx[i] = points(i, 0);
+        pointsy[i] = points(i, 1);
+        pointsz[i] = points(i, 2);
+    }
+    int num_coils  = gammas.size();
+
+    Array dummyjac = xt::zeros<double>({1, 1, 1});
+    Array dummyhess = xt::zeros<double>({1, 1, 1, 1});
+
+    int nderivs = 0;
+    if(dB_by_dX.size() == num_coils) {
+        nderivs = 1;
+        if(d2B_by_dXdX.size() == num_coils) {
+            nderivs = 2;
+        }
+    }
+
+#pragma omp parallel for
+    for(int i=0; i<num_coils; i++) {
+        if(nderivs == 2)
+            biot_savart_kernel<Array, 2>(pointsx, pointsy, pointsz, gammas[i], dgamma_by_dphis[i], B[i], dB_by_dX[i], d2B_by_dXdX[i]);
+        else {
+            if(nderivs == 1) 
+                biot_savart_kernel<Array, 1>(pointsx, pointsy, pointsz, gammas[i], dgamma_by_dphis[i], B[i], dB_by_dX[i], dummyhess);
+            else
+                biot_savart_kernel<Array, 0>(pointsx, pointsy, pointsz, gammas[i], dgamma_by_dphis[i], B[i], dummyjac, dummyhess);
+        }
+    }
+}
+
+Array biot_savart_B(Array& points, vector<Array>& gammas, vector<Array>& dgamma_by_dphis, vector<double>& currents){
+    auto dB_by_dXs = vector<Array>();
+    auto d2B_by_dXdXs = vector<Array>();
+    int num_coils = currents.size();
+    auto Bs = vector<Array>(num_coils, Array());
+    for (int i = 0; i < num_coils; ++i) {
+        Bs[i] = xt::zeros<double>({points.shape(0), points.shape(1)});
+    }
+    biot_savart(points, gammas, dgamma_by_dphis, Bs, dB_by_dXs, d2B_by_dXdXs);
+    Array B = xt::zeros<double>({points.shape(0), points.shape(1)});
+    for (int i = 0; i < num_coils; ++i) {
+        B += currents[i] * Bs[i];
+    }
+    return B;
+}

--- a/src/simsgeopp/biot_savart_py.h
+++ b/src/simsgeopp/biot_savart_py.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "xtensor/xarray.hpp"
+#include "xtensor/xmath.hpp"
+#include "xtensor-python/pyarray.hpp"     // Numpy bindings
+typedef xt::pyarray<double> Array;
+
+void biot_savart(Array& points, vector<Array>& gammas, vector<Array>& dgamma_by_dphis, vector<Array>& B, vector<Array>& dB_by_dX, vector<Array>& d2B_by_dXdX);
+//void biot_savart_vjp(Array& points, vector<Array>& gammas, vector<Array>& dgamma_by_dphis, vector<double>& currents, Array& v, Array& vgrad, vector<Array>& dgamma_by_dcoeffs, vector<Array>& d2gamma_by_dphidcoeffs, vector<Array>& res_B, vector<Array>& res_dB);
+Array biot_savart_B(Array& points, vector<Array>& gammas, vector<Array>& dgamma_by_dphis, vector<double>& currents);

--- a/src/simsgeopp/biot_savart_vjp_c.cpp
+++ b/src/simsgeopp/biot_savart_vjp_c.cpp
@@ -1,0 +1,6 @@
+#include "biot_savart_vjp_impl.h"
+#include "biot_savart_vjp_c.h"
+#include "xtensor/xarray.hpp"
+
+template void biot_savart_vjp_kernel<xt::xarray<double>, 0>(vector_type&, vector_type&, vector_type&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&);
+template void biot_savart_vjp_kernel<xt::xarray<double>, 1>(vector_type&, vector_type&, vector_type&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&);

--- a/src/simsgeopp/biot_savart_vjp_c.h
+++ b/src/simsgeopp/biot_savart_vjp_c.h
@@ -1,0 +1,5 @@
+#pragma once
+#include "simdhelpers.h"
+
+template<class T, int derivs>
+void biot_savart_vjp_kernel(vector_type& pointsx, vector_type& pointsy, vector_type& pointsz, T& gamma, T& dgamma_by_dphi, T& v, T& res_gamma, T& res_dgamma_by_dphi, T& vgrad, T& res_grad_gamma, T& res_grad_dgamma_by_dphi);

--- a/src/simsgeopp/biot_savart_vjp_impl.h
+++ b/src/simsgeopp/biot_savart_vjp_impl.h
@@ -22,8 +22,12 @@ void biot_savart_vjp_kernel(vector_type& pointsx, vector_type& pointsy, vector_t
           throw std::runtime_error("dgamma_by_dphi needs to be in row-major storage order");
     if(res_gamma.layout() != xt::layout_type::row_major)
           throw std::runtime_error("res_gamma needs to be in row-major storage order");
+    if(res_dgamma_by_dphi.layout() != xt::layout_type::row_major)
+          throw std::runtime_error("res_dgamma_by_dphi needs to be in row-major storage order");
     if(res_grad_gamma.layout() != xt::layout_type::row_major)
           throw std::runtime_error("res_grad_gamma needs to be in row-major storage order");
+    if(res_grad_dgamma_by_dphi.layout() != xt::layout_type::row_major)
+          throw std::runtime_error("res_grad_dgamma_by_dphi needs to be in row-major storage order");
     int num_points         = pointsx.size();
     int num_quad_points    = gamma.shape(0);
     constexpr int simd_size = xsimd::simd_type<double>::size;

--- a/src/simsgeopp/biot_savart_vjp_impl.h
+++ b/src/simsgeopp/biot_savart_vjp_impl.h
@@ -1,4 +1,4 @@
-#include "biot_savart.h"
+#include "simdhelpers.h"
 
 // When compiled with C++17, then we use `if constexpr` to check for
 // derivatives that need to be computed.  These are actually evaluated at
@@ -145,67 +145,4 @@ void biot_savart_vjp_kernel(vector_type& pointsx, vector_type& pointsy, vector_t
 }
 
 
-template void biot_savart_vjp_kernel<xt::xarray<double>, 0>(vector_type&, vector_type&, vector_type&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&);
-template void biot_savart_vjp_kernel<xt::xarray<double>, 1>(vector_type&, vector_type&, vector_type&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&, xt::xarray<double>&);
 
-void biot_savart_vjp(Array& points, vector<Array>& gammas, vector<Array>& dgamma_by_dphis, vector<double>& currents, Array& v, Array& vgrad, vector<Array>& dgamma_by_dcoeffs, vector<Array>& d2gamma_by_dphidcoeffs, vector<Array>& res_B, vector<Array>& res_dB){
-    auto pointsx = vector_type(points.shape(0), 0);
-    auto pointsy = vector_type(points.shape(0), 0);
-    auto pointsz = vector_type(points.shape(0), 0);
-    for (int i = 0; i < points.shape(0); ++i) {
-        pointsx[i] = points(i, 0);
-        pointsy[i] = points(i, 1);
-        pointsz[i] = points(i, 2);
-    }
-
-    int num_coils  = gammas.size();
-
-    auto res_gamma = std::vector<Array>(num_coils, Array());
-    auto res_dgamma_by_dphi = std::vector<Array>(num_coils, Array());
-    auto res_grad_gamma = std::vector<Array>(num_coils, Array());
-    auto res_grad_dgamma_by_dphi = std::vector<Array>(num_coils, Array());
-
-    bool compute_dB = res_dB.size() > 0;
-    // Don't understand why, but in parallel this loop segfaults...
-    for(int i=0; i<num_coils; i++) {
-        int num_points = gammas[i].shape(0);
-        res_gamma[i] = xt::zeros<double>({num_points, 3});
-        res_dgamma_by_dphi[i] = xt::zeros<double>({num_points, 3});
-        if(compute_dB) {
-            res_grad_gamma[i] = xt::zeros<double>({num_points, 3});
-            res_grad_dgamma_by_dphi[i] = xt::zeros<double>({num_points, 3});
-        }
-    }
-    Array dummy = Array();
-
-    #pragma omp parallel for
-    for(int i=0; i<num_coils; i++) {
-        if(compute_dB)
-            biot_savart_vjp_kernel<Array, 1>(pointsx, pointsy, pointsz, gammas[i], dgamma_by_dphis[i],
-                    v, res_gamma[i], res_dgamma_by_dphi[i],
-                    vgrad, res_grad_gamma[i], res_grad_dgamma_by_dphi[i]);
-        else
-            biot_savart_vjp_kernel<Array, 0>(pointsx, pointsy, pointsz, gammas[i], dgamma_by_dphis[i],
-                    v, res_gamma[i], res_dgamma_by_dphi[i], dummy, dummy, dummy);
-        int numcoeff = dgamma_by_dcoeffs[i].shape(2);
-        for (int j = 0; j < dgamma_by_dcoeffs[i].shape(0); ++j) {
-            for (int l = 0; l < 3; ++l) {
-                auto t1 = res_gamma[i](j, l);
-                auto t2 = res_dgamma_by_dphi[i](j, l);
-                for (int k = 0; k < numcoeff; ++k)
-                    res_B[i](k) += dgamma_by_dcoeffs[i](j, l, k) * t1 + d2gamma_by_dphidcoeffs[i](j, l, k) * t2;
-
-                if(compute_dB) {
-                    auto t3 = res_grad_gamma[i](j, l);
-                    auto t4 = res_grad_dgamma_by_dphi[i](j, l);
-                    for (int k = 0; k < numcoeff; ++k)
-                        res_dB[i](k) += dgamma_by_dcoeffs[i](j, l, k) * t3 + d2gamma_by_dphidcoeffs[i](j, l, k) * t4;
-                }
-            }
-        }
-        double fak = (currents[i] * 1e-7/gammas[i].shape(0));
-        res_B[i] *= fak;
-        if(compute_dB)
-            res_dB[i] *= fak;
-    }
-}

--- a/src/simsgeopp/biot_savart_vjp_py.cpp
+++ b/src/simsgeopp/biot_savart_vjp_py.cpp
@@ -1,0 +1,64 @@
+#include "biot_savart_vjp_impl.h"
+#include "biot_savart_vjp_py.h"
+
+void biot_savart_vjp(Array& points, vector<Array>& gammas, vector<Array>& dgamma_by_dphis, vector<double>& currents, Array& v, Array& vgrad, vector<Array>& dgamma_by_dcoeffs, vector<Array>& d2gamma_by_dphidcoeffs, vector<Array>& res_B, vector<Array>& res_dB){
+    auto pointsx = vector_type(points.shape(0), 0);
+    auto pointsy = vector_type(points.shape(0), 0);
+    auto pointsz = vector_type(points.shape(0), 0);
+    for (int i = 0; i < points.shape(0); ++i) {
+        pointsx[i] = points(i, 0);
+        pointsy[i] = points(i, 1);
+        pointsz[i] = points(i, 2);
+    }
+
+    int num_coils  = gammas.size();
+
+    auto res_gamma = std::vector<Array>(num_coils, Array());
+    auto res_dgamma_by_dphi = std::vector<Array>(num_coils, Array());
+    auto res_grad_gamma = std::vector<Array>(num_coils, Array());
+    auto res_grad_dgamma_by_dphi = std::vector<Array>(num_coils, Array());
+
+    bool compute_dB = res_dB.size() > 0;
+    // Don't understand why, but in parallel this loop segfaults...
+    for(int i=0; i<num_coils; i++) {
+        int num_points = gammas[i].shape(0);
+        res_gamma[i] = xt::zeros<double>({num_points, 3});
+        res_dgamma_by_dphi[i] = xt::zeros<double>({num_points, 3});
+        if(compute_dB) {
+            res_grad_gamma[i] = xt::zeros<double>({num_points, 3});
+            res_grad_dgamma_by_dphi[i] = xt::zeros<double>({num_points, 3});
+        }
+    }
+    Array dummy = Array();
+
+    #pragma omp parallel for
+    for(int i=0; i<num_coils; i++) {
+        if(compute_dB)
+            biot_savart_vjp_kernel<Array, 1>(pointsx, pointsy, pointsz, gammas[i], dgamma_by_dphis[i],
+                    v, res_gamma[i], res_dgamma_by_dphi[i],
+                    vgrad, res_grad_gamma[i], res_grad_dgamma_by_dphi[i]);
+        else
+            biot_savart_vjp_kernel<Array, 0>(pointsx, pointsy, pointsz, gammas[i], dgamma_by_dphis[i],
+                    v, res_gamma[i], res_dgamma_by_dphi[i], dummy, dummy, dummy);
+        int numcoeff = dgamma_by_dcoeffs[i].shape(2);
+        for (int j = 0; j < dgamma_by_dcoeffs[i].shape(0); ++j) {
+            for (int l = 0; l < 3; ++l) {
+                auto t1 = res_gamma[i](j, l);
+                auto t2 = res_dgamma_by_dphi[i](j, l);
+                for (int k = 0; k < numcoeff; ++k)
+                    res_B[i](k) += dgamma_by_dcoeffs[i](j, l, k) * t1 + d2gamma_by_dphidcoeffs[i](j, l, k) * t2;
+
+                if(compute_dB) {
+                    auto t3 = res_grad_gamma[i](j, l);
+                    auto t4 = res_grad_dgamma_by_dphi[i](j, l);
+                    for (int k = 0; k < numcoeff; ++k)
+                        res_dB[i](k) += dgamma_by_dcoeffs[i](j, l, k) * t3 + d2gamma_by_dphidcoeffs[i](j, l, k) * t4;
+                }
+            }
+        }
+        double fak = (currents[i] * 1e-7/gammas[i].shape(0));
+        res_B[i] *= fak;
+        if(compute_dB)
+            res_dB[i] *= fak;
+    }
+}

--- a/src/simsgeopp/biot_savart_vjp_py.h
+++ b/src/simsgeopp/biot_savart_vjp_py.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "xtensor/xarray.hpp"
+#include "xtensor/xmath.hpp"
+#include "xtensor-python/pyarray.hpp"     // Numpy bindings
+typedef xt::pyarray<double> Array;
+
+void biot_savart_vjp(Array& points, vector<Array>& gammas, vector<Array>& dgamma_by_dphis, vector<double>& currents, Array& v, Array& vgrad, vector<Array>& dgamma_by_dcoeffs, vector<Array>& d2gamma_by_dphidcoeffs, vector<Array>& res_B, vector<Array>& res_dB);

--- a/src/simsgeopp/python.cpp
+++ b/src/simsgeopp/python.cpp
@@ -19,7 +19,8 @@ typedef SurfaceXYZFourier<PyArray> PySurfaceXYZFourier;
 typedef CurveXYZFourier<PyArray> PyCurveXYZFourier;
 #include "curverzfourier.cpp"
 typedef CurveRZFourier<PyArray> PyCurveRZFourier; 
-#include "biot_savart.h"
+#include "biot_savart_py.h"
+#include "biot_savart_vjp_py.h"
 
 namespace py = pybind11;
 

--- a/src/simsgeopp/simdhelpers.h
+++ b/src/simsgeopp/simdhelpers.h
@@ -103,15 +103,15 @@ struct Vec3dSimd {
 
 
 inline simd_t inner(const Vec3dSimd& a, const Vec3dSimd& b){
-    return a.x*b.x+a.y*b.y+a.z*b.z;
+    return xsimd::fma(a.x, b.x, xsimd::fma(a.y, b.y, a.z*b.z));
 }
 
 inline simd_t inner(const Vec3d& b, const Vec3dSimd& a){
-    return a.x*b[0]+a.y*b[1]+a.z*b[2];
+    return xsimd::fma(a.x, simd_t(b[0]), xsimd::fma(a.y, simd_t(b[1]), a.z*b[2]));
 }
 
 inline simd_t inner(const Vec3dSimd& a, const Vec3d& b){
-    return a.x*b[0]+a.y*b[1]+a.z*b[2];
+    return xsimd::fma(a.x, simd_t(b[0]), xsimd::fma(a.y, simd_t(b[1]), a.z*b[2]));
 }
 
 inline simd_t inner(int i, Vec3dSimd& a){
@@ -144,12 +144,19 @@ inline Vec3dSimd cross(Vec3dSimd& a, Vec3dSimd& b){
 }
 
 inline Vec3dSimd cross(Vec3dSimd& a, Vec3d& b){
-    return Vec3dSimd(a.y * b[2] - a.z * b[1], a.z * b[0] - a.x * b[2], a.x * b[1] - a.y * b[0]);
-
+    return Vec3dSimd(
+            xsimd::fms(a.y, simd_t(b[2]), a.z * b[1]),
+            xsimd::fms(a.z, simd_t(b[0]), a.x * b[2]),
+            xsimd::fms(a.x, simd_t(b[1]), a.y * b[0])
+            );
 }
 
 inline Vec3dSimd cross(Vec3d& a, Vec3dSimd& b){
-    return Vec3dSimd(a[1] * b.z - a[2] * b.y, a[2] * b.x - a[0] * b.z, a[0] * b.y - a[1] * b.x);
+    return Vec3dSimd(
+            xsimd::fms(simd_t(a[1]), b.z, a[2] * b.y),
+            xsimd::fms(simd_t(a[2]), b.x, a[0] * b.z),
+            xsimd::fms(simd_t(a[0]), b.y, a[1] * b.x)
+            );
 }
 
 inline Vec3dSimd cross(Vec3dSimd& a, int i){

--- a/src/simsgeopp/simdhelpers.h
+++ b/src/simsgeopp/simdhelpers.h
@@ -79,6 +79,13 @@ struct Vec3dSimd {
         return *this;
     }
 
+    Vec3dSimd& operator*=(const double& rhs) {
+        this->x *= rhs;
+        this->y *= rhs;
+        this->z *= rhs;
+        return *this;
+    }
+
     friend Vec3dSimd operator-(Vec3dSimd lhs, const Vec3d& rhs) {
         lhs.x -= rhs[0];
         lhs.y -= rhs[1];
@@ -175,6 +182,24 @@ inline Vec3dSimd cross(int i, Vec3dSimd& b){
         return Vec3dSimd(b.z, simd_t(0.), -b.x);
     else
         return Vec3dSimd(-b.y, b.x, simd_t(0.));
+}
+
+inline Vec3d cross(int i, Vec3d& b){
+    if(i==0)
+        return Vec3d{0., -b.coeff(2), b.coeff(1)};
+    else if(i == 1)
+        return Vec3d{b.coeff(2), 0., -b.coeff(0)};
+    else
+        return Vec3d{-b.coeff(1), b.coeff(0), 0.};
+}
+
+inline Vec3d cross(Vec3d& a, int i){
+    if(i==0)
+        return Vec3d{0., a.coeff(2), -a.coeff(1)};
+    else if(i == 1)
+        return Vec3d{-a.coeff(2), 0., a.coeff(0)};
+    else
+        return Vec3d{a.coeff(1), -a.coeff(0), 0.};
 }
 
 inline simd_t normsq(Vec3dSimd& a){

--- a/src/simsgeopp/simdhelpers.h
+++ b/src/simsgeopp/simdhelpers.h
@@ -11,24 +11,24 @@ namespace xs = xsimd;
 
 // xsimd provides the 'aligned_allocator' which makes sure that objects are
 // aligned properly.  we extend this operator to align a bit more memory than
-// required, so tha twe definitely always have a multiple of the simd vector
+// required, so that we definitely always have a multiple of the simd vector
 // size. that way we can use simd operations for the entire vector, and don't
 // have to special case the last few entries. this is used in biot_savart_kernel
-template <class T, size_t Align>
-class aligned_padded_allocator : public xs::aligned_allocator<T, Align> {
+template <size_t Align>
+class aligned_padded_allocator : public xs::aligned_allocator<double, Align> {
     public:
-        T* allocate(size_t n, const void* hint = 0) {
-            int nn = (n + Align) - (n % Align); // round to next highest multiple of Align
-            T* res = reinterpret_cast<T*>(xsimd::detail::xaligned_malloc(sizeof(T) * nn, Align));
+        double* allocate(size_t n, const void* hint = 0) {
+            int simdcount = Align/sizeof(double);
+            int nn = (n + simdcount) - (n % simdcount); // round to next highest multiple of simdcount
+            double* res = reinterpret_cast<double*>(xsimd::detail::xaligned_malloc(sizeof(double) * nn, Align));
             if (res == nullptr)
                 throw std::bad_alloc();
-            memset(res, 0, sizeof(T) * nn);
             return res;
         }
 };
 
 
-using vector_type = std::vector<double, aligned_padded_allocator<double, XSIMD_DEFAULT_ALIGNMENT>>;
+using vector_type = std::vector<double, aligned_padded_allocator<XSIMD_DEFAULT_ALIGNMENT>>;
 using simd_t = xs::simd_type<double>;
 
 #include <Eigen/Core>


### PR DESCRIPTION
This PR makes two main changes:

- Compile with `-march=native` when compiled locally. Compile with `-march=ivybridge`  when compiled on the CI for our wheels. Ivy Bridge supports avx but is old enough that we can probably rely on this wheel working everywhere.

- If compiled with AVX512F instructions available, then we use a Fast Inverse Square root trick to speed up the computation of `1/||diff||`, since both inverses and square roots are pretty slow on current AVX512 hardware.