### PR TITLE
Remove pandas

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -20,7 +20,6 @@ Mandatory Packages
 - jax
 - jaxlib
 - scipy
-- pandas
 - nptyping
 - ruamel.yaml
 - importlib_metadata if python version is less than 3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy>=1.19.4
 jax>=0.2.5
 scipy>=1.5.4
-pandas>=1.1.4
 nptyping>=1.3.0
 Deprecated>=1.2.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ install_requires =
     scipy >= 1.5.4
     Deprecated >= 1.2.10
     nptyping >= 1.3.0
-    pandas >= 1.1.4
     monty >= 2021.6.10 
     ruamel.yaml
     importlib_metadata; python_version < "3.8"

--- a/src/simsopt/_core/graph_optimizable.py
+++ b/src/simsopt/_core/graph_optimizable.py
@@ -18,7 +18,6 @@ from typing import Union, Tuple, Dict, Callable, Sequence, \
     MutableSequence as MutSeq, List
 
 import numpy as np
-import pandas as pd
 from deprecated import deprecated
 
 from ..util.types import RealArray, StrArray, BoolArray, Key
@@ -30,21 +29,17 @@ class DOFs:
     Defines the (D)egrees (O)f (F)reedom(s) associated with optimization
 
     This class holds data related to the degrees of freedom
-    associated with an Optimizable object. The class subclasses
-    pandas.DataFrame. To access the data stored in the DOFs class as a
-    pandas dataframe, use the labels under internal column shown in the
-    table below.
+    associated with an Optimizable object.
 
-    DOFs Dataframe column index table
-
-    =====   =============  ===============
-    Index   External name  Internal column
-    =====   =============  ===============
-    0       x              _x
-    1       free           free
-    2       lower_bounds   _lb
-    3       upper_bounds   _ub
-    =====   =============  ===============
+    =============  =============
+    External name  Internal name
+    =============  =============
+    x              _x
+    free           _free
+    lower_bounds   _lb
+    upper_bounds   _ub
+    names          _names
+    =============  =============
 
     The class implements the external name column properties in the above
     table as properties. Additional methods to update bounds, fix/unfix DOFs,


### PR DESCRIPTION
While pandas is no longer used in graph_optimizable.py, it was still being imported, included as a dependency, and discussed in the documentation. In this PR, these remaining mentions of pandas are removed.