### PR TITLE
BoozerRadialInterpolant fix

### DIFF
--- a/src/simsopt/field/boozermagneticfield.py
+++ b/src/simsopt/field/boozermagneticfield.py
@@ -527,7 +527,7 @@ class BoozerRadialInterpolant(BoozerMagneticField):
             self.mn_factor_splines.append(InterpolatedUnivariateSpline(s_half_mn, mn_factor[im, :], k=self.order))
             self.d_mn_factor_splines.append(InterpolatedUnivariateSpline(s_half_mn, d_mn_factor[im, :], k=self.order))
             if (self.enforce_qs and (self.xn_b[im] != self.N * self.xm_b[im])):
-                self.bmnc_splines.append(InterpolatedUnivariateSpline(s_half_bmnc, 0*bmnc[im, :], k=self.order))
+                self.bmnc_splines.append(InterpolatedUnivariateSpline(s_half_mn, 0*bmnc[im, :], k=self.order))
                 self.dbmncds_splines.append(InterpolatedUnivariateSpline(s_full[1:-1], 0*dbmncds[im, :], k=self.order))
             else:
                 self.bmnc_splines.append(InterpolatedUnivariateSpline(s_half_mn, mn_factor[im, :]*bmnc[im, :], k=self.order))


### PR DESCRIPTION
I fixed one typo on the following line 

https://github.com/hiddenSymmetries/simsopt/blob/e716442b8cf81885675402e66cb28802cea6d8a3/src/simsopt/field/boozermagneticfield.py#L530