### PR TITLE
Faster signed distance computaton

### DIFF
--- a/src/simsopt/geo/surface.py
+++ b/src/simsopt/geo/surface.py
@@ -280,10 +280,9 @@ def signed_distance_from_surface(xyz, surface):
     positive for points inside the volume surrounded by the surface.
     """
     gammas = surface.gamma().reshape((-1, 3))
-    from scipy.spatial.distance import cdist
     from scipy.spatial import KDTree
     tree = KDTree(gammas)
-    _, mins = tree.query(xyz, k=1) # find closest points on the surface
+    _, mins = tree.query(xyz, k=1)  # find closest points on the surface
 
     n = surface.unitnormal().reshape((-1, 3))
     nmins = n[mins]

--- a/src/simsopt/geo/surface.py
+++ b/src/simsopt/geo/surface.py
@@ -281,8 +281,10 @@ def signed_distance_from_surface(xyz, surface):
     """
     gammas = surface.gamma().reshape((-1, 3))
     from scipy.spatial.distance import cdist
-    dists = cdist(xyz, gammas)
-    mins = np.argmin(dists, axis=1)
+    from scipy.spatial import KDTree
+    tree = KDTree(gammas)
+    _, mins = tree.query(xyz, k=1) # find closest points on the surface
+
     n = surface.unitnormal().reshape((-1, 3))
     nmins = n[mins]
     gammamins = gammas[mins]


### PR DESCRIPTION
switch to using a KDTree in the shortest distance computation of `signed_distance_from_surface`

This improves performance from `O(N*M)` where `N` is the number of points on the
surface and `M` is the number of points for which we want to compute the
distance to `O(log(N)*M)`