### PR TITLE
New Surface quadpoints initialization

### DIFF
--- a/src/simsopt/_core/graph_optimizable.py
+++ b/src/simsopt/_core/graph_optimizable.py
@@ -1189,6 +1189,7 @@ def make_optimizable(func, /, *args, dof_indicators=None, **kwargs):
         Subclass of Optimizable class to create optimizable objects dynamically.
         dof_indicators argument is used to filter out dofs and
         """
+
         def __init__(self, func, /, *args, dof_indicators=None, **kwargs):
 
             self.func = func

--- a/src/simsopt/_core/util.py
+++ b/src/simsopt/_core/util.py
@@ -236,11 +236,13 @@ def nested_lists_to_array(ll):
                 arr[jm, jn] = x
     return arr
 
+
 class WeakKeyDefaultDict(WeakKeyDictionary):
     """
     A simple implementation of defaultdict that uses WeakKeyDictionary as its
     parent class instead of standard dictionary.
     """
+
     def __init__(self, default_factory=None, /, *args, **kwargs):
         self.default_factory = default_factory
         super().__init__(*args, **kwargs)

--- a/src/simsopt/geo/surface.py
+++ b/src/simsopt/geo/surface.py
@@ -27,8 +27,48 @@ class Surface(Optimizable):
     quadrature points :math:`\{\phi_1, \ldots, \phi_{n_\phi}\}\times\{\theta_1, \ldots, \theta_{n_\theta}\}`.
     """
 
+    # Options for the 'range' parameter for setting quadpoints_phi:
+    RANGE_FULL_TORUS = "full torus"
+    RANGE_FIELD_PERIOD = "field period"
+    RANGE_HALF_PERIOD = "half period"
+
     def __init__(self, **kwargs):
         Optimizable.__init__(self, **kwargs)
+
+    def get_quadpoints(quadpoints_phi=None,
+                       quadpoints_theta=None,
+                       range=RANGE_FULL_TORUS,
+                       nphi=None,
+                       ntheta=None,
+                       nfp=1):
+        """
+        """
+        # Handle theta:
+        if (quadpoints_theta is not None) and (ntheta is not None):
+            raise ValueError("quadpoints_theta and ntheta cannot both be specified")
+        if (quadpoints_theta is None) and (ntheta is None):
+            # Neither is specified, so use a default:
+            ntheta = 62
+        if quadpoints_theta is None:
+            quadpoints_theta = np.linspace(0.0, 1.0, ntheta, endpoint=False)
+
+        # Handle phi:
+        if (quadpoints_phi is not None) and (nphi is not None):
+            raise ValueError("quadpoints_phi and nphi cannot both be specified")
+        if (quadpoints_phi is None) and (nphi is None):
+            # Neither is specified, so use a default:
+            nphi = 61
+        if quadpoints_phi is None:
+            if range == Surface.RANGE_FULL_TORUS:
+                quadpoints_phi = np.linspace(0.0, 1.0, nphi, endpoint=False)
+            elif range == Surface.RANGE_FIELD_PERIOD:
+                quadpoints_phi = np.linspace(0.0, 1.0 / nfp, nphi, endpoint=False)
+            elif range == Surface.RANGE_HALF_PERIOD:
+                quadpoints_phi = np.linspace(0.0, 0.5 / nfp, nphi, endpoint=False)
+            else:
+                raise ValueError("Invalid setting for range")
+
+        return list(quadpoints_phi), list(quadpoints_theta)
 
     @SimsoptRequires(mlab is not None, "Install mayavi to generate surface plot")
     def plot(self, ax=None, show=True, plot_normal=False, plot_derivative=False,

--- a/src/simsopt/geo/surfacegarabedian.py
+++ b/src/simsopt/geo/surfacegarabedian.py
@@ -1,13 +1,14 @@
 import numpy as np
 import logging
 
+import simsoptpp as sopp
 from .surface import Surface
 from .surfacerzfourier import SurfaceRZFourier
 
 logger = logging.getLogger(__name__)
 
 
-class SurfaceGarabedian(Surface):
+class SurfaceGarabedian(sopp.Surface, Surface):
     """
     `SurfaceGarabedian` represents a toroidal surface for which the
     shape is parameterized using Garabedian's :math:`\Delta_{m,n}`
@@ -18,7 +19,7 @@ class SurfaceGarabedian(Surface):
     coefficients be imaginary.
     """
 
-    def __init__(self, nfp=1, mmax=1, mmin=0, nmax=0, nmin=None):
+    def __init__(self, nfp=1, mmax=1, mmin=0, nmax=0, nmin=None, **kwargs):
         if nmin is None:
             nmin = -nmax
         # Perform some validation.
@@ -42,6 +43,8 @@ class SurfaceGarabedian(Surface):
         self.shape = (self.mdim, self.ndim)
 
         Delta = np.zeros(self.shape)
+        quadpoints_phi, quadpoints_theta = Surface.get_quadpoints(nfp=nfp, **kwargs)
+        sopp.Surface.__init__(self, quadpoints_phi, quadpoints_theta)
         Surface.__init__(self, x0=Delta.ravel(),
                          names=self._make_dof_names())
 

--- a/src/simsopt/geo/surfacehenneberg.py
+++ b/src/simsopt/geo/surfacehenneberg.py
@@ -72,12 +72,11 @@ class SurfaceHenneberg(sopp.Surface, Surface):
     """
 
     def __init__(self,
-                 nfp: int,
-                 alpha_fac: int,
-                 mmax: int,
-                 nmax: int,
-                 quadpoints_phi: int = 63,
-                 quadpoints_theta: int = 62):
+                 nfp: int = 1,
+                 alpha_fac: int = 1,
+                 mmax: int = 1,
+                 nmax: int = 0,
+                 **kwargs):
         if alpha_fac > 1 or alpha_fac < -1:
             raise ValueError('alpha_fac must be 1, 0, or -1')
 
@@ -88,11 +87,7 @@ class SurfaceHenneberg(sopp.Surface, Surface):
         self.stellsym = True
         self.allocate()
 
-        if isinstance(quadpoints_phi, int):
-            quadpoints_phi = np.linspace(0, 1.0, quadpoints_phi, endpoint=False)
-        if isinstance(quadpoints_theta, int):
-            quadpoints_theta = np.linspace(0, 1.0, quadpoints_theta, endpoint=False)
-
+        quadpoints_phi, quadpoints_theta = Surface.get_quadpoints(nfp=nfp, **kwargs)
         sopp.Surface.__init__(self, quadpoints_phi, quadpoints_theta)
         # Initialize to an axisymmetric torus with major radius 1m and
         # minor radius 0.1m

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -257,7 +257,7 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
         return surf
 
     @classmethod
-    def from_focus(cls, filename, quadpoints_phi=32, quadpoints_theta=32):
+    def from_focus(cls, filename, **kwargs):
         """
         Read in a surface from a FOCUS-format file.
         """
@@ -291,9 +291,8 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
         mpol = int(np.max(m))
         ntor = int(np.max(np.abs(n)))
 
-        surf = cls(mpol=mpol, ntor=ntor, nfp=nfp, stellsym=stellsym,
-                   quadpoints_phi=quadpoints_phi,
-                   quadpoints_theta=quadpoints_theta)
+        surf = cls(mpol=mpol, ntor=ntor, nfp=nfp, stellsym=stellsym, **kwargs)
+
         for j in range(Nfou):
             surf.rc[m[j], n[j] + ntor] = rc[j]
             surf.zs[m[j], n[j] + ntor] = zs[j]

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -35,11 +35,8 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
     :math:`r`, and the cos terms for :math:`z`.
     """
 
-    def __init__(self, nfp=1, stellsym=True, mpol=1, ntor=0, quadpoints_phi=63,
-                 quadpoints_theta=62):
-        if isinstance(quadpoints_phi, np.ndarray):
-            quadpoints_phi = list(quadpoints_phi)
-            quadpoints_theta = list(quadpoints_theta)
+    def __init__(self, nfp=1, stellsym=True, mpol=1, ntor=0, **kwargs):
+        quadpoints_phi, quadpoints_theta = Surface.get_quadpoints(nfp=nfp, **kwargs)
         sopp.SurfaceRZFourier.__init__(self, mpol, ntor, nfp, stellsym,
                                        quadpoints_phi, quadpoints_theta)
         self.rc[0, ntor] = 1.0

--- a/src/simsopt/geo/surfacexyzfourier.py
+++ b/src/simsopt/geo/surfacexyzfourier.py
@@ -36,11 +36,8 @@ class SurfaceXYZFourier(sopp.SurfaceXYZFourier, Surface):
     terms to zero.
     """
 
-    def __init__(self, nfp=1, stellsym=True, mpol=1, ntor=0, quadpoints_phi=32,
-                 quadpoints_theta=32):
-        if isinstance(quadpoints_phi, np.ndarray):
-            quadpoints_phi = list(quadpoints_phi)
-            quadpoints_theta = list(quadpoints_theta)
+    def __init__(self, nfp=1, stellsym=True, mpol=1, ntor=0, **kwargs):
+        quadpoints_phi, quadpoints_theta = Surface.get_quadpoints(nfp=nfp, **kwargs)
         sopp.SurfaceXYZFourier.__init__(self, mpol, ntor, nfp, stellsym,
                                         quadpoints_phi, quadpoints_theta)
         self.xc[0, ntor] = 1.0

--- a/src/simsopt/geo/surfacexyztensorfourier.py
+++ b/src/simsopt/geo/surfacexyztensorfourier.py
@@ -39,10 +39,8 @@ class SurfaceXYZTensorFourier(sopp.SurfaceXYZTensorFourier, Surface):
 
     def __init__(self, nfp=1, stellsym=True, mpol=1, ntor=1,
                  clamped_dims=[False, False, False],
-                 quadpoints_phi=32, quadpoints_theta=32):
-        if isinstance(quadpoints_phi, np.ndarray):
-            quadpoints_phi = list(quadpoints_phi)
-            quadpoints_theta = list(quadpoints_theta)
+                 **kwargs):
+        quadpoints_phi, quadpoints_theta = Surface.get_quadpoints(nfp=nfp, **kwargs)
         sopp.SurfaceXYZTensorFourier.__init__(self, mpol, ntor, nfp, stellsym,
                                               clamped_dims, quadpoints_phi,
                                               quadpoints_theta)

--- a/src/simsoptpp/python_surfaces.cpp
+++ b/src/simsoptpp/python_surfaces.cpp
@@ -150,7 +150,6 @@ void init_surfaces(py::module_ &m){
 
     auto pysurfacerzfourier = py::class_<PySurfaceRZFourier, shared_ptr<PySurfaceRZFourier>, PySurfaceRZFourierTrampoline<PySurfaceRZFourier>>(m, "SurfaceRZFourier")
         .def(py::init<int, int, int, bool, vector<double>, vector<double>>())
-        .def(py::init<int, int, int, bool, int, int>())
         .def_readwrite("rc", &PySurfaceRZFourier::rc)
         .def_readwrite("rs", &PySurfaceRZFourier::rs)
         .def_readwrite("zc", &PySurfaceRZFourier::zc)
@@ -164,7 +163,6 @@ void init_surfaces(py::module_ &m){
 
     auto pysurfacexyzfourier = py::class_<PySurfaceXYZFourier, shared_ptr<PySurfaceXYZFourier>, PySurfaceXYZFourierTrampoline<PySurfaceXYZFourier>>(m, "SurfaceXYZFourier")
         .def(py::init<int, int, int, bool, vector<double>, vector<double>>())
-        .def(py::init<int, int, int, bool, int, int>())
         .def_readwrite("xc", &PySurfaceXYZFourier::xc)
         .def_readwrite("xs", &PySurfaceXYZFourier::xs)
         .def_readwrite("yc", &PySurfaceXYZFourier::yc)
@@ -179,7 +177,6 @@ void init_surfaces(py::module_ &m){
 
     auto pysurfacexyztensorfourier = py::class_<PySurfaceXYZTensorFourier, shared_ptr<PySurfaceXYZTensorFourier>, PySurfaceXYZTensorFourierTrampoline<PySurfaceXYZTensorFourier>>(m, "SurfaceXYZTensorFourier")
         .def(py::init<int, int, int, bool, vector<bool>, vector<double>, vector<double>>())
-        .def(py::init<int, int, int, bool, vector<bool>, int, int>())
         .def_readwrite("xcs", &PySurfaceXYZTensorFourier::x)
         .def_readwrite("ycs", &PySurfaceXYZTensorFourier::y)
         .def_readwrite("zcs", &PySurfaceXYZTensorFourier::z)

--- a/src/simsoptpp/surface.h
+++ b/src/simsoptpp/surface.h
@@ -80,21 +80,6 @@ class Surface {
             }
         }
 
-        Surface(int _numquadpoints_phi, int _numquadpoints_theta) {
-            numquadpoints_phi = _numquadpoints_phi;
-            numquadpoints_theta = _numquadpoints_theta;
-
-            quadpoints_phi = xt::zeros<double>({numquadpoints_phi});
-            for (int i = 0; i < numquadpoints_phi; ++i) {
-                quadpoints_phi[i] = i/double(numquadpoints_phi);
-            }
-            quadpoints_theta = xt::zeros<double>({numquadpoints_theta});
-            for (int i = 0; i < numquadpoints_theta; ++i) {
-                quadpoints_theta[i] = i/double(numquadpoints_theta);
-            }
-        }
-
-
         void least_squares_fit(Array& target_values);
         void fit_to_curve(Curve<Array>& curve, double radius, bool flip_theta);
         void scale(double scale);

--- a/src/simsoptpp/surfacerzfourier.h
+++ b/src/simsoptpp/surfacerzfourier.h
@@ -43,11 +43,6 @@ class SurfaceRZFourier : public Surface<Array> {
                 this->allocate();
             }
 
-        SurfaceRZFourier(int _mpol, int _ntor, int _nfp, bool _stellsym, int _numquadpoints_phi, int _numquadpoints_theta)
-            : Surface<Array>(_numquadpoints_phi, _numquadpoints_theta), mpol(_mpol), ntor(_ntor), nfp(_nfp), stellsym(_stellsym) {
-                this->allocate();
-            }
-
         void allocate() {
             rc = xt::zeros<double>({mpol+1, 2*ntor+1});
             rs = xt::zeros<double>({mpol+1, 2*ntor+1});

--- a/src/simsoptpp/surfacexyzfourier.h
+++ b/src/simsoptpp/surfacexyzfourier.h
@@ -62,18 +62,6 @@ class SurfaceXYZFourier : public Surface<Array> {
                 zs = xt::zeros<double>({mpol+1, 2*ntor+1});
             }
 
-        SurfaceXYZFourier(int _mpol, int _ntor, int _nfp, bool _stellsym, int _numquadpoints_phi, int _numquadpoints_theta)
-            : Surface<Array>(_numquadpoints_phi, _numquadpoints_theta), mpol(_mpol), ntor(_ntor), nfp(_nfp), stellsym(_stellsym) {
-                xc = xt::zeros<double>({mpol+1, 2*ntor+1});
-                xs = xt::zeros<double>({mpol+1, 2*ntor+1});
-                yc = xt::zeros<double>({mpol+1, 2*ntor+1});
-                ys = xt::zeros<double>({mpol+1, 2*ntor+1});
-                zc = xt::zeros<double>({mpol+1, 2*ntor+1});
-                zs = xt::zeros<double>({mpol+1, 2*ntor+1});
-            }
-
-
-
         int num_dofs() override {
             if(stellsym)
                 return 3*(mpol+1)*(2*ntor+1) - 1*ntor - 2*(ntor+1);

--- a/src/simsoptpp/surfacexyztensorfourier.h
+++ b/src/simsoptpp/surfacexyztensorfourier.h
@@ -59,16 +59,6 @@ class SurfaceXYZTensorFourier : public Surface<Array> {
                 build_cache();
             }
 
-        SurfaceXYZTensorFourier(int _mpol, int _ntor, int _nfp, bool _stellsym, std::vector<bool> _clamped_dims, int _numquadpoints_phi, int _numquadpoints_theta)
-            : Surface<Array>(_numquadpoints_phi, _numquadpoints_theta), mpol(_mpol), ntor(_ntor), nfp(_nfp), stellsym(_stellsym), clamped_dims(_clamped_dims) {
-                x = xt::zeros<double>({2*mpol+1, 2*ntor+1});
-                y = xt::zeros<double>({2*mpol+1, 2*ntor+1});
-                z = xt::zeros<double>({2*mpol+1, 2*ntor+1});
-                build_cache();
-            }
-
-
-
         int num_dofs() override {
             if(stellsym)
                 return (ntor+1)*(mpol+1)+ ntor*mpol + 2*(ntor+1)*mpol + 2*ntor*(mpol+1);

--- a/tests/core/test_graph_optimizable.py
+++ b/tests/core/test_graph_optimizable.py
@@ -857,7 +857,7 @@ class OptimizableTestsExternalDofs(unittest.TestCase):
 class TestMakeOptimizable(unittest.TestCase):
     def setUp(self) -> None:
         def arb_fun_dofs_noopts(a, b, c, /):
-            return a ** 2 + 2 * b ** 2 + 3 * c ** 2  - 10
+            return a ** 2 + 2 * b ** 2 + 3 * c ** 2 - 10
 
         def arb_fun_nodofs_opts(adder):
             return adder.sum()**2 - 10
@@ -895,7 +895,7 @@ class TestMakeOptimizable(unittest.TestCase):
         a = 2.0
         b = 3.0
         adder = Adder(n=3, x0=[1.0, 2.0, 3.0])
-        opt = make_optimizable(self.arb_fun_dofs_opts, a,  b, adder)
+        opt = make_optimizable(self.arb_fun_dofs_opts, a, b, adder)
         self.assertAlmostEqual(opt.J(), 39.0)
         x = opt.x   # Length of x is 3
         self.assertEqual(len(x), 3)
@@ -912,7 +912,7 @@ class TestMakeOptimizable(unittest.TestCase):
                                a, b, adder,
                                dof_indicators=['dof', 'non-dof', 'opt'])
         self.assertAlmostEqual(opt.J(), 39.0)
-        x = opt.x # Length of x is 4
+        x = opt.x  # Length of x is 4
         self.assertEqual(len(x), 4)
         opt.x = x / 2.0
         self.assertAlmostEqual(opt.J(), 9.0)

--- a/tests/core/test_integrated.py
+++ b/tests/core/test_integrated.py
@@ -41,7 +41,7 @@ class IntegratedTests(unittest.TestCase):
 
             # Start with a default surface, which is axisymmetric with major
             # radius 1 and minor radius 0.1.
-            surf = SurfaceRZFourier(quadpoints_phi=62, quadpoints_theta=63)
+            surf = SurfaceRZFourier()
 
             # Set initial surface shape. It helps to make zs(1,0) larger
             # than rc(1,0) since there are two solutions to this

--- a/tests/field/test_sampling.py
+++ b/tests/field/test_sampling.py
@@ -43,7 +43,7 @@ class SamplingTesting(unittest.TestCase):
     def test_surface_sampling(self):
         np.random.seed(1)
         nquadpoints = int(4e2)
-        surface = SurfaceRZFourier(nfp=1, stellsym=True, mpol=1, ntor=0, quadpoints_phi=nquadpoints, quadpoints_theta=nquadpoints)
+        surface = SurfaceRZFourier(nfp=1, stellsym=True, mpol=1, ntor=0, nphi=nquadpoints, ntheta=nquadpoints)
         dofs = surface.get_dofs()
         dofs[0] = 1
         dofs[1] = 0.8

--- a/tests/geo/test_surface_rzfourier.py
+++ b/tests/geo/test_surface_rzfourier.py
@@ -146,8 +146,8 @@ class SurfaceRZFourierTests(unittest.TestCase):
         true_volume = 2.98138727016329
         self.assertAlmostEqual(s.volume(), true_volume, places=8)
         # Try specifying the number of quadrature points:
-        s = SurfaceRZFourier.from_wout(filename, quadpoints_phi=71,
-                                       quadpoints_theta=78)
+        s = SurfaceRZFourier.from_wout(filename, nphi=71,
+                                       ntheta=78)
         self.assertAlmostEqual(s.volume(), true_volume, places=8)
         # If you ask for the s=0 surface, which is just the magnetic
         # axis, the volume and area should be 0.
@@ -178,8 +178,8 @@ class SurfaceRZFourierTests(unittest.TestCase):
         true_volume = 2.97871721453671
         self.assertAlmostEqual(s.volume(), true_volume, places=8)
         # Try specifying the number of quadrature points:
-        s = SurfaceRZFourier.from_vmec_input(filename, quadpoints_phi=78,
-                                             quadpoints_theta=71)
+        s = SurfaceRZFourier.from_vmec_input(filename, nphi=78,
+                                             ntheta=71)
         self.assertAlmostEqual(s.volume(), true_volume, places=8)
 
         filename = TEST_DIR / 'input.NuhrenbergZille_1988_QHS'
@@ -203,8 +203,8 @@ class SurfaceRZFourierTests(unittest.TestCase):
         true_volume = 0.199228326303124
         self.assertAlmostEqual(s.volume(), true_volume, places=8)
         # Try specifying the number of quadrature points:
-        s = SurfaceRZFourier.from_vmec_input(filename, quadpoints_phi=67,
-                                             quadpoints_theta=69)
+        s = SurfaceRZFourier.from_vmec_input(filename, nphi=67,
+                                             ntheta=69)
         self.assertAlmostEqual(s.volume(), true_volume, places=8)
 
     def test_from_vmec_2_ways(self):

--- a/tests/geo/test_surfacehenneberg.py
+++ b/tests/geo/test_surfacehenneberg.py
@@ -29,22 +29,6 @@ TEST_DIR = (Path(__file__).parent / ".." / "test_files").resolve()
 
 
 class SurfaceHennebergTests(unittest.TestCase):
-    def test_init_quadpoints(self):
-        """
-        Test that we can initialize the points either by an integer, list,
-        or numpy array.
-        """
-        for phi_points in [32,
-                           np.linspace(0.0, 1.0, 32, endpoint=False),
-                           list(np.linspace(0.0, 1.0, 32, endpoint=False))]:
-
-            for theta_points in [32,
-                                 np.linspace(0.0, 1.0, 32, endpoint=False),
-                                 list(np.linspace(0.0, 1.0, 32, endpoint=False))]:
-
-                surf = SurfaceHenneberg(nfp=5, alpha_fac=-1, mmax=3, nmax=4,
-                                        quadpoints_phi=phi_points,
-                                        quadpoints_theta=theta_points)
 
     def test_names(self):
         """


### PR DESCRIPTION
This PR implements the new methods for initializing Surface quadpoints that we have discussed.

Now, the quadrature points can be initialized via

    s = SurfaceXYZFourier(range="half period", nphi=128, ntheta=64)

or

    s = SurfaceRZFourier(range=SurfaceRZFourier.RANGE_FULL_TORUS, nphi=128, ntheta=64)

where, as shown in these examples, the phi range can be set by either a string or a constant. You can still specify arrays for quadpoints_phi and/or quadpoints_theta directly instead if you like, as previously. The new initialization methods work for and are tested for all Surface subclasses.

The bit of code that handles setting `quadpoints_phi` from `range` and `nphi` is pure python, so nothing was added to C++. It would have been nice to put this new bit of code in the python `Surface` constructor, but I don't think this is possible. The reason is that in the different Surface sub-types, the C++ constructor has to be called before the python constructor (so e.g. `self.mpol` is set before the dof names are set before the Optimizable constructor is called.) Hence a `get_quadpoints` function was introduced in the Surface base class, and it is called in the constructor of each Surface sub-type. See what you think of this implementation.

If you're happy with this implementation, I'll polish some docstrings and other docs before we merge.

A little bit of C++ code was removed since it is now required that `quadpoints_phi` and `quadpoints_theta` are lists and not integers when the C++ Surface constructors are called.

Note that this PR is based on the `graph_surface` branch instead of `master` to minimize merge conflicts with Bharat's work.