### PR TITLE
Use mpich for docker container

### DIFF
--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -2,10 +2,38 @@
 # ===================================
 FROM ubuntu:20.04 as intermediate
 
-RUN apt update && DEBIAN_FRONTEND=noninteractive  apt-get install -y  python3-dev python3-pip python3-virtualenv build-essential gfortran openmpi-bin libopenmpi-dev libnetcdf-dev libnetcdff-dev libopenblas-dev libscalapack-openmpi-dev  libhdf5-dev libhdf5-serial-dev  git m4 libfftw3-dev libboost-all-dev libgl1-mesa-dev
+RUN apt update && DEBIAN_FRONTEND=noninteractive  apt-get install -y  python3-dev python3-pip python3-virtualenv build-essential gfortran libnetcdf-dev libnetcdff-dev libopenblas-dev  libhdf5-dev libhdf5-serial-dev  git m4 libfftw3-dev libboost-all-dev libgl1-mesa-dev
+
+# Install mpich manually
+WORKDIR /opt
+ARG mpich=3.3
+ARG mpich_prefix=mpich-$mpich
+
+RUN \
+    wget https://www.mpich.org/static/downloads/$mpich/$mpich_prefix.tar.gz && \
+    tar xvzf $mpich_prefix.tar.gz                                           && \
+    cd $mpich_prefix                                                        && \
+    ./configure                                                             && \
+    make -j 4                                                               && \
+    make install                                                            && \
+    make clean                                                              && \
+    cd ..                                                                   && \
+    rm -rf $mpich_prefix
+
+
+RUN /sbin/ldconfig
 
 RUN mkdir -p /src
 
+RUN \
+    git clone --depth 1 https://github.com/Reference-ScaLAPACK/scalapack.git /src/scalapack && \
+    cd /src/scalapack && \
+    cmake -S . -B build && \
+    cmake --build build && \
+    cmake --install build && \
+    cd ..  && \
+    rm -rf scalapack
+     
 RUN python3 -m pip install wheel
 RUN virtualenv /venv/
 
@@ -43,15 +71,16 @@ FROM ubuntu:20.04
 LABEL maintainer.name="Bharat Medasani" \
       maintainer.email="mbkumar.at.gmail" \
       developers="Hidden Symmetries Team" \
-      version="0.06" \
+      version="0.07" \
       description="Docker file for simsopt container based on ubuntu image" 
 
-RUN apt update && DEBIAN_FRONTEND=noninteractive  apt-get install -y  python3-dev python3-virtualenv  openmpi-bin  libnetcdf-dev libnetcdff-dev libopenblas-dev libscalapack-openmpi-dev  libhdf5-openmpi-dev m4 libfftw3-dev libgl1-mesa-dev libopenblas-dev vim emacs nano git
+RUN apt update && DEBIAN_FRONTEND=noninteractive  apt-get install -y  python3-dev python3-virtualenv   libnetcdf-dev libnetcdff-dev libopenblas-dev libscalapack-mpich-dev  libhdf5-serial-dev m4 libfftw3-dev libgl1-mesa-dev libopenblas-dev vim emacs nano git
 
 COPY --from=intermediate /venv /venv
+COPY --from=intermediate /opt /opt
 COPY entrypoint.sh /venv/bin
 
 #env PATH=$PATH:/venv/bin
-ENV OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+# ENV OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 ENTRYPOINT ["bash", "/venv/bin/entrypoint.sh"]
 CMD ["bash"]

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -2,40 +2,44 @@
 # ===================================
 FROM ubuntu:20.04 as intermediate
 
-RUN apt update && DEBIAN_FRONTEND=noninteractive  apt-get install -y  python3-dev python3-pip python3-virtualenv build-essential gfortran libnetcdf-dev libnetcdff-dev libopenblas-dev  libhdf5-dev libhdf5-serial-dev  git m4 libfftw3-dev libboost-all-dev libgl1-mesa-dev
+RUN apt update && DEBIAN_FRONTEND=noninteractive  apt-get install -y  python3-dev python3-pip python3-venv build-essential gfortran libnetcdf-dev libnetcdff-dev libopenblas-dev  libhdf5-dev libhdf5-serial-dev  git m4 libfftw3-dev libgl1-mesa-dev cmake
 
 # Install mpich manually
-WORKDIR /opt
+WORKDIR /src
 ARG mpich=3.3
 ARG mpich_prefix=mpich-$mpich
+ARG NPROC=$(expr `nproc` \* 2)
 
 RUN \
     wget https://www.mpich.org/static/downloads/$mpich/$mpich_prefix.tar.gz && \
-    tar xvzf $mpich_prefix.tar.gz                                           && \
-    cd $mpich_prefix                                                        && \
-    ./configure                                                             && \
-    make -j 4                                                               && \
-    make install                                                            && \
-    make clean                                                              && \
-    cd ..                                                                   && \
+    tar xvzf $mpich_prefix.tar.gz   && \
+    cd $mpich_prefix                && \
+    ./configure                     && \
+    make -j $NPROC                  && \
+    make install                    && \
+    make clean                      && \
+    cd ..                           && \
     rm -rf $mpich_prefix
 
 
 RUN /sbin/ldconfig
 
-RUN mkdir -p /src
+# RUN mkdir -p /src
 
 RUN \
     git clone --depth 1 https://github.com/Reference-ScaLAPACK/scalapack.git /src/scalapack && \
     cd /src/scalapack && \
-    cmake -S . -B build && \
-    cmake --build build && \
-    cmake --install build && \
-    cd ..  && \
+    CC=mpicc F77=mpif77 FC=mpif90 CXX=mpicxx cmake -DBUILD_SHARED_LIBS=ON -S . -B build && \
+    cd build && \
+    make -j $NPROC && \
+    cmake --install . && \
+    cd ../..  && \
     rm -rf scalapack
      
+RUN /sbin/ldconfig
+
 RUN python3 -m pip install wheel
-RUN virtualenv /venv/
+RUN python3 -m venv /venv/
 
 RUN /venv/bin/pip install -U pip
 RUN /venv/bin/python -m pip install numpy scipy jax jaxlib f90nml mpi4py jupyter notebook ipython qsc sympy scikit-build ninja "pybind11[global]" cmake

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -23,10 +23,7 @@ RUN \
     cd ..                           && \
     rm -rf $mpich_prefix
 
-
 RUN /sbin/ldconfig
-
-# RUN mkdir -p /src
 
 RUN \
     git clone --depth 1 https://github.com/Reference-ScaLAPACK/scalapack.git /src/scalapack && \
@@ -80,7 +77,10 @@ LABEL maintainer.name="Bharat Medasani" \
       version="0.07" \
       description="Docker file for simsopt container based on ubuntu image" 
 
-RUN apt update && DEBIAN_FRONTEND=noninteractive  apt-get install -y  python3-dev python3-virtualenv   libnetcdf-dev libnetcdff-dev libopenblas-dev libscalapack-mpich-dev  libhdf5-serial-dev m4 libfftw3-dev libgl1-mesa-dev libopenblas-dev vim emacs nano git
+RUN apt update && \
+    DEBIAN_FRONTEND=noninteractive  apt-get install -y m4 vim emacs nano git wget \
+    libfftw3-dev  libopenblas-dev libhdf5-serial-dev libnetcdf-dev libnetcdff-dev libgl1-mesa-dev \
+    python3-dev python3-venv
 
 COPY --from=intermediate /venv /venv
 COPY --from=intermediate /usr/local /usr/local

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -81,7 +81,8 @@ LABEL maintainer.name="Bharat Medasani" \
 RUN apt update && DEBIAN_FRONTEND=noninteractive  apt-get install -y  python3-dev python3-virtualenv   libnetcdf-dev libnetcdff-dev libopenblas-dev libscalapack-mpich-dev  libhdf5-serial-dev m4 libfftw3-dev libgl1-mesa-dev libopenblas-dev vim emacs nano git
 
 COPY --from=intermediate /venv /venv
-COPY --from=intermediate /opt /opt
+COPY --from=intermediate /usr/local /usr/local
+RUN /sbin/ldconfig
 COPY entrypoint.sh /venv/bin
 
 #env PATH=$PATH:/venv/bin


### PR DESCRIPTION
This PR modifies Dockerfile.ubuntu as a preliminary step to get the docker imagefile work with shifter at NERSC. In place of openmpi, mpich is used to take advantage of mpich's ABI compatibility.

Specifically, the docker container build is modified to build mpich and scalapack manually in place of libopenmpi-dev, openmpi-bin, and libscalapack-dev installed with apt-get. libboost-all-dev is also not installed to prevent mpi libraries installed as dependencies by apt-get.