### PR TITLE
Minimize warnings output to screen

### DIFF
--- a/src/simsopt/_core/finite_difference.py
+++ b/src/simsopt/_core/finite_difference.py
@@ -309,13 +309,11 @@ class MPIFiniteDifference:
         logger.debug('mpi workers task')
 
         # x is a buffer for receiving the state vector:
-        print(f"worker loop  dofsize is {self.opt.dof_size}")
         x = np.empty(self.opt.dof_size, dtype='d')
         # If we make it here, we must be doing a fd_jac_par
         # calculation, so receive the state vector: mpi4py has
         # separate bcast and Bcast functions!!  comm.Bcast(x, root=0)
         x = self.mpi.comm_groups.bcast(x, root=0)
-        print(f"worker loop x is {x}")
         logger.debug(f'worker loop worker x={x}')
         self.opt.x = x
 

--- a/src/simsopt/_core/graph_optimizable.py
+++ b/src/simsopt/_core/graph_optimizable.py
@@ -18,6 +18,7 @@ from numbers import Real, Integral
 from typing import Union, Tuple, Dict, Callable, Sequence, \
     MutableSequence as MutSeq, List
 from functools import lru_cache
+import logging
 
 import numpy as np
 from deprecated import deprecated
@@ -26,6 +27,7 @@ from ..util.types import RealArray, StrArray, BoolArray, Key
 from .util import ImmutableId, OptimizableMeta, WeakKeyDefaultDict, \
     DofLengthMismatchError
 
+log = logging.getLogger(__name__)
 
 class DOFs:
     """
@@ -716,7 +718,7 @@ class Optimizable(ABC_Callable, Hashable, metaclass=OptimizableMeta):
             self._update_full_dof_size_indices()
             self._set_new_x()
         else:
-            print("The given Optimizable object is already a parent")
+            log.debug("The given Optimizable object is already a parent")
 
     def append_parent(self, other: Optimizable) -> None:
         """
@@ -733,7 +735,7 @@ class Optimizable(ABC_Callable, Hashable, metaclass=OptimizableMeta):
             self._update_full_dof_size_indices()
             self._set_new_x()
         else:
-            print("The given Optimizable object is already a parent")
+            log.debug("The given Optimizable object is already a parent")
 
     def pop_parent(self, index: int = -1) -> Optimizable:
         """
@@ -1284,7 +1286,7 @@ def make_optimizable(func, *args, dof_indicators=None, **kwargs):
                 else:
                     raise ValueError
                 j += 1
-            print(f'reassembled args len is {len(args)}')
+            log.info(f'reassembled args len is {len(args)}')
 
             return self.func(*args, **kwargs)
 

--- a/src/simsopt/_core/graph_optimizable.py
+++ b/src/simsopt/_core/graph_optimizable.py
@@ -29,6 +29,7 @@ from .util import ImmutableId, OptimizableMeta, WeakKeyDefaultDict, \
 
 log = logging.getLogger(__name__)
 
+
 class DOFs:
     """
     Defines the (D)egrees (O)f (F)reedom(s) associated with optimization

--- a/src/simsopt/field/boozermagneticfield.py
+++ b/src/simsopt/field/boozermagneticfield.py
@@ -9,7 +9,7 @@ try:
     from mpi4py import MPI
 except ImportError as e:
     MPI = None
-    logger.warning(str(e))
+    logger.debug(str(e))
 
 if MPI is not None:
     try:
@@ -18,7 +18,7 @@ if MPI is not None:
     except ImportError as e:
         Vmec = None
         Boozer = None
-        logger.warning(str(e))
+        logger.debug(str(e))
 
 
 class BoozerMagneticField(sopp.BoozerMagneticField):

--- a/src/simsopt/mhd/__init__.py
+++ b/src/simsopt/mhd/__init__.py
@@ -12,35 +12,16 @@ try:
     from mpi4py import MPI
 except ImportError as e:
     MPI = None 
-    logger.warning(str(e))
+    logger.debug(str(e))
 
 if MPI is not None:
-    from .vmec import Vmec  # , vmec_found
-    from .spec import Spec, Residue  # , spec_found
-    from .boozer import Boozer, Quasisymmetry  # , boozer_found
+    from .vmec import Vmec
+    from .spec import Spec, Residue
+    from .boozer import Boozer, Quasisymmetry
 else:
     Vmec = None
     Spec = None
     Residue = None
     Boozer = None
     Quasisymmetry = None
-    logger.warning("mpi4py not installed. Not loading Vmec, Spec and other MHD modules.")
-
-#try:
-#    import vmec
-#except BaseException as err:
-#    print('Unable to load VMEC module, so some functionality will not be available.')
-#    print('Reason VMEC module was not loaded:')
-#    print(err)
-
-#try:
-#    from .vmec import Vmec
-#    vmec_found = True
-#except ImportError as err:
-#    vmec_found = False
-#    print('Unable to load VMEC module, so some functionality will not be available.')
-#    print('Reason VMEC module was not loaded:')
-#    print(err)
-
-#if vmec_found:
-#    from .vmec import Vmec
+    logger.debug("mpi4py not installed. Not loading Vmec, Spec and other MHD modules.")

--- a/src/simsopt/mhd/boozer.py
+++ b/src/simsopt/mhd/boozer.py
@@ -19,20 +19,20 @@ try:
     from mpi4py import MPI
 except ImportError as e:
     MPI = None
-    logger.warning(str(e))
+    logger.debug(str(e))
 
 try:
     import booz_xform
 except ImportError as e:
     booz_xform = None
-    logger.warning(str(e))
+    logger.debug(str(e))
 
 if MPI is not None:
     try:
         from .vmec import Vmec
     except ImportError as e:
         Vmec = None
-        logger.warning(str(e))
+        logger.debug(str(e))
 
 from .._core.graph_optimizable import Optimizable
 

--- a/src/simsopt/mhd/spec.py
+++ b/src/simsopt/mhd/spec.py
@@ -19,25 +19,25 @@ try:
     from mpi4py import MPI
 except ImportError as e:
     MPI = None 
-    logger.warning(str(e))
+    logger.debug(str(e))
 
 try:
     import spec.spec as spec
 except ImportError as e:
     spec = None
-    logger.warning(str(e))
+    logger.debug(str(e))
 
 try:
     import py_spec
 except ImportError as e:
     py_spec = None
-    logger.warning(str(e))
+    logger.debug(str(e))
 
 try:
     import pyoculus
 except ImportError as e:
     pyoculus = None
-    logger.warning(str(e))
+    logger.debug(str(e))
 
 from .._core.graph_optimizable import Optimizable
 from .._core.util import ObjectiveFailure

--- a/src/simsopt/mhd/vmec.py
+++ b/src/simsopt/mhd/vmec.py
@@ -19,13 +19,13 @@ try:
     from mpi4py import MPI
 except ImportError as e:
     MPI = None
-    logger.warning(str(e))
+    logger.debug(str(e))
 
 try:
     import vmec
 except ImportError as e:
     vmec = None
-    logger.warning(str(e))
+    logger.debug(str(e))
 
 from ..util.dev import SimsoptRequires
 from .._core.graph_optimizable import Optimizable


### PR DESCRIPTION
This PR minimizes the number of warning statements outputted to the screen, mainly import warnings. Import warnings are converted to debug log statements. And miscellaneous print statements are converted to debug statements.