### PR TITLE
Simplified logging interface introduced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,11 @@ build/
 build-cmake/
 dist/
 pip-wheel-metadata/
-src/SIMSOPT.egg-info/
+*simsopt.egg-info/
 .DS_Store
 .coverage
 .tox
+*fort.9
 	
 # f90wrap related
 src.*/
@@ -40,6 +41,10 @@ spec*.sp.h5
 
 # examples
 examples/VMEC/
+examples/*.log
 
 # Sphinx related files
 docs/build/
+
+# IDE
+.idea

--- a/examples/logger_example.py
+++ b/examples/logger_example.py
@@ -17,4 +17,4 @@ except:
 if comm is not None:
     initialize_logging(mpi=True, filename='mpi.log')
     for i in range(2):
-        logging.warning("Hello (times %i) from rank %i (of %i)" % (i+1, comm.rank, comm.size))
+        logging.warning("Hello (times %i) from mpi job" % (i+1))

--- a/examples/logger_example.py
+++ b/examples/logger_example.py
@@ -1,0 +1,20 @@
+# Example file for transparently logging both MPI and serial jobs
+import logging
+from simsopt.util.logging import initialize_logging
+
+# Serial logging
+initialize_logging(filename='serial.log')
+for i in range(2):
+    logging.info("Hello (times %i) from serial job" % (i+1))
+
+# MPI logging
+try:
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+except:
+    comm = None
+
+if comm is not None:
+    initialize_logging(mpi=True, filename='mpi.log')
+    for i in range(2):
+        logging.warning("Hello (times %i) from rank %i (of %i)" % (i+1, comm.rank, comm.size))

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,8 @@ install_requires =
     jax >= 0.2.4
     jaxlib >= 0.1.56
     scipy >= 1.5.4
+    monty >= 2021.3.3
+    ruamel.yaml
     importlib_metadata; python_version < "3.8"
 package_dir =
     =src
@@ -62,6 +64,8 @@ SPEC =
     f90nml >= 1.2
 MPI =
     mpi4py >= 3.0.3
+    MPILogger @ https://github.com/mbkumar/python-mpi-logger/tarball/master#egg=MPILogger
+
 
 [options.packages.find]
 where = src
@@ -70,3 +74,4 @@ where = src
 * =
     input.default
     defaults.sp
+    log_config.yaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,6 @@ install_requires =
     jax >= 0.2.4
     jaxlib >= 0.1.56
     scipy >= 1.5.4
-    monty >= 2021.3.3
     ruamel.yaml
     importlib_metadata; python_version < "3.8"
 package_dir =

--- a/src/simsopt/util/log_config.yaml
+++ b/src/simsopt/util/log_config.yaml
@@ -1,0 +1,63 @@
+---
+
+version: 1
+
+disable_existing_loggers: False
+
+formatters:
+    std:
+        format: "%(asctime)s %(name)s-%(levelname)s: %(message)s"
+    mpi:
+        format: "[rank %(rank)s/%(size)s] %(asctime)s %(name)s-%(levelname)s: %(message)s"
+    info_stream:
+        format: "%(message)s"
+    warning_stream:
+        format: "%(levelname)s-%(name)s: %(message)s"
+
+
+handlers:
+    console:
+        class: logging.StreamHandler
+        level: INFO
+        formatter: info_stream
+        stream: ext://sys.stdout
+
+    console_warning:
+        class: logging.StreamHandler
+        level: WARNING
+        formatter: warning_stream
+        stream: ext://sys.stderr
+
+    file_handler:
+        class: logging.handlers.RotatingFileHandler
+        level: DEBUG            
+        formatter: std
+        filename: debug.log
+        maxBytes: 10485760 # 10MB
+        backupCount: 20
+        encoding: utf8
+
+    mpi_file_handler:
+        class: mpilogger.MPILogHandler
+        level: DEBUG            
+        formatter: mpi
+        logfile: debug.log
+        # filename: deubg.log
+        # maxBytes: 10485760 # 10MB
+        # backupCount: 20
+        # encoding: utf8
+
+    
+#loggers:
+#    my_module:
+#        level: ERROR
+#        handlers: [console]
+#        propagate: no
+
+
+root:
+    level: DEBUG
+    # Delete either file_handler or mpi_file_handler in init function depending on mpi
+    handlers: [console, console_warning, file_handler, mpi_file_handler] 
+
+...

--- a/src/simsopt/util/logging.py
+++ b/src/simsopt/util/logging.py
@@ -6,7 +6,7 @@ import logging
 import logging.config
 from pathlib import Path
 
-from monty.serialization import loadfn
+from ruamel.yaml import YAML
 try:
     from mpilogger import MPILogHandler
 except:
@@ -14,7 +14,8 @@ except:
 
 
 def initialize_logging(filename=None, level=None, mpi=False):
-    config_dict = loadfn(Path(__file__).parent / 'log_config.yaml')
+    yaml = YAML(typ='safe')
+    config_dict = yaml.load(Path(__file__).parent / 'log_config.yaml')
     if filename:
         config_dict['handlers']['file_handler'].update({'filename': filename})
         config_dict['handlers']['mpi_file_handler'].update({'logfile': filename})

--- a/src/simsopt/util/logging.py
+++ b/src/simsopt/util/logging.py
@@ -1,0 +1,33 @@
+# coding: utf-8
+# Copyright (c) HiddenSymmetries Development Team.
+# Distributed under the terms of the LGPL License
+
+import logging
+import logging.config
+from pathlib import Path
+
+from monty.serialization import loadfn
+try:
+    from mpilogger import MPILogHandler
+except:
+    MPILogHander = None
+
+
+def initialize_logging(filename=None, level=None, mpi=False):
+    config_dict = loadfn(Path(__file__).parent / 'log_config.yaml')
+    if filename:
+        config_dict['handlers']['file_handler'].update({'filename': filename})
+        config_dict['handlers']['mpi_file_handler'].update({'logfile': filename})
+    if level:
+        config_dict['handlers']['file_handler'].update({'level': level})
+        config_dict['handlers']['mpi_file_handler'].update({'level': level})
+    if mpi and MPILogHandler:
+        config_dict['root']['handlers'].pop(2) # Remove file hander
+    else:
+        config_dict['root']['handlers'].pop(3) # Remove mpi hander
+        del config_dict['handlers']['mpi_file_handler']
+
+    logging.config.dictConfig(config_dict)
+
+    if mpi and not MPILogHandler:
+        logging.warning("mpilogger not installed. Not able to log MPI info")


### PR DESCRIPTION
This PR introduces logging functionality that is simple and consistent to use for both serial and mpi jobs.

For serial jobs: 
```python 
from simstop.util.log import initialize_logging
initialize_logging(filename="serial.log")
for i in range(2):   # Some log dumping
    logging.info("Hello (times %i) from serial job" % (i+1))
```
serial.log:
```bash
2021-04-14 12:31:00,089 root-INFO: Hello (times 1) from serial job
2021-04-14 12:31:00,089 root-INFO: Hello (times 2) from serial job
```

For mpi jobs:
```python
from mpi4py import MPI
from simstop.util.log import initialize_logging

comm = MPI.COMM_WORLD
initialize_logging(mpi=True, filename="mpi.log")
for i in range(2):
    logging.warning("Hello (times %i) from mpi job)
```
Resulting mpi.log with 2 MPI processes:
```bash
[rank 0/2] 2021-04-14 12:32:35,898 root-WARNING: Hello (times 1) from mpi job
[rank 1/2] 2021-04-14 12:32:35,898 root-WARNING: Hello (times 1) from mpi job
[rank 0/2] 2021-04-14 12:32:35,911 root-WARNING: Hello (times 2) from mpi job
[rank 1/2] 2021-04-14 12:32:35,911 root-WARNING: Hello (times 2) from mpi job
```

The `initialize_logging` function imported from `simsopt.util.log` module uses dictconfig method to initialize logging. The default logging handler and formatting options are stored in `simsopt/util/log_config.yaml` file.

For optional MPI, in addition to _mpi4py_, _mbkumar/python-mpi-logger_ repo is also installed.

Credits: The MPI logging functionality uses MPILogger package from Richard Shaw, Dept. of Physics, Univ. of British Columbia. I modified the MPILogger to get it work with python3.x.

`