### PR TITLE
Add necessary terms to particle tracer to ensure phase-space conservation

### DIFF
--- a/src/simsoptpp/tracing.cpp
+++ b/src/simsoptpp/tracing.cpp
@@ -65,15 +65,18 @@ class GuidingCenterVacuumRHS {
             auto& GradAbsB = field->GradAbsB_ref();
             auto& B = field->B_ref();
             double AbsB = field->AbsB_ref()(0);
+            auto& GradB = field->dB_by_dX_ref();
             BcrossGradAbsB[0] = (B(0, 1) * GradAbsB(0, 2)) - (B(0, 2) * GradAbsB(0, 1));
             BcrossGradAbsB[1] = (B(0, 2) * GradAbsB(0, 0)) - (B(0, 0) * GradAbsB(0, 2));
             BcrossGradAbsB[2] = (B(0, 0) * GradAbsB(0, 1)) - (B(0, 1) * GradAbsB(0, 0));
+            double BdotcurlB = GradB(0, 2, 2);
             double v_perp2 = 2*mu*AbsB;
             double fak1 = (v_par/AbsB);
             double fak2 = (m/(q*pow(AbsB, 3)))*(0.5*v_perp2 + v_par*v_par);
-            dydt[0] = fak1*B(0, 0) + fak2*BcrossGradAbsB[0];
-            dydt[1] = fak1*B(0, 1) + fak2*BcrossGradAbsB[1];
-            dydt[2] = fak1*B(0, 2) + fak2*BcrossGradAbsB[2];
+            double fak3 = 1+(m*v_par/(q*pow(AbsB, 3)))*BdotcurlB;
+            dydt[0] = fak1*B(0, 0) + fak2*BcrossGradAbsB[0]/fak3;
+            dydt[1] = fak1*B(0, 1) + fak2*BcrossGradAbsB[1]/fak3;
+            dydt[2] = fak1*B(0, 2) + fak2*BcrossGradAbsB[2]/fak3;
             dydt[3] = -mu*(B(0, 0)*GradAbsB(0, 0) + B(0, 1)*GradAbsB(0, 1) + B(0, 2)*GradAbsB(0, 2))/AbsB;
         }
 };


### PR DESCRIPTION
This pull request changes the the equations of motion being solved by the particle tracer to match the ones derived by the Littlejohn in
Variational principles of guiding centre motion, R. G. Littlejohn, J. Plasma Physics (1983), vol. 29, part 1, pp. 111-125
https://www.cambridge.org/core/journals/journal-of-plasma-physics/article/variational-principles-of-guiding-centre-motion/8FF3F0D2C6ECB02E983AE506DC40684F

This modification ensure phase-space conservation, leading to precise energy and angular momentum conservation.