### PR TITLE
Add missing file to examples script

### DIFF
--- a/examples/run_serial_examples
+++ b/examples/run_serial_examples
@@ -6,6 +6,7 @@ set -ex
 
 ./1_Simple/just_a_quadratic.py
 ./1_Simple/surface_volume_and_area.py
+./1_Simple/graph_surf_vol_area.py
 ./1_Simple/minimize_curve_length.py
 ./1_Simple/tracing_fieldline.py
 ./1_Simple/tracing_particle.py


### PR DESCRIPTION
Hey, this may not be really a helpful PR, but I figured it'd be the best way to ping you all about this :) I was trying to run the examples, in random order, basically, and I stumbled upon `graph_surf_vol_area.py`. Turns out it's not running in the current Docker build. That looked suspicious, wouldn't your CI catch that? Well, it would have, if only this particular file had been included in it!

I suspect #130 may be somewhat superseding that particular example, so, feel free to close this one if that's the case.