### PR TITLE
Only initialize MPI if necessary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,9 @@ jobs:
     - name: Install simsopt package
       run: pip install -v .[MPI,SPEC]
 
+    - name: Verify that importing simsopt does not automatically initialize MPI
+      run: ./tests/verify_MPI_not_initialized.py
+
     - name: Run examples as part of integrated tests
       if: contains(matrix.test-type, 'integrated')
       run: |

--- a/src/simsopt/__init__.py
+++ b/src/simsopt/__init__.py
@@ -21,6 +21,5 @@ __version__ = metadata.version('simsopt')
 from ._core import make_optimizable
 from .objectives import LeastSquaresProblem
 from .solve import least_squares_serial_solve
-from mpi4py import MPI  # This line is temporary, to check the new MPI test. MJL 20211121
 
 #__all__ = ['LeastSquaresProblem', 'LeastSquaresTerm']

--- a/src/simsopt/__init__.py
+++ b/src/simsopt/__init__.py
@@ -21,6 +21,5 @@ __version__ = metadata.version('simsopt')
 from ._core import make_optimizable
 from .objectives import LeastSquaresProblem
 from .solve import least_squares_serial_solve
-from .util import initialize_logging
 
 #__all__ = ['LeastSquaresProblem', 'LeastSquaresTerm']

--- a/src/simsopt/__init__.py
+++ b/src/simsopt/__init__.py
@@ -21,5 +21,5 @@ __version__ = metadata.version('simsopt')
 from ._core import make_optimizable
 from .objectives import LeastSquaresProblem
 from .solve import least_squares_serial_solve
-
+from mpi4py import MPI
 #__all__ = ['LeastSquaresProblem', 'LeastSquaresTerm']

--- a/src/simsopt/__init__.py
+++ b/src/simsopt/__init__.py
@@ -21,5 +21,5 @@ __version__ = metadata.version('simsopt')
 from ._core import make_optimizable
 from .objectives import LeastSquaresProblem
 from .solve import least_squares_serial_solve
-from mpi4py import MPI
+
 #__all__ = ['LeastSquaresProblem', 'LeastSquaresTerm']

--- a/src/simsopt/__init__.py
+++ b/src/simsopt/__init__.py
@@ -21,5 +21,6 @@ __version__ = metadata.version('simsopt')
 from ._core import make_optimizable
 from .objectives import LeastSquaresProblem
 from .solve import least_squares_serial_solve
+from mpi4py import MPI  # This line is temporary, to check the new MPI test. MJL 20211121
 
 #__all__ = ['LeastSquaresProblem', 'LeastSquaresTerm']

--- a/src/simsopt/_core/finite_difference.py
+++ b/src/simsopt/_core/finite_difference.py
@@ -18,13 +18,15 @@ from numbers import Real
 
 import numpy as np
 try:
-    from mpi4py import MPI
+    # We import mpi4py here rather than mpi4py.MPI so MPI is not
+    # initialized, since initializing MPI is disallowed on login nodes
+    # for some HPC systems.
+    import mpi4py
 except ImportError:
-    MPI = None
+    mpi4py = None
 
 from ..util.types import RealArray
 from ..util.dev import SimsoptRequires
-from ..util.mpi import MpiPartition
 from .graph_optimizable import Optimizable
 from .util import finite_difference_steps
 
@@ -112,7 +114,7 @@ class FiniteDifference:
         return jac
 
 
-@SimsoptRequires(MPI is not None, "MPIFiniteDifference requires mpi4py")
+@SimsoptRequires(mpi4py is not None, "MPIFiniteDifference requires mpi4py")
 class MPIFiniteDifference:
     """
     Provides Jacobian evaluated with finite difference scheme.
@@ -123,7 +125,7 @@ class MPIFiniteDifference:
     """
 
     def __init__(self, func: Callable,
-                 mpi: MpiPartition,
+                 mpi,  # Specifying the type MpiPartition here would require initializing MPI
                  x0: RealArray = None,
                  abs_step: Real = 1.0e-7,
                  rel_step: Real = 0.0,
@@ -255,7 +257,7 @@ class MPIFiniteDifference:
                 # evals[:, j] = np.array([f() for f in dofs.funcs])
 
         # Combine the results from all groups:
-        evals = mpi.comm_leaders.reduce(evals, op=MPI.SUM, root=0)
+        evals = mpi.comm_leaders.reduce(evals, op=mpi4py.MPI.SUM, root=0)
 
         if not mpi.is_apart:
             mpi.stop_workers()

--- a/src/simsopt/solve/__init__.py
+++ b/src/simsopt/solve/__init__.py
@@ -1,4 +1,3 @@
 from .graph_serial import least_squares_serial_solve, serial_solve
-#from .mpi import least_squares_mpi_solve, fd_jac_mpi
 
 __all__ = ['least_squares_serial_solve', 'serial_solve']

--- a/src/simsopt/util/__init__.py
+++ b/src/simsopt/util/__init__.py
@@ -1,2 +1,0 @@
-# from .mpi import *
-from .logging import *

--- a/tests/verify_MPI_not_initialized.py
+++ b/tests/verify_MPI_not_initialized.py
@@ -14,17 +14,11 @@ unit tests, because otherwise one of the unit tests that uses MPI
 would initialize MPI.
 """
 
+import sys
 import simsopt
 from simsopt.geo.surfacerzfourier import SurfaceRZFourier
 
-import mpi4py
-# The next line tells mpi4py to not initialize MPI when mpi4py.MPI is imported:
-mpi4py.rc.initialize = False
+assert "mpi4py.MPI" not in sys.modules, \
+    "Importing simsopt should not initialize MPI"
 
-from mpi4py import MPI
-
-if mpi4py.MPI.Is_initialized():
-    print("ERROR! Importing simsopt should not initialize MPI")
-    exit(1)
-else:
-    print("Verified that importing simsopt does not initialize MPI")
+print("Verified that importing simsopt does not initialize MPI")

--- a/tests/verify_MPI_not_initialized.py
+++ b/tests/verify_MPI_not_initialized.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+"""
+Some HPC systems only allow MPI to be initialized when jobs are
+submitted through slurm, not on login nodes.  To make the non-MPI
+parts of simsopt usable on login nodes, then, we want to be sure that
+simsopt does not initialize MPI (via mpi4py) unless classes are
+imported that require MPI, such as MpiPartition or Vmec. This script
+checks to be sure that importing the top-level simsopt module and
+importing a simsopt geometry class do not initialize MPI.
+
+We must do this check in an isolated script rather than in the set of
+unit tests, because otherwise one of the unit tests that uses MPI
+would initialize MPI.
+"""
+
+import simsopt
+from simsopt.geo.surfacerzfourier import SurfaceRZFourier
+
+import mpi4py
+# The next line tells mpi4py to not initialize MPI when mpi4py.MPI is imported:
+mpi4py.rc.initialize = False
+
+from mpi4py import MPI
+
+if mpi4py.MPI.Is_initialized():
+    print("ERROR! Importing simsopt should not initialize MPI")
+    exit(1)
+else:
+    print("Verified that importing simsopt does not initialize MPI")


### PR DESCRIPTION
In the master branch of simsopt presently, MPI is initialized whenever any part of simsopt is imported, even just `import simsopt`. This is a problem because some HPC systems, such as Cobra and Raven at IPP, only allow MPI to be initialized when programs are submitted through slurm, not on login nodes. This means simsopt is not presently usable on the login nodes even for non-computationally-expensive scripts. This might also be frustrating for new users, if they try `import simsopt` on a login node and it crashes with an MPI error. This PR fixes this issue by modifying some imports so that MPI is only initialized when it is really necessary, such as for the `MpiPartition` or `Vmec` classes. A test was also added to the CI to verify that `import simsopt` and importing a surface class do not initialize MPI now.