### PR TITLE
Reorganize SurfaceRZFourier->Garabedian conversion

### DIFF
--- a/examples/stellarator_benchmarks/1DOF_circularCrossSection_varyAxis_targetIota.py
+++ b/examples/stellarator_benchmarks/1DOF_circularCrossSection_varyAxis_targetIota.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 from mpi4py import MPI
 import numpy as np
 
@@ -7,7 +8,7 @@ from simsopt.mhd import Vmec
 from simsopt.objectives.graph_least_squares import LeastSquaresProblem
 from simsopt.util.mpi import MpiPartition, log
 from simsopt.solve.graph_mpi import least_squares_mpi_solve
-import os
+from simsopt.geo.surfacegarabedian import SurfaceGarabedian
 
 """
 This script implements the "1DOF_circularCrossSection_varyAxis_targetIota"
@@ -43,7 +44,7 @@ equil = Vmec(os.path.join(os.path.dirname(__file__), 'inputs', 'input.1DOF_Garab
 # We will optimize in the space of Garabedian coefficients rather than
 # RBC/ZBS coefficients. To do this, we convert the boundary to the
 # Garabedian representation:
-surf = equil.boundary.to_Garabedian()
+surf = SurfaceGarabedian.from_RZFourier(equil.boundary)
 equil.boundary = surf
 
 # VMEC parameters are all fixed by default, while surface parameters

--- a/examples/stellarator_benchmarks/1DOF_circularCrossSection_varyAxis_targetIota_spec.py
+++ b/examples/stellarator_benchmarks/1DOF_circularCrossSection_varyAxis_targetIota_spec.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import logging
 import numpy as np
 
@@ -7,9 +8,9 @@ from simsopt.util.mpi import MpiPartition, log
 from simsopt.mhd import Spec
 from simsopt.objectives.graph_least_squares import LeastSquaresProblem
 from simsopt.solve.graph_mpi import least_squares_mpi_solve
-import os
+from simsopt.geo.surfacegarabedian import SurfaceGarabedian
 
-"""¡
+"""
 This script implements the "1DOF_circularCrossSection_varyAxis_targetIota"
 example from
 https://github.com/landreman/stellopt_scenarios
@@ -43,7 +44,7 @@ equil = Spec(os.path.join(os.path.dirname(__file__), 'inputs', '1DOF_Garabedian.
 # We will optimize in the space of Garabedian coefficients rather than
 # RBC/ZBS coefficients. To do this, we convert the boundary to the
 # Garabedian representation:
-surf = equil.boundary.to_Garabedian()
+surf = SurfaceGarabedian.from_RZFourier(equil.boundary)
 equil.boundary = surf
 
 # VMEC parameters are all fixed by default, while surface parameters

--- a/examples/stellarator_benchmarks/7dof.py
+++ b/examples/stellarator_benchmarks/7dof.py
@@ -5,6 +5,7 @@ from simsopt.util.mpi import MpiPartition, log
 from simsopt.mhd import Vmec, Boozer, Quasisymmetry
 from simsopt.objectives.graph_least_squares import LeastSquaresProblem
 from simsopt.solve.graph_mpi import least_squares_mpi_solve
+from simsopt.geo.surfacegarabedian import SurfaceGarabedian
 
 """
 This script solve the problem in
@@ -21,7 +22,7 @@ mpi = MpiPartition()
 vmec = Vmec(os.path.join(os.path.dirname(__file__), 'inputs', 'input.stellopt_scenarios_7dof'), mpi)
 
 # We will optimize in the space of Garabedian coefficients:
-surf = vmec.boundary.to_Garabedian()
+surf = SurfaceGarabedian.from_RZFourier(vmec.boundary)
 vmec.boundary = surf
 
 # Define parameter space:

--- a/src/simsopt/geo/surfacegarabedian.py
+++ b/src/simsopt/geo/surfacegarabedian.py
@@ -183,6 +183,33 @@ class SurfaceGarabedian(sopp.Surface, Surface):
 
         return s
 
+    # TODO: Reimplement by passing all Delta values once
+    @classmethod
+    def from_RZFourier(cls, surf):
+        """
+        Create a `SurfaceGarabedian` from a `SurfaceRZFourier` object of the identical shape.
+
+        For a derivation of the transformation here, see
+        https://terpconnect.umd.edu/~mattland/assets/notes/toroidal_surface_parameterizations.pdf
+        """
+        if not surf.stellsym:
+            raise RuntimeError('Non-stellarator-symmetric SurfaceGarabedian '
+                               'objects have not been implemented')
+        mmax = surf.mpol + 1
+        mmin = np.min((0, 1 - surf.mpol))
+        s = cls(nfp=surf.nfp, mmin=mmin, mmax=mmax,
+                nmin=-surf.ntor, nmax=surf.ntor)
+        for n in range(-surf.ntor, surf.ntor + 1):
+            for m in range(mmin, mmax + 1):
+                Delta = 0
+                if m - 1 >= 0:
+                    Delta = 0.5 * (surf.get_rc(m - 1, n) - surf.get_zs(m - 1, n))
+                if 1 - m >= 0:
+                    Delta += 0.5 * (surf.get_rc(1 - m, -n) + surf.get_zs(1 - m, -n))
+                s.set_Delta(m, n, Delta)
+
+        return s
+
     def area_volume(self):
         """
         Compute the surface area and the volume enclosed by the surface.

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -490,33 +490,6 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
                     if m > 0 or n != 0:
                         fn(f'rs({m},{n})')
 
-    # TODO: Reimplement by passing all Delta values once
-    def to_Garabedian(self):
-        """
-        Return a `SurfaceGarabedian` object with the identical shape.
-
-        For a derivation of the transformation here, see
-        https://terpconnect.umd.edu/~mattland/assets/notes/toroidal_surface_parameterizations.pdf
-        """
-        if not self.stellsym:
-            raise RuntimeError('Non-stellarator-symmetric SurfaceGarabedian '
-                               'objects have not been implemented')
-        from simsopt.geo.surfacegarabedian import SurfaceGarabedian
-        mmax = self.mpol + 1
-        mmin = np.min((0, 1 - self.mpol))
-        s = SurfaceGarabedian(nfp=self.nfp, mmin=mmin, mmax=mmax,
-                              nmin=-self.ntor, nmax=self.ntor)
-        for n in range(-self.ntor, self.ntor + 1):
-            for m in range(mmin, mmax + 1):
-                Delta = 0
-                if m - 1 >= 0:
-                    Delta = 0.5 * (self.get_rc(m - 1, n) - self.get_zs(m - 1, n))
-                if 1 - m >= 0:
-                    Delta += 0.5 * (self.get_rc(1 - m, -n) + self.get_zs(1 - m, -n))
-                s.set_Delta(m, n, Delta)
-
-        return s
-
     def recompute_bell(self, parent=None):
         self.invalidate_cache()
 

--- a/tests/geo/test_surface_garabedian.py
+++ b/tests/geo/test_surface_garabedian.py
@@ -78,7 +78,7 @@ class SurfaceGarabedianTests(unittest.TestCase):
                     sf1 = SurfaceRZFourier(nfp=nfp, mpol=mpol, ntor=ntor)
                     # Set all dofs to random numbers in [-2, 2]:
                     sf1.set_dofs((np.random.rand(len(sf1.get_dofs())) - 0.5) * 4)
-                    sg = sf1.to_Garabedian()
+                    sg = SurfaceGarabedian.from_RZFourier(sf1)
                     sf2 = sg.to_RZFourier()
                     np.testing.assert_allclose(sf1.rc, sf2.rc)
                     np.testing.assert_allclose(sf1.zs, sf2.zs)

--- a/tests/mhd/test_spec.py
+++ b/tests/mhd/test_spec.py
@@ -27,6 +27,7 @@ except:
 if (MPI is not None) and spec_found:
     from simsopt.mhd.spec import Spec, Residue
 from simsopt.objectives.graph_least_squares import LeastSquaresProblem
+from simsopt.geo.surfacegarabedian import SurfaceGarabedian
 from simsopt.solve.graph_serial import least_squares_serial_solve
 from . import TEST_DIR
 
@@ -186,7 +187,7 @@ class SpecTests(unittest.TestCase):
             # We will optimize in the space of Garabedian coefficients
             # rather than RBC/ZBS coefficients. To do this, we convert the
             # boundary to the Garabedian representation:
-            surf = equil.boundary.to_Garabedian()
+            surf = SurfaceGarabedian.from_RZFourier(equil.boundary)
             equil.boundary = surf
 
             # SPEC parameters are all fixed by default, while surface


### PR DESCRIPTION
In this PR, the `SurfaceRZFourier.to_Garabedian()` function is moved to `SurfaceGarabedian.from_RZFourier()`. The idea is that `SurfaceRZFourier`, as it is the basis for VMEC and SPEC, should not know about "specialty" surface representations like `SurfaceGarabedian` and `SurfaceHenneberg`. Each specialty surface class should handle the conversion to and from `SurfaceRZFourier`, whereas `SurfaceRZFourier` should be as stable as possible, and not have to have any conversion methods added if a new specialty surface class is introduced. `SurfaceHenneberg` already was organized this way, and now `SurfaceGarabedian` is organized this way too.