### PR TITLE
CircularCoil fix

### DIFF
--- a/src/simsopt/field/magneticfieldclasses.py
+++ b/src/simsopt/field/magneticfieldclasses.py
@@ -274,19 +274,34 @@ class CircularCoil(MagneticField):
         self.Inorm = I*4e-7
         self.center = center
         if len(normal) == 2:
-            self.normal = [normal[0], -normal[1]]
+            theta = normal[0]
+            phi   = normal[1]
         else:
-            self.normal = [np.arctan2(np.sqrt(normal[0]**2+normal[1]**2), normal[2]), -np.arctan2(normal[0], normal[1])]
-        self.rotMatrix = np.array([[np.cos(self.normal[1]), np.sin(self.normal[0])*np.sin(self.normal[1]),
-                                    np.cos(self.normal[0])*np.sin(self.normal[1])],
-                                   [0, np.cos(self.normal[0]), -np.sin(self.normal[0])],
-                                   [np.sin(self.normal[1]), np.sin(self.normal[0])*np.cos(self.normal[1]),
-                                    np.cos(self.normal[0])*np.cos(self.normal[1])]])
+            theta = np.arctan2(normal[1], normal[0])
+            phi   = np.arctan2(np.sqrt(normal[0]**2+normal[1]**2), normal[2])
+        # self.rotMatrix = np.array([[np.cos(self.normal[1]), np.sin(self.normal[0])*np.sin(self.normal[1]),
+        #                             np.cos(self.normal[0])*np.sin(self.normal[1])],
+        #                            [0, np.cos(self.normal[0]), -np.sin(self.normal[0])],
+        #                            [np.sin(self.normal[1]), np.sin(self.normal[0])*np.cos(self.normal[1]),
+        #                             np.cos(self.normal[0])*np.cos(self.normal[1])]])
+
+        self.rotMatrix = np.array([
+            [np.cos(phi) * np.cos(theta)**2 + np.sin(theta)**2,
+             -np.sin(phi / 2)**2 * np.sin(2 * theta), 
+             -np.cos(theta) * np.sin(phi)],
+            [np.sin(phi / 2)**2 * np.sin(2 * theta), 
+             np.cos(theta)**2 + np.cos(phi) * np.sin(theta)**2, 
+             np.sin(phi) * np.sin(theta)],
+            [np.cos(theta) * np.sin(phi),
+             -np.sin(phi) * np.sin(theta), 
+             np.cos(phi)]
+        ])
+
         self.rotMatrixInv = np.array(self.rotMatrix.T)
 
     def _B_impl(self, B):
         points = self.get_points_cart_ref()
-        points = np.array(np.dot(self.rotMatrix, np.array(np.subtract(points, self.center)).T).T)
+        points = np.array(np.dot(self.rotMatrixInv, np.array(np.subtract(points, self.center)).T).T)
         rho = np.sqrt(np.square(points[:, 0]) + np.square(points[:, 1]))
         r = np.sqrt(np.square(points[:, 0]) + np.square(points[:, 1]) + np.square(points[:, 2]))
         alpha = np.sqrt(self.r0**2 + np.square(r) - 2*self.r0*rho)
@@ -295,14 +310,14 @@ class CircularCoil(MagneticField):
         ellipek2 = ellipe(k**2)
         ellipkk2 = ellipk(k**2)
         gamma = np.square(points[:, 0]) - np.square(points[:, 1])
-        B[:] = np.dot(self.rotMatrixInv, np.array(
+        B[:] = np.dot(self.rotMatrix, np.array(
             [self.Inorm*points[:, 0]*points[:, 2]/(2*alpha**2*beta*rho**2+1e-31)*((self.r0**2+r**2)*ellipek2-alpha**2*ellipkk2),
              self.Inorm*points[:, 1]*points[:, 2]/(2*alpha**2*beta*rho**2+1e-31)*((self.r0**2+r**2)*ellipek2-alpha**2*ellipkk2),
              self.Inorm/(2*alpha**2*beta+1e-31)*((self.r0**2-r**2)*ellipek2+alpha**2*ellipkk2)])).T
 
     def _dB_by_dX_impl(self, dB):
         points = self.get_points_cart_ref()
-        points = np.array(np.dot(self.rotMatrix, np.array(np.subtract(points, self.center)).T).T)
+        points = np.array(np.dot(self.rotMatrixInv, np.array(np.subtract(points, self.center)).T).T)
         rho = np.sqrt(np.square(points[:, 0]) + np.square(points[:, 1]))
         r = np.sqrt(np.square(points[:, 0]) + np.square(points[:, 1]) + np.square(points[:, 2]))
         alpha = np.sqrt(self.r0**2 + np.square(r) - 2*self.r0*rho)
@@ -360,19 +375,19 @@ class CircularCoil(MagneticField):
             [dBxdz, dBydz, dBzdz]])
 
         dB[:] = np.array([
-            [np.dot(self.rotMatrix[:, 0], np.dot(self.rotMatrixInv[0, :], dB_by_dXm)),
-             np.dot(self.rotMatrix[:, 1], np.dot(self.rotMatrixInv[0, :], dB_by_dXm)),
-             np.dot(self.rotMatrix[:, 2], np.dot(self.rotMatrixInv[0, :], dB_by_dXm))],
-            [np.dot(self.rotMatrix[:, 0], np.dot(self.rotMatrixInv[1, :], dB_by_dXm)),
-             np.dot(self.rotMatrix[:, 1], np.dot(self.rotMatrixInv[1, :], dB_by_dXm)),
-             np.dot(self.rotMatrix[:, 2], np.dot(self.rotMatrixInv[1, :], dB_by_dXm))],
-            [np.dot(self.rotMatrix[:, 0], np.dot(self.rotMatrixInv[2, :], dB_by_dXm)),
-             np.dot(self.rotMatrix[:, 1], np.dot(self.rotMatrixInv[2, :], dB_by_dXm)),
-             np.dot(self.rotMatrix[:, 2], np.dot(self.rotMatrixInv[2, :], dB_by_dXm))]]).T
+            [np.dot(self.rotMatrixInv[:, 0], np.dot(self.rotMatrix[0, :], dB_by_dXm)),
+             np.dot(self.rotMatrixInv[:, 1], np.dot(self.rotMatrix[0, :], dB_by_dXm)),
+             np.dot(self.rotMatrixInv[:, 2], np.dot(self.rotMatrix[0, :], dB_by_dXm))],
+            [np.dot(self.rotMatrixInv[:, 0], np.dot(self.rotMatrix[1, :], dB_by_dXm)),
+             np.dot(self.rotMatrixInv[:, 1], np.dot(self.rotMatrix[1, :], dB_by_dXm)),
+             np.dot(self.rotMatrixInv[:, 2], np.dot(self.rotMatrix[1, :], dB_by_dXm))],
+            [np.dot(self.rotMatrixInv[:, 0], np.dot(self.rotMatrix[2, :], dB_by_dXm)),
+             np.dot(self.rotMatrixInv[:, 1], np.dot(self.rotMatrix[2, :], dB_by_dXm)),
+             np.dot(self.rotMatrixInv[:, 2], np.dot(self.rotMatrix[2, :], dB_by_dXm))]]).T
 
     def _A_impl(self, A):
         points = self.get_points_cart_ref()
-        points = np.array(np.dot(self.rotMatrix, np.array(np.subtract(points, self.center)).T).T)
+        points = np.array(np.dot(self.rotMatrixInv, np.array(np.subtract(points, self.center)).T).T)
         rho = np.sqrt(np.square(points[:, 0]) + np.square(points[:, 1]))
         r = np.sqrt(np.square(points[:, 0]) + np.square(points[:, 1]) + np.square(points[:, 2]))
         alpha = np.sqrt(self.r0**2 + np.square(r) - 2*self.r0*rho)
@@ -381,7 +396,7 @@ class CircularCoil(MagneticField):
         ellipek2 = ellipe(k**2)
         ellipkk2 = ellipk(k**2)
 
-        A[:] = -self.Inorm/2*np.dot(self.rotMatrixInv, np.array(
+        A[:] = -self.Inorm/2*np.dot(self.rotMatrix, np.array(
             (2*self.r0+np.sqrt(points[:, 0]**2+points[:, 1]**2)*ellipek2+(self.r0**2+points[:, 0]**2+points[:, 1]**2+points[:, 2]**2)*(ellipe(k**2)-ellipkk2)) /
             ((points[:, 0]**2+points[:, 1]**2+1e-31)*np.sqrt(self.r0**2+points[:, 0]**2+points[:, 1]**2+2*self.r0*np.sqrt(points[:, 0]**2+points[:, 1]**2)+points[:, 2]**2+1e-31)) *
             np.array([-points[:, 1], points[:, 0], 0])).T)

--- a/src/simsopt/field/magneticfieldclasses.py
+++ b/src/simsopt/field/magneticfieldclasses.py
@@ -222,16 +222,18 @@ class ScalarPotentialRZMagneticField(MagneticField):
         self.PhiStr = PhiStr
         self.Phiparsed = parse_expr(PhiStr)
         R, Z, Phi = sp.symbols('R Z phi')
-        self.Blambdify = sp.lambdify((R, Z, Phi), [self.Phiparsed.diff(R)+1e-30*sp.sin(Phi), self.Phiparsed.diff(Phi)/R+1e-30*sp.sin(Phi), self.Phiparsed.diff(Z)+1e-30*sp.sin(Phi)])
+        self.Blambdify = sp.lambdify((R, Z, Phi), [self.Phiparsed.diff(R)+1e-30*sp.sin(Phi*R*Z), self.Phiparsed.diff(Phi)/R+1e-30*sp.sin(Phi*R*Z), self.Phiparsed.diff(Z)+1e-30*sp.sin(Phi*R*Z)])
         self.dBlambdify_by_dX = sp.lambdify(
             (R, Z, Phi),
-            [[sp.cos(Phi)*self.Phiparsed.diff(R).diff(R)-(sp.sin(Phi)/R)*self.Phiparsed.diff(R).diff(Phi),
-              sp.cos(Phi)*(self.Phiparsed.diff(Phi)/R).diff(R)-(sp.sin(Phi)/R)*(self.Phiparsed.diff(Phi)/R).diff(Phi),
-              sp.cos(Phi)*self.Phiparsed.diff(Z).diff(R)-(sp.sin(Phi)/R)*self.Phiparsed.diff(Z).diff(Phi)],
-             [sp.sin(Phi)*self.Phiparsed.diff(R).diff(R)+(sp.cos(Phi)/R)*self.Phiparsed.diff(R).diff(Phi),
-              sp.sin(Phi)*(self.Phiparsed.diff(Phi)/R).diff(R)+(sp.cos(Phi)/R)*(self.Phiparsed.diff(Phi)/R).diff(Phi),
-              sp.sin(Phi)*self.Phiparsed.diff(Z).diff(R)+(sp.cos(Phi)/R)*self.Phiparsed.diff(Z).diff(Phi)],
-             [self.Phiparsed.diff(R).diff(Z)+1e-30*sp.sin(Phi), (self.Phiparsed.diff(Phi)/R).diff(Z), self.Phiparsed.diff(Z).diff(Z)+1e-30*sp.sin(Phi)]])
+            [[1e-30*sp.sin(Phi*R*Z)+sp.cos(Phi)*self.Phiparsed.diff(R).diff(R)-(sp.sin(Phi)/R)*self.Phiparsed.diff(R).diff(Phi),
+              1e-30*sp.sin(Phi*R*Z)+sp.cos(Phi)*(self.Phiparsed.diff(Phi)/R).diff(R)-(sp.sin(Phi)/R)*(self.Phiparsed.diff(Phi)/R).diff(Phi),
+              1e-30*sp.sin(Phi*R*Z)+sp.cos(Phi)*self.Phiparsed.diff(Z).diff(R)-(sp.sin(Phi)/R)*self.Phiparsed.diff(Z).diff(Phi)],
+             [1e-30*sp.sin(Phi*R*Z)+sp.sin(Phi)*self.Phiparsed.diff(R).diff(R)+(sp.cos(Phi)/R)*self.Phiparsed.diff(R).diff(Phi),
+              1e-30*sp.sin(Phi*R*Z)+sp.sin(Phi)*(self.Phiparsed.diff(Phi)/R).diff(R)+(sp.cos(Phi)/R)*(self.Phiparsed.diff(Phi)/R).diff(Phi),
+              1e-30*sp.sin(Phi*R*Z)+sp.sin(Phi)*self.Phiparsed.diff(Z).diff(R)+(sp.cos(Phi)/R)*self.Phiparsed.diff(Z).diff(Phi)],
+             [1e-30*sp.sin(Phi*R*Z)+self.Phiparsed.diff(R).diff(Z),
+              1e-30*sp.sin(Phi*R*Z)+(self.Phiparsed.diff(Phi)/R).diff(Z),
+              1e-30*sp.sin(Phi*R*Z)+self.Phiparsed.diff(Z).diff(Z)]])
 
     def _B_impl(self, B):
         points = self.get_points_cart_ref()

--- a/tests/field/test_magneticfields.py
+++ b/tests/field/test_magneticfields.py
@@ -149,7 +149,7 @@ class Testing(unittest.TestCase):
         points = np.asarray(npoints * [[-1.41513202e-03, 8.99999382e-01, -3.14473221e-04]])
         points += pointVar * (np.random.rand(*points.shape)-0.5)
         ## verify with a x^2+z^2=radius^2 circular coil
-        normal = [np.pi/2, 0]
+        normal = [np.pi/2, np.pi/2]
         curve = CurveXYZFourier(300, 1)
         curve.set_dofs([center[0], radius, 0., center[1], 0., 0., center[2], 0., radius])
         Bcircular = BiotSavart([Coil(curve, Current(current))])
@@ -177,7 +177,7 @@ class Testing(unittest.TestCase):
         assert np.allclose(dB1_by_dX[:, 0, 0]+dB1_by_dX[:, 1, 1]+dB1_by_dX[:, 2, 2], np.zeros((npoints)))
         assert np.allclose(dB1_by_dX, transpGradB1)
         ## verify with a y^2+z^2=radius^2 circular coil
-        normal = [np.pi/2, np.pi/2]
+        normal = [0, np.pi/2]
         curve = CurveXYZFourier(300, 1)
         curve.set_dofs([center[0], 0, 0., center[1], radius, 0., center[2], 0., radius])
         Bcircular = BiotSavart([Coil(curve, Current(current))])
@@ -192,7 +192,7 @@ class Testing(unittest.TestCase):
         assert np.allclose(dB1_by_dX, transpGradB1)  # symmetry of the gradient
         Bfield.set_points([[0.1, 0.2, 0.3]])
         Afield = Bfield.A()
-        assert np.allclose(Afield, [[0, 5.15786, -2.643056]])
+        assert np.allclose(Afield, [[0, -5.15785, 2.643056]])
         # use normal=[1,0,0]
         normal = [1, 0, 0]
         curve = CurveXYZFourier(300, 1)


### PR DESCRIPTION
This PR fixes a known issue in the magnetic field class called CircularCoil. It was seen that although the magnetic field and its derivatives were correct at some angles, not all angles were giving sensible results. Furthermore, when testing for a circular arrangement of toroidal coils, periodicity was not being observed.
The rotation matrix was missing important elements. The new rotation matrix is now obtained using the Mathematica function _RotationMatrix_, which gives matrices for rotations of vectors around the origin. The formula, made in such a way that the Bfield as the necessary orientation to match the one with the BioSavart class with the same current, is
`RotationMatrix[phi, {-Sin[theta], -Cos[theta], 0}]`
Theta and Phi angles are spherical angles as often used in mathematics: 
x=rho sin(phi) cos(theta)
y=rho sin(phi) sin(theta
z=rho cos(phi)
