### PR TITLE
Cleanup and refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       run: |
         cd SPEC
         # In the SPEC Makefile, we need to set BUILD_ENV:
-        cat Makefile | sed 's/BUILD_ENV=intel/BUILD_ENV=gfortran_ubuntu/' > Makefile1
+        cat Makefile | sed 's/BUILD_ENV?=intel/BUILD_ENV?=gfortran_ubuntu/' > Makefile1
         cp Makefile1 Makefile
         head -n66 Makefile
         make -j

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -94,5 +94,6 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PYPI_TOKEN }}
+          #password: ${{ secrets.TEST_PYPI_TOKEN }}
+          #repository_url: https://test.pypi.org/legacy/

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = simsopt
 description: Framework for optimizing stellarators
 long-description = file: README.md
 long-description_content_type = text/markdown
-version = 0.2.02
+version = 0.2.03
 license = GNU Lesser General Public License Version 3
 license_files = COPYING, COPYING.LESSER
 author = "Matt Landreman, Florian Wechsung, Bharat Medasani"
@@ -66,8 +66,6 @@ SPEC =
     f90nml >= 1.2
 MPI =
     mpi4py >= 3.0.3
-    MPILogger @ https://github.com/mbkumar/python-mpi-logger/tarball/master#egg=MPILogger
-
 
 [options.packages.find]
 where = src

--- a/src/simsopt/geo/graph_surface.py
+++ b/src/simsopt/geo/graph_surface.py
@@ -265,7 +265,7 @@ class SurfaceRZFourier(Surface, Optimizable):
         rc[1, ntor] = 0.1
         zs[1, ntor] = 0.1
 
-        dofs = np.concatenate([rc.flatten(), zs.flatten()])
+        dofs_x = np.concatenate([rc.flatten(), zs.flatten()])
         rc_fixed = [True] * self.ntor + [False] * (self.ntor + 1)
         zs_fixed = [True] * (self.ntor + 1) + [False] * self.ntor
         for m in range(self.mpol):
@@ -276,7 +276,7 @@ class SurfaceRZFourier(Surface, Optimizable):
         if not self.stellsym:
             rs = np.zeros(self.shape)
             zc = np.zeros(self.shape)
-            dofs = np.concatenate([dofs, rs.flatten(), zc.flatten()])
+            dofs_x = np.concatenate([dofs_x, rs.flatten(), zc.flatten()])
 
             zc_fixed = [True] * self.ntor + [False] * (self.ntor + 1)
             rs_fixed = [True] * (self.ntor + 1) + [False] * self.ntor
@@ -287,7 +287,7 @@ class SurfaceRZFourier(Surface, Optimizable):
                                         np.array(zc_fixed)])
             dof_names += self.make_names('rs') + self.make_names('zc')
 
-        Optimizable.__init__(self, x0=dofs, names=dof_names, fixed=dofs_fixed)
+        Optimizable.__init__(self, x0=dofs_x, names=dof_names, fixed=dofs_fixed)
 
         #self.recalculate = True
         self.recalculate_derivs = True

--- a/src/simsopt/objectives/graph_functions.py
+++ b/src/simsopt/objectives/graph_functions.py
@@ -32,6 +32,7 @@ class Identity(Optimizable):
         dof_name: Identifier for the DOF
         dof_fixed: To specify if the dof is fixed
     """
+
     def __init__(self,
                  x: Real = 0.0,
                  dof_name: str = None,
@@ -111,6 +112,7 @@ class Rosenbrock(Optimizable):
         x: *x* coordinate
         y: *y* coordinate
     """
+
     def __init__(self, b=100.0, x=0.0, y=0.0):
         self._sqrtb = np.sqrt(b)
         super().__init__([x, y], names=['x', 'y'])

--- a/src/simsopt/objectives/graph_least_squares.py
+++ b/src/simsopt/objectives/graph_least_squares.py
@@ -117,7 +117,6 @@ class LeastSquaresProblem(Optimizable):
     def from_tuples(cls,
                     tuples: Sequence[Tuple[Callable, Real, Real]]
                     ) -> LeastSquaresProblem:
-
         """
         Initializes graph based LeastSquaresProblem from a sequence of tuples
         containing *f_in*, *goal*, and *weight*.

--- a/src/simsopt/util/logging.py
+++ b/src/simsopt/util/logging.py
@@ -10,9 +10,11 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 try:
-    from mpilogger import MPILogHandler
+    from mpi4py import MPI
 except:
-    MPILogHander = None
+    MPI = None
+
+from .mpi_logger import MPILogHandler
 
 
 def initialize_logging(filename: str = None,
@@ -35,7 +37,7 @@ def initialize_logging(filename: str = None,
     if level:
         config_dict['handlers']['file_handler'].update({'level': level})
         config_dict['handlers']['mpi_file_handler'].update({'level': level})
-    if mpi and MPILogHandler:
+    if mpi and MPI is not None:
         config_dict['root']['handlers'].pop(2)  # Remove file hander
     else:
         config_dict['root']['handlers'].pop(3)  # Remove mpi hander
@@ -43,5 +45,5 @@ def initialize_logging(filename: str = None,
 
     logging.config.dictConfig(config_dict)
 
-    if mpi and not MPILogHandler:
-        logging.warning("mpilogger not installed. Not able to log MPI info")
+    if mpi and MPI is None:
+        logging.warning("mpi4py not installed. Not able to log MPI info")

--- a/src/simsopt/util/mpi_logger.py
+++ b/src/simsopt/util/mpi_logger.py
@@ -1,0 +1,205 @@
+# -------------LICENSE TERMS FOR THIS FILE ONLY
+
+# Copyright (c) 2013, J. Richard Shaw
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met: 
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer. 
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution. 
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.import sys
+# --------------------END OF LICENSE TERMS -----------------------------------------
+
+import time
+import logging
+import array
+import atexit
+
+import mpi4py
+from mpi4py import MPI
+
+
+# Maximum length of message in characters
+_message_maxlen = 2048
+
+# Interval between checking for new logging messages.
+# Used instead of Waitsome to reduce CPU load.
+_sleep_interval = 0.01
+
+
+# Because of clashes between `mpi4py` and `logging` when python is exiting we
+# need to destroy the connections to the logging proceses at the module level.
+# Object level destructors, or the `Handler.close` method will not work.
+@atexit.register
+def _destroy_log_comm():
+    for lc in _log_comm_list:
+        if lc.rank == 0:
+            lc.Isend([None, MPI.INT], dest=0, tag=1)
+        lc.Disconnect()
+
+# Internal variable for keeping track of the log communicators.
+_log_comm_list = []
+
+
+class MPILogHandler(logging.Handler):
+    """A Handler which logs messages over MPI to a single process
+    which then write them to a file.
+
+    This uses MPI-2's Dynamic Process Management to spawn a child process
+    which listens for log messages and then writes them to the specified file.
+    It checks for new messages every 0.01s.
+
+    Note
+    ----
+    This Handler also makes `rank` and `size` available in the `logger.Record`
+    for any formatter to use.
+
+    """
+
+    def __init__(self, logfile, comm=None, *args, **kwargs):
+        """Create the logger.
+
+        Parameters
+        ----------
+        logfile : string
+            Name of file to write.
+        comm : MPI.Intracomm
+            MPI communicator used by this logger.
+        """
+
+        super().__init__(*args, **kwargs)
+
+        self._logfile = logfile
+
+        self._comm  = MPI.COMM_WORLD if comm is None else comm
+
+        # Spawn new process for logging
+        self._log_comm = self._comm.Spawn(sys.executable, args=[__file__, self._logfile])
+
+        # Add the communicator to the list of ones to keep track of.
+        _log_comm_list.append(self._log_comm)
+
+
+    def __del__(self):
+        # Note this does not get called unless the Handler has been removed
+        # from the logger.
+
+        _log_comm_list.remove(self._log_comm)
+
+        if self._log_comm.rank == 0:
+            self._log_comm.Isend([None, MPI.INT], dest=0, tag=1)
+        self._log_comm.Disconnect()
+
+
+    def emit(self, record):
+        """Emit the log message.
+
+        Parameters
+        ----------
+        record : logging.Record
+            logging record that will get written to disk.
+        """
+
+        try:
+
+            record.rank = self._comm.rank
+            record.size = self._comm.size            
+
+            msg = self.format(record)
+
+            # If message too long, truncate it
+            if len(msg) > _message_maxlen:
+                msg = msg[:_message_maxlen]
+
+            msg_buf = array.array('b', msg.encode())
+
+            # Send message to the logging process
+            self._request = self._log_comm.Issend([msg_buf, MPI.CHAR], dest=0, tag=0)
+            s = MPI.Status()
+            self._request.Wait(status=s)
+
+
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            self.handleError(record)
+        
+
+
+if __name__ == '__main__':
+
+    if len(sys.argv) < 2:
+        raise Exception("Too few arguments to MPI logging process.")
+
+    # Get the logfile and tag from the command line arguments
+    logfile = sys.argv[1]
+
+    # Open the logfile
+    fh = open(logfile, 'w')
+
+    # Get the parent Intracomm
+    comm_parent = MPI.Comm.Get_parent()
+
+    # Initialise all the buffers to receive logging messages
+    buffers = [(array.array('b', '\0'.encode()) * _message_maxlen) for pi in range(comm_parent.remote_size)]
+    requests = []
+
+    # Create a request for checking if we should exit
+    exit_request = comm_parent.Irecv([None, MPI.INT], source=0, tag=1)
+
+    # Establish all the initial connections for receiving messages
+    for pi in range(comm_parent.remote_size):
+        request = comm_parent.Irecv([buffers[pi], MPI.CHAR], source=pi, tag=0)
+        requests.append(request)
+
+    while True:
+
+        # Wait until any connection receives a message
+        status_list = []
+        ind_requests = MPI.Request.Testsome(requests, statuses=status_list)
+        # Request.Waitsome() and Request.Testsome() return None or list from mpi4py 2.0.0
+        num_requests = len(ind_requests)
+
+        # If a request has changed
+        if num_requests > 0:
+
+            # Iterate over changed requests and process them
+            for ind, s in zip(ind_requests, status_list):
+
+                # Check to see if there was an error.
+                if s.Get_error() != 0:
+                    raise Exception("Logging error (code %i)." % s.Get_error())
+            
+                # Write the message to disk
+                msg_rank = s.Get_source()
+                msg = buffers[msg_rank].tobytes().decode().rstrip('\0')
+                fh.write('%s\n' % msg)
+                fh.flush()
+
+                # Replace the buffer and connection
+                buffers[ind] = (array.array('b', '\0'.encode()) * _message_maxlen)
+                requests[ind] = comm_parent.Irecv([buffers[ind], MPI.CHAR], source=msg_rank, tag=0)
+           
+        if MPI.Request.Test(exit_request):
+            # We should exit from this process.
+            break
+
+        time.sleep(_sleep_interval)
+
+
+    comm_parent.Disconnect()
+    fh.close()

--- a/src/simsopt/util/mpi_logger.py
+++ b/src/simsopt/util/mpi_logger.py
@@ -51,6 +51,7 @@ def _destroy_log_comm():
             lc.Isend([None, MPI.INT], dest=0, tag=1)
         lc.Disconnect()
 
+
 # Internal variable for keeping track of the log communicators.
 _log_comm_list = []
 
@@ -85,14 +86,13 @@ class MPILogHandler(logging.Handler):
 
         self._logfile = logfile
 
-        self._comm  = MPI.COMM_WORLD if comm is None else comm
+        self._comm = MPI.COMM_WORLD if comm is None else comm
 
         # Spawn new process for logging
         self._log_comm = self._comm.Spawn(sys.executable, args=[__file__, self._logfile])
 
         # Add the communicator to the list of ones to keep track of.
         _log_comm_list.append(self._log_comm)
-
 
     def __del__(self):
         # Note this does not get called unless the Handler has been removed
@@ -103,7 +103,6 @@ class MPILogHandler(logging.Handler):
         if self._log_comm.rank == 0:
             self._log_comm.Isend([None, MPI.INT], dest=0, tag=1)
         self._log_comm.Disconnect()
-
 
     def emit(self, record):
         """Emit the log message.
@@ -132,12 +131,10 @@ class MPILogHandler(logging.Handler):
             s = MPI.Status()
             self._request.Wait(status=s)
 
-
         except (KeyboardInterrupt, SystemExit):
             raise
         except:
             self.handleError(record)
-        
 
 
 if __name__ == '__main__':
@@ -183,7 +180,7 @@ if __name__ == '__main__':
                 # Check to see if there was an error.
                 if s.Get_error() != 0:
                     raise Exception("Logging error (code %i)." % s.Get_error())
-            
+
                 # Write the message to disk
                 msg_rank = s.Get_source()
                 msg = buffers[msg_rank].tobytes().decode().rstrip('\0')
@@ -193,13 +190,12 @@ if __name__ == '__main__':
                 # Replace the buffer and connection
                 buffers[ind] = (array.array('b', '\0'.encode()) * _message_maxlen)
                 requests[ind] = comm_parent.Irecv([buffers[ind], MPI.CHAR], source=msg_rank, tag=0)
-           
+
         if MPI.Request.Test(exit_request):
             # We should exit from this process.
             break
 
         time.sleep(_sleep_interval)
-
 
     comm_parent.Disconnect()
     fh.close()

--- a/tests/core/test_graph_dofs.py
+++ b/tests/core/test_graph_dofs.py
@@ -2,63 +2,9 @@ import unittest
 import numpy as np
 from collections import Counter
 
-from simsopt._core.graph_optimizable import DOF, DOFs
+from simsopt._core.graph_optimizable import DOFs
 from simsopt.objectives.graph_functions import Identity, Adder, \
     TestObject2, Rosenbrock, Affine
-
-
-class DOFTest(unittest.TestCase):
-    """
-    Unit tests for simsopt.core.DOF class
-    """
-
-    def setUp(self):
-        self.dof1 = DOF(2.0, 'x', True, np.NINF, np.inf)
-        self.dof2 = DOF(3.0, 'y', False, np.NINF, np.inf)
-
-    def tearDown(self) -> None:
-        self.dof1 = None
-        self.dof2 = None
-
-    #def test_hash(self):
-    #    self.assertFalse(True)
-
-    #def test_extended_name(self):
-    #    self.assertFalse(True)
-
-    def test_is_fixed(self):
-        self.assertFalse(self.dof1.is_fixed())
-        self.assertTrue(self.dof2.is_fixed())
-
-    def test_is_free(self):
-        self.assertTrue(self.dof1.is_free())
-        self.assertFalse(self.dof2.is_free())
-
-    def test_fix(self):
-        self.dof1.fix()
-        self.assertTrue(self.dof1.is_fixed())
-
-    def test_unfix(self):
-        self.dof2.unfix()
-        self.assertTrue(self.dof2.is_free())
-
-    def test_min(self):
-        self.assertTrue(np.isclose(self.dof1.min, np.NINF))
-        self.dof1.min = -10.0
-        self.assertAlmostEqual(self.dof1.min, -10.0)
-
-    def test_max(self):
-        self.assertTrue(np.isclose(self.dof1.max, np.inf))
-        self.dof1.max = 1e2
-        self.assertAlmostEqual(self.dof1.max, 100.0)
-
-    #def test_owner(self):
-    #    self.assertTrue(False)
-
-    def test_x(self):
-        self.assertAlmostEqual(self.dof1.x, 2.0)
-        self.dof1.x = 10.0
-        self.assertAlmostEqual(self.dof1.x, 10.0)
 
 
 class DOFsTests(unittest.TestCase):

--- a/tests/core/test_graph_optimizable.py
+++ b/tests/core/test_graph_optimizable.py
@@ -466,160 +466,6 @@ class OptimizableTests(unittest.TestCase):
                                                  Adder(3)])
         self.assertEqual(test_obj1.local_full_dof_size, 1)
 
-    def test_dofs(self):
-        # Check with leaf type Optimizable objects
-        adder = Adder(n=3, x0=[1, 2, 3], dof_names=['x', 'y', 'z'])
-        iden = Identity(x=10, dof_fixed=True)
-        adder_dofs = adder.dofs
-        iden_dofs = iden.dofs
-        self.assertAlmostEqual(adder_dofs[0], 1)
-        self.assertAlmostEqual(adder_dofs[1], 2)
-        self.assertAlmostEqual(adder_dofs[2], 3)
-        self.assertEqual(len(iden_dofs), 0)
-
-        adder.dofs = [4, 5, 6]
-        self.assertAlmostEqual(adder._dofs.loc['x', '_x'], 4)
-        self.assertAlmostEqual(adder._dofs.loc['y', '_x'], 5)
-        self.assertAlmostEqual(adder._dofs.loc['z', '_x'], 6)
-        with self.assertRaises(ValueError):
-            iden.dofs = np.array([11], dtype=float)
-        self.assertAlmostEqual(iden.full_dofs[0], 10)
-
-        # Check with Optimizable objects containing parents
-        adder2 = Adder(3)
-        iden2 = Identity(x=10)
-        test_obj1 = OptClassWithParents(10, opts_in=[iden2, adder2])
-        with self.assertRaises(ValueError):
-            test_obj1.x = np.array([20])
-
-        test_obj1.x = np.array([20, 4, 5, 6, 25])
-        self.assertAlmostEqual(test_obj1._dofs.loc['val', '_x'], 25)
-        self.assertAlmostEqual(iden2._dofs.loc['x0', '_x'], 20)
-        self.assertAlmostEqual(adder2._dofs.loc['x0', '_x'], 4)
-        self.assertAlmostEqual(adder2._dofs.loc['x1', '_x'], 5)
-        self.assertAlmostEqual(adder2._dofs.loc['x2', '_x'], 6)
-
-        adder3 = Adder(3)
-        test_obj2 = OptClassWithParents(10, opts_in=[iden, adder3])
-        with self.assertRaises(ValueError):
-            test_obj2.dofs = np.array([20, 4, 5, 6, 25])
-
-        test_obj2.dofs = np.array([4, 5, 6, 25])
-        self.assertAlmostEqual(iden._dofs.loc['x0', '_x'], 10)
-        self.assertAlmostEqual(adder3._dofs.loc['x0', '_x'], 4)
-        self.assertAlmostEqual(adder3._dofs.loc['x1', '_x'], 5)
-        self.assertAlmostEqual(adder3._dofs.loc['x2', '_x'], 6)
-        self.assertAlmostEqual(test_obj2._dofs.loc['val', '_x'], 25)
-
-    def test_local_dofs(self):
-        # Check with leaf type Optimizable objects
-        adder = Adder(n=3, x0=[1, 2, 3], dof_names=['x', 'y', 'z'])
-        iden = Identity(x=10, dof_fixed=True)
-        adder_dofs = adder.local_dofs
-        iden_dofs = iden.local_dofs
-        self.assertAlmostEqual(adder_dofs[0], 1)
-        self.assertAlmostEqual(adder_dofs[1], 2)
-        self.assertAlmostEqual(adder_dofs[2], 3)
-        self.assertTrue(len(iden_dofs) == 0)
-
-        adder.local_dofs = [4, 5, 6]
-        self.assertAlmostEqual(adder._dofs.loc['x', '_x'], 4)
-        self.assertAlmostEqual(adder._dofs.loc['y', '_x'], 5)
-        self.assertAlmostEqual(adder._dofs.loc['z', '_x'], 6)
-        with self.assertRaises(ValueError):
-            iden.local_dofs = np.array([11], dtype=float)
-        self.assertAlmostEqual(iden.full_dofs[0], 10)
-
-        # Check with Optimizable objects containing parents
-        adder2 = Adder(3)
-        iden2 = Identity(x=10)
-        test_obj1 = OptClassWithParents(10, opts_in=[iden2, adder2])
-        test_obj1.local_dofs = np.array([25])
-        self.assertAlmostEqual(test_obj1._dofs.loc['val', '_x'], 25)
-
-        adder3 = Adder(3)
-        test_obj2 = OptClassWithParents(10, opts_in=[iden, adder3])
-
-        test_obj2.local_dofs = np.array([25])
-        self.assertAlmostEqual(test_obj2._dofs.loc['val', '_x'], 25)
-
-    def test_state(self):
-        # Check with leaf type Optimizable objects
-        adder = Adder(n=3, x0=[1, 2, 3], dof_names=['x', 'y', 'z'])
-        iden = Identity(x=10, dof_fixed=True)
-        adder_dofs = adder.state
-        iden_dofs = iden.state
-        self.assertAlmostEqual(adder_dofs[0], 1)
-        self.assertAlmostEqual(adder_dofs[1], 2)
-        self.assertAlmostEqual(adder_dofs[2], 3)
-        self.assertEqual(len(iden_dofs), 0)
-
-        adder.state = [4, 5, 6]
-        self.assertAlmostEqual(adder._dofs.loc['x', '_x'], 4)
-        self.assertAlmostEqual(adder._dofs.loc['y', '_x'], 5)
-        self.assertAlmostEqual(adder._dofs.loc['z', '_x'], 6)
-        with self.assertRaises(ValueError):
-            iden.state = np.array([11, ], dtype=float)
-        self.assertAlmostEqual(iden.full_state[0], 10)
-
-        # Check with Optimizable objects containing parents
-        adder2 = Adder(3)
-        iden2 = Identity(x=10)
-        test_obj1 = OptClassWithParents(10, opts_in=[iden2, adder2])
-        with self.assertRaises(ValueError):
-            test_obj1.state = np.array([20])
-
-        test_obj1.state = np.array([20, 4, 5, 6, 25])
-        self.assertAlmostEqual(test_obj1._dofs.loc['val', '_x'], 25)
-        self.assertAlmostEqual(iden2._dofs.loc['x0', '_x'], 20)
-        self.assertAlmostEqual(adder2._dofs.loc['x0', '_x'], 4)
-        self.assertAlmostEqual(adder2._dofs.loc['x1', '_x'], 5)
-        self.assertAlmostEqual(adder2._dofs.loc['x2', '_x'], 6)
-
-        adder3 = Adder(3)
-        test_obj2 = OptClassWithParents(10, opts_in=[iden, adder3])
-        with self.assertRaises(ValueError):
-            test_obj2.state = np.array([20, 4, 5, 6, 25])
-
-        test_obj2.state = np.array([4, 5, 6, 25])
-        self.assertAlmostEqual(iden._dofs.loc['x0', '_x'], 10)
-        self.assertAlmostEqual(adder3._dofs.loc['x0', '_x'], 4)
-        self.assertAlmostEqual(adder3._dofs.loc['x1', '_x'], 5)
-        self.assertAlmostEqual(adder3._dofs.loc['x2', '_x'], 6)
-        self.assertAlmostEqual(test_obj2._dofs.loc['val', '_x'], 25)
-
-    def test_local_state(self):
-        # Check with leaf type Optimizable objects
-        adder = Adder(n=3, x0=[1, 2, 3], dof_names=['x', 'y', 'z'])
-        iden = Identity(x=10, dof_fixed=True)
-        adder_dofs = adder.local_state
-        iden_dofs = iden.local_state
-        self.assertAlmostEqual(adder_dofs[0], 1)
-        self.assertAlmostEqual(adder_dofs[1], 2)
-        self.assertAlmostEqual(adder_dofs[2], 3)
-        self.assertTrue(len(iden_dofs) == 0)
-
-        adder.local_state = [4, 5, 6]
-        self.assertAlmostEqual(adder._dofs.loc['x', '_x'], 4)
-        self.assertAlmostEqual(adder._dofs.loc['y', '_x'], 5)
-        self.assertAlmostEqual(adder._dofs.loc['z', '_x'], 6)
-        with self.assertRaises(ValueError):
-            iden.local_state = np.array([11, ], dtype=float)
-        self.assertAlmostEqual(iden.full_dofs[0], 10)
-
-        # Check with Optimizable objects containing parents
-        adder2 = Adder(3)
-        iden2 = Identity(x=10)
-        test_obj1 = OptClassWithParents(10, opts_in=[iden2, adder2])
-        test_obj1.local_state = np.array([25])
-        self.assertAlmostEqual(test_obj1._dofs.loc['val', '_x'], 25)
-
-        adder3 = Adder(3)
-        test_obj2 = OptClassWithParents(10, opts_in=[iden, adder3])
-
-        test_obj2.local_state = np.array([25])
-        self.assertAlmostEqual(test_obj2._dofs.loc['val', '_x'], 25)
-
     def test_x(self):
         # Check with leaf type Optimizable objects
         adder = Adder(n=3, x0=[1, 2, 3], dof_names=['x', 'y', 'z'])
@@ -637,7 +483,7 @@ class OptimizableTests(unittest.TestCase):
         self.assertAlmostEqual(adder._dofs.loc['z', '_x'], 6)
         with self.assertRaises(ValueError):
             iden.x = np.array([11, ], dtype=float)
-        self.assertAlmostEqual(iden.full_state[0], 10)
+        self.assertAlmostEqual(iden.full_x[0], 10)
 
         # Check with Optimizable objects containing parents
         adder2 = Adder(3)
@@ -669,12 +515,12 @@ class OptimizableTests(unittest.TestCase):
         # Check with leaf type Optimizable objects
         adder = Adder(n=3, x0=[1, 2, 3], dof_names=['x', 'y', 'z'])
         iden = Identity(x=10, dof_fixed=True)
-        adder_dofs = adder.local_x
-        iden_dofs = iden.local_x
-        self.assertAlmostEqual(adder_dofs[0], 1)
-        self.assertAlmostEqual(adder_dofs[1], 2)
-        self.assertAlmostEqual(adder_dofs[2], 3)
-        self.assertTrue(len(iden_dofs) == 0)
+        adder_x = adder.local_x
+        iden_x = iden.local_x
+        self.assertAlmostEqual(adder_x[0], 1)
+        self.assertAlmostEqual(adder_x[1], 2)
+        self.assertAlmostEqual(adder_x[2], 3)
+        self.assertTrue(len(iden_x) == 0)
 
         adder.local_x = [4, 5, 6]
         self.assertAlmostEqual(adder._dofs.loc['x', '_x'], 4)
@@ -682,7 +528,7 @@ class OptimizableTests(unittest.TestCase):
         self.assertAlmostEqual(adder._dofs.loc['z', '_x'], 6)
         with self.assertRaises(ValueError):
             iden.local_x = np.array([11, ], dtype=float)
-        self.assertAlmostEqual(iden.full_dofs[0], 10)
+        self.assertAlmostEqual(iden.full_x[0], 10)
 
         # Check with Optimizable objects containing parents
         adder2 = Adder(3)
@@ -696,88 +542,6 @@ class OptimizableTests(unittest.TestCase):
 
         test_obj2.local_x = np.array([25])
         self.assertAlmostEqual(test_obj2._dofs.loc['val', '_x'], 25)
-
-    def test_full_dofs(self):
-        # Check with leaf type Optimizable objects
-        adder = Adder(n=3, x0=[1, 2, 3], dof_names=['x', 'y', 'z'])
-        iden = Identity(x=10, dof_fixed=True)
-        adder_full_dofs = adder.full_dofs
-        self.assertAlmostEqual(adder_full_dofs[0], 1)
-        self.assertAlmostEqual(adder_full_dofs[1], 2)
-        self.assertAlmostEqual(adder_full_dofs[2], 3)
-        self.assertEqual(len(iden.full_dofs), 1)
-        self.assertAlmostEqual(iden.full_dofs[0], 10)
-
-        # Check with Optimizable objects containing parents
-        test_obj1 = OptClassWithParents(20, opts_in=[iden, adder])
-        full_dofs = test_obj1.full_dofs
-        self.assertTrue(np.allclose(full_dofs, np.array([10, 1, 2, 3, 20])))
-
-        test_obj1.x = np.array([4, 5, 6, 25])
-        full_dofs = test_obj1.full_dofs
-        self.assertTrue(np.allclose(full_dofs, np.array([10, 4, 5, 6, 25])))
-
-    def test_local_full_dofs(self):
-        # Check with leaf type Optimizable objects
-        # Check with Optimizable objects containing parents
-        adder = Adder(n=3, x0=[1, 2, 3], dof_names=['x', 'y', 'z'])
-        iden = Identity(x=10, dof_fixed=True)
-        adder_full_dofs = adder.local_full_dofs
-        self.assertAlmostEqual(adder_full_dofs[0], 1)
-        self.assertAlmostEqual(adder_full_dofs[1], 2)
-        self.assertAlmostEqual(adder_full_dofs[2], 3)
-        self.assertEqual(len(iden.full_dofs), 1)
-        self.assertAlmostEqual(iden.local_full_dofs[0], 10)
-
-        # Check with Optimizable objects containing parents
-        test_obj1 = OptClassWithParents(20, opts_in=[iden, adder])
-        local_full_dofs = test_obj1.local_full_dofs
-        self.assertTrue(np.allclose(local_full_dofs, np.array([20])))
-
-        test_obj1.x = np.array([4, 5, 6, 25])
-        local_full_dofs = test_obj1.local_full_dofs
-        self.assertTrue(np.allclose(local_full_dofs, np.array([25])))
-
-    def test_full_state(self):
-        # Check with leaf type Optimizable objects
-        adder = Adder(n=3, x0=[1, 2, 3], dof_names=['x', 'y', 'z'])
-        iden = Identity(x=10, dof_fixed=True)
-        adder_full_state = adder.full_state
-        self.assertAlmostEqual(adder_full_state[0], 1)
-        self.assertAlmostEqual(adder_full_state[1], 2)
-        self.assertAlmostEqual(adder_full_state[2], 3)
-        self.assertEqual(len(iden.full_state), 1)
-        self.assertAlmostEqual(iden.full_state[0], 10)
-
-        # Check with Optimizable objects containing parents
-        test_obj1 = OptClassWithParents(20, opts_in=[iden, adder])
-        full_state = test_obj1.full_state
-        self.assertTrue(np.allclose(full_state, np.array([10, 1, 2, 3, 20])))
-
-        test_obj1.x = np.array([4, 5, 6, 25])
-        full_state = test_obj1.full_state
-        self.assertTrue(np.allclose(full_state, np.array([10, 4, 5, 6, 25])))
-
-    def test_local_full_state(self):
-        # Check with leaf type Optimizable objects
-        # Check with Optimizable objects containing parents
-        adder = Adder(n=3, x0=[1, 2, 3], dof_names=['x', 'y', 'z'])
-        iden = Identity(x=10, dof_fixed=True)
-        adder_full_state = adder.local_full_state
-        self.assertAlmostEqual(adder_full_state[0], 1)
-        self.assertAlmostEqual(adder_full_state[1], 2)
-        self.assertAlmostEqual(adder_full_state[2], 3)
-        self.assertEqual(len(iden.full_state), 1)
-        self.assertAlmostEqual(iden.local_full_state[0], 10)
-
-        # Check with Optimizable objects containing parents
-        test_obj1 = OptClassWithParents(20, opts_in=[iden, adder])
-        local_full_state = test_obj1.local_full_state
-        self.assertTrue(np.allclose(local_full_state, np.array([20])))
-
-        test_obj1.state = np.array([4, 5, 6, 25])
-        local_full_state = test_obj1.local_full_state
-        self.assertTrue(np.allclose(local_full_state, np.array([25])))
 
     def test_full_x(self):
         # Check with leaf type Optimizable objects

--- a/tests/geo/test_graph_surface.py
+++ b/tests/geo/test_graph_surface.py
@@ -86,7 +86,7 @@ class SurfaceRZFourierTests(unittest.TestCase):
         self.assertEqual(s.rs.shape, (2, 7))
         self.assertEqual(s.zc.shape, (2, 7))
 
-    def test_get_dofs1(self):
+    def test_get_x(self):
         """
         Test that we can convert the degrees of freedom into a 1D vector
         """
@@ -96,20 +96,20 @@ class SurfaceRZFourierTests(unittest.TestCase):
         s.set_rc(0, 0, 1.3)
         s.set_rc(1, 0, 0.4)
         s.set_zs(1, 0, 0.2)
-        dofs = s.dofs
-        self.assertEqual(dofs.shape, (3,))
-        self.assertAlmostEqual(dofs[0], 1.3)
-        self.assertAlmostEqual(dofs[1], 0.4)
-        self.assertAlmostEqual(dofs[2], 0.2)
+        x = s.x
+        self.assertEqual(x.shape, (3,))
+        self.assertAlmostEqual(x[0], 1.3)
+        self.assertAlmostEqual(x[1], 0.4)
+        self.assertAlmostEqual(x[2], 0.2)
 
         # Now try a nonaxisymmetric shape:
         s = SurfaceRZFourier(mpol=3, ntor=1)
         s.rc = np.array([[100, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])
         s.zs = np.array([[101, 102, 13], [14, 15, 16], [17, 18, 19], [20, 21, 22]])
-        dofs = s.dofs
-        self.assertEqual(dofs.shape, (21,))
+        x = s.x
+        self.assertEqual(x.shape, (21,))
         for j in range(21):
-            self.assertAlmostEqual(dofs[j], j + 2)
+            self.assertAlmostEqual(x[j], j + 2)
 
     def test_set_dofs(self):
         """
@@ -118,14 +118,14 @@ class SurfaceRZFourierTests(unittest.TestCase):
 
         # First try an axisymmetric surface for simplicity:
         s = SurfaceRZFourier()
-        s.dofs = [2.9, -1.1, 0.7]
+        s.x = [2.9, -1.1, 0.7]
         self.assertAlmostEqual(s.get_rc(0, 0), 2.9)
         self.assertAlmostEqual(s.get_rc(1, 0), -1.1)
         self.assertAlmostEqual(s.get_zs(1, 0), 0.7)
 
         # Now try a nonaxisymmetric shape:
         s = SurfaceRZFourier(mpol=3, ntor=1)
-        s.dofs = np.array(list(range(21))) + 1
+        s.x = np.array(list(range(21))) + 1
         self.assertAlmostEqual(s.get_rc(0, -1), 0)
         self.assertAlmostEqual(s.get_rc(0, 0), 1)
         self.assertAlmostEqual(s.get_rc(0, 1), 2)


### PR DESCRIPTION
1. This PR addresses #66 by merging mbkumar/python-mpi-logger into simsopt and removes the optional dependency so that simsopt could be uploaded to pypi. To test run examples/logger_example.py with mpirun and check mpi.log
2. Github actions wheel workflow is modified to upload the wheels to pypi instead of test.pypi.
3. dofs, state type properties that are synonymous with x type properties in Optimizable class definition are removed (Fixes issue #68).
4. DOF class that is not used anywhere removed (Fixes issue #64).




