### PR TITLE
Bugfix: CI SPEC compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,9 @@ jobs:
       run: |
         cd SPEC
         cat Makefile | sed 's/BUILD_ENV=intel/BUILD_ENV=gfortran_ubuntu/' > Makefile1
-        cp Makefile1 Makefile
-        head -n30 Makefile
+        cat Makefile1 | sed 's/$(FC) $(FLAGS) $(CFLAGS) $(RFLAGS) $(LINKS) $(addsuffix _r.o,$(ALLFILES)) -o xspec/$(FC) $(FLAGS) $(CFLAGS) $(RFLAGS) -o xspec $(addsuffix _r.o,$(ALLFILES)) $(LINKS)/' > Makefile
+        #cp Makefile1 Makefile
+        head -n66 Makefile
         make -j
 
     - name: Add xspec to PATH.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,17 @@ jobs:
     - name: apt-get stuff needed for libstell and vmec
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential gfortran openmpi-bin libopenmpi-dev libnetcdf-dev libnetcdff-dev liblapack-dev libblacs-mpi-dev libscalapack-mpi-dev libhdf5-dev git m4 libfftw3-dev
+        sudo apt-get install -y build-essential gfortran openmpi-bin libopenmpi-dev libnetcdf-dev libnetcdff-dev liblapack-dev libblacs-mpi-dev libscalapack-mpi-dev libhdf5-dev libhdf5-serial-dev git m4 libfftw3-dev
+
+    - name: ls hdf5 stuff
+      run: |
+        cd /usr/lib/x86_64-linux-gnu/hdf5
+        ls -l
+
+    - name: ls hdf5 serial stuff
+      run: |
+        cd /usr/lib/x86_64-linux-gnu/hdf5/serial
+        ls -l
 
     - uses: actions/checkout@v2
       # If we want submodules downloaded, uncomment the next 2 lines:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     - name: apt-get stuff needed for libstell and vmec
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential gfortran openmpi-bin libopenmpi-dev libnetcdf-dev libnetcdff-dev liblapack-dev libblacs-mpi-dev libscalapack-mpi-dev libhdf5-openmpi-dev git m4 libfftw3-dev
+        sudo apt-get install -y build-essential gfortran openmpi-bin libopenmpi-dev libnetcdf-dev libnetcdff-dev liblapack-dev libblacs-mpi-dev libscalapack-mpi-dev libhdf5-dev git m4 libfftw3-dev
 
     - uses: actions/checkout@v2
       # If we want submodules downloaded, uncomment the next 2 lines:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
     - name: Build SPEC.
       run: |
         cd SPEC
-        cat Makefile | sed 's/CC=intel/CC=gfortran_ubuntu/' > Makefile1
+        cat Makefile | sed 's/BUILD_ENV=intel/BUILD_ENV=gfortran_ubuntu/' > Makefile1
         cp Makefile1 Makefile
         head -n30 Makefile
         make -j

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y build-essential gfortran openmpi-bin libopenmpi-dev libnetcdf-dev libnetcdff-dev liblapack-dev libblacs-mpi-dev libscalapack-mpi-dev libhdf5-dev libhdf5-serial-dev git m4 libfftw3-dev
 
-    - name: ls hdf5 stuff
-      run: |
-        cd /usr/lib/x86_64-linux-gnu/hdf5
-        ls -l
-
-    - name: ls hdf5 serial stuff
-      run: |
-        cd /usr/lib/x86_64-linux-gnu/hdf5/serial
-        ls -l
-
     - uses: actions/checkout@v2
       # If we want submodules downloaded, uncomment the next 2 lines:
       #with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,9 +128,9 @@ jobs:
     - name: Build SPEC.
       run: |
         cd SPEC
+        # In the SPEC Makefile, we need to set BUILD_ENV:
         cat Makefile | sed 's/BUILD_ENV=intel/BUILD_ENV=gfortran_ubuntu/' > Makefile1
-        cat Makefile1 | sed 's/$(FC) $(FLAGS) $(CFLAGS) $(RFLAGS) $(LINKS) $(addsuffix _r.o,$(ALLFILES)) -o xspec/$(FC) $(FLAGS) $(CFLAGS) $(RFLAGS) -o xspec $(addsuffix _r.o,$(ALLFILES)) $(LINKS)/' > Makefile
-        #cp Makefile1 Makefile
+        cp Makefile1 Makefile
         head -n66 Makefile
         make -j
 


### PR DESCRIPTION
The simsopt CI was failing at the step of compiling SPEC, due to some recent changes in the SPEC repository. This is now fixed, and all tests pass now. Basically the only change in simsopt is that serial HDF5 is used in the CI instead of parallel HDF5.