### PR TITLE
better cpp documentation linking

### DIFF
--- a/docs/source/simsopt.rst
+++ b/docs/source/simsopt.rst
@@ -14,6 +14,7 @@ Subpackages
    simsopt.objectives
    simsopt.solve
    simsopt.util
+   simsoptpp
 
 Module contents
 ---------------

--- a/docs/source/simsoptpp.rst
+++ b/docs/source/simsoptpp.rst
@@ -1,0 +1,11 @@
+simsoptpp package
+=================
+
+
+Module contents
+---------------
+
+.. automodule:: simsoptpp
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
This PR makes sure that the C++ documentation shows up and is linked properly to the python documentation. For example, when looking at `simsopt.field.biotsavart.BiotSavart`, there is now a link to `simsoptpp.BiotSavart`