### PR TITLE
Surfaces: shift phi grid by half the grid spacing when range='half period'

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -255,14 +255,17 @@ setting the ``range`` keyword argument of the surface subclasses to
 Equivalently, you can set ``range`` to the constants
 ``S.RANGE_FULL_TORUS``, ``S.RANGE_FIELD_PERIOD``, or
 ``S.RANGE_HALF_PERIOD``, where ``S`` can be
-:obj:`simsopt.geo.surface.Surface` or any of its subclasses.  For all
-of these cases, the ``nphi`` keyword argument can be set to the
-desired number of :math:`\phi` grid points. Alternatively, you can
-pass a list or array to the ``quadpoints_phi`` keyword argument of the
-constructor for any Surface subclass to specify the :math:`\phi_j`
-points directly.  An exception will be raised if both ``nphi`` and
-``quadpoints_phi`` are specified.  For more information about these
-arguments, see the
+:obj:`simsopt.geo.surface.Surface` or any of its subclasses.  Note
+that the :math:`\phi` grid points begin at 0 for ``"full torus"`` and
+``"field period"``, whereas for ``"half period"`` the :math:`\phi`
+grid is shifted by half of the grid spacing to preserve spectral
+accuracy of integration.  For all three cases, the ``nphi`` keyword
+argument can be set to the desired number of :math:`\phi` grid
+points. Alternatively, you can pass a list or array to the
+``quadpoints_phi`` keyword argument of the constructor for any Surface
+subclass to specify the :math:`\phi_j` points directly.  An exception
+will be raised if both ``nphi`` and ``quadpoints_phi`` are specified.
+For more information about these arguments, see the
 :obj:`~simsopt.geo.surfacerzfourier.SurfaceRZFourier` API
 documentation.
 

--- a/src/simsopt/geo/surface.py
+++ b/src/simsopt/geo/surface.py
@@ -56,7 +56,8 @@ class Surface(Optimizable):
               Set to ``"field period"`` (or equivalently ``Surface.RANGE_FIELD_PERIOD``)
               to generate points up to :math:`1/n_{fp}` (with no point at :math:`1/n_{fp}`).
               Set to ``"half period"`` (or equivalently ``Surface.RANGE_HALF_PERIOD``)
-              to generate points up to :math:`1/(2 n_{fp})` (with no point at :math:`1/(2 n_{fp})`).
+              to generate points up to :math:`1/(2 n_{fp})`, with all grid points shifted by half
+              of the grid spacing in order to provide spectral convergence of integrals.
               If ``quadpoints_phi`` is specified, ``range`` is irrelevant.
             quadpoints_phi: Set this to a list or 1D array to set the :math:`\phi_j` grid points directly.
             quadpoints_theta: Set this to a list or 1D array to set the :math:`\theta_j` grid points directly.
@@ -83,6 +84,9 @@ class Surface(Optimizable):
                 quadpoints_phi = np.linspace(0.0, 1.0 / nfp, nphi, endpoint=False)
             elif range == Surface.RANGE_HALF_PERIOD:
                 quadpoints_phi = np.linspace(0.0, 0.5 / nfp, nphi, endpoint=False)
+                # Shift by half of the grid spacing:
+                dphi = quadpoints_phi[1] - quadpoints_phi[0]
+                quadpoints_phi += 0.5 * dphi
             else:
                 raise ValueError("Invalid setting for range")
 

--- a/src/simsopt/geo/surfacegarabedian.py
+++ b/src/simsopt/geo/surfacegarabedian.py
@@ -43,7 +43,8 @@ class SurfaceGarabedian(sopp.Surface, Surface):
           Set to ``"field period"`` (or equivalently ``SurfaceGarabedian.RANGE_FIELD_PERIOD``)
           to generate points up to :math:`1/n_{fp}` (with no point at :math:`1/n_{fp}`).
           Set to ``"half period"`` (or equivalently ``SurfaceGarabedian.RANGE_HALF_PERIOD``)
-          to generate points up to :math:`1/(2 n_{fp})` (with no point at :math:`1/(2 n_{fp})`).
+          to generate points up to :math:`1/(2 n_{fp})`, with all grid points shifted by half
+          of the grid spacing in order to provide spectral convergence of integrals.
           If ``quadpoints_phi`` is specified, ``range`` is irrelevant.
         quadpoints_phi: Set this to a list or 1D array to set the :math:`\phi_j` grid points directly.
         quadpoints_theta: Set this to a list or 1D array to set the :math:`\theta_j` grid points directly.

--- a/src/simsopt/geo/surfacehenneberg.py
+++ b/src/simsopt/geo/surfacehenneberg.py
@@ -89,7 +89,8 @@ class SurfaceHenneberg(sopp.Surface, Surface):
           Set to ``"field period"`` (or equivalently ``SurfaceHenneberg.RANGE_FIELD_PERIOD``)
           to generate points up to :math:`1/n_{fp}` (with no point at :math:`1/n_{fp}`).
           Set to ``"half period"`` (or equivalently ``SurfaceHenneberg.RANGE_HALF_PERIOD``)
-          to generate points up to :math:`1/(2 n_{fp})` (with no point at :math:`1/(2 n_{fp})`).
+          to generate points up to :math:`1/(2 n_{fp})`, with all grid points shifted by half
+          of the grid spacing in order to provide spectral convergence of integrals.
           If ``quadpoints_phi`` is specified, ``range`` is irrelevant.
         quadpoints_phi: Set this to a list or 1D array to set the :math:`\phi_j` grid points directly.
         quadpoints_theta: Set this to a list or 1D array to set the :math:`\theta_j` grid points directly.

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -53,7 +53,8 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
           Set to ``"field period"`` (or equivalently ``SurfaceRZFourier.RANGE_FIELD_PERIOD``)
           to generate points up to :math:`1/n_{fp}` (with no point at :math:`1/n_{fp}`).
           Set to ``"half period"`` (or equivalently ``SurfaceRZFourier.RANGE_HALF_PERIOD``)
-          to generate points up to :math:`1/(2 n_{fp})` (with no point at :math:`1/(2 n_{fp})`).
+          to generate points up to :math:`1/(2 n_{fp})`, with all grid points shifted by half
+          of the grid spacing in order to provide spectral convergence of integrals.
           If ``quadpoints_phi`` is specified, ``range`` is irrelevant.
         quadpoints_phi: Set this to a list or 1D array to set the :math:`\phi_j` grid points directly.
         quadpoints_theta: Set this to a list or 1D array to set the :math:`\theta_j` grid points directly.

--- a/src/simsopt/geo/surfacexyzfourier.py
+++ b/src/simsopt/geo/surfacexyzfourier.py
@@ -53,7 +53,8 @@ class SurfaceXYZFourier(sopp.SurfaceXYZFourier, Surface):
           Set to ``"field period"`` (or equivalently ``SurfaceXYZFourier.RANGE_FIELD_PERIOD``)
           to generate points up to :math:`1/n_{fp}` (with no point at :math:`1/n_{fp}`).
           Set to ``"half period"`` (or equivalently ``SurfaceXYZFourier.RANGE_HALF_PERIOD``)
-          to generate points up to :math:`1/(2 n_{fp})` (with no point at :math:`1/(2 n_{fp})`).
+          to generate points up to :math:`1/(2 n_{fp})`, with all grid points shifted by half
+          of the grid spacing in order to provide spectral convergence of integrals.
           If ``quadpoints_phi`` is specified, ``range`` is irrelevant.
         quadpoints_phi: Set this to a list or 1D array to set the :math:`\phi_j` grid points directly.
         quadpoints_theta: Set this to a list or 1D array to set the :math:`\theta_j` grid points directly.

--- a/src/simsopt/geo/surfacexyztensorfourier.py
+++ b/src/simsopt/geo/surfacexyztensorfourier.py
@@ -54,7 +54,8 @@ class SurfaceXYZTensorFourier(sopp.SurfaceXYZTensorFourier, Surface):
           Set to ``"field period"`` (or equivalently ``SurfaceXYZTensorFourier.RANGE_FIELD_PERIOD``)
           to generate points up to :math:`1/n_{fp}` (with no point at :math:`1/n_{fp}`).
           Set to ``"half period"`` (or equivalently ``SurfaceXYZTensorFourier.RANGE_HALF_PERIOD``)
-          to generate points up to :math:`1/(2 n_{fp})` (with no point at :math:`1/(2 n_{fp})`).
+          to generate points up to :math:`1/(2 n_{fp})`, with all grid points shifted by half
+          of the grid spacing in order to provide spectral convergence of integrals.
           If ``quadpoints_phi`` is specified, ``range`` is irrelevant.
         quadpoints_phi: Set this to a list or 1D array to set the :math:`\phi_j` grid points directly.
         quadpoints_theta: Set this to a list or 1D array to set the :math:`\theta_j` grid points directly.


### PR DESCRIPTION
Presently, surface integrals are inaccurate when `range="half period"`. After the change in this PR, integrals are now spectrally accurate (as they have been for `range="full torus"` and `field period`).

Addresses #174 .