### PR TITLE
Tidying up requirements

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -36,16 +36,17 @@ requirements:
   run:
     - python
     - numpy {{ numpy }}
-    - jax >=0.2.4
+    - jax >=0.2.5
     - jaxlib >=0.1.56
     - scipy >=1.5.4
     - Deprecated >=1.2.10
     - nptyping >=1.3.0
     - monty >=2021.6.10 
     - ruamel.yaml
-    - matplotlib
     - sympy
     - f90nml
+    - randomgen
+    - pyevtk
 
 about:
   home: {{ data.get('url') }}

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -8,37 +8,39 @@ on `the wiki <https://github.com/hiddenSymmetries/simsopt/wiki>`_.
 Requirements
 ^^^^^^^^^^^^
 
-``simsopt`` is a python package focused on stellarator optimization and requires
-python version 3.7 or higher.  ``simsopt``
-also requires some mandatory python packages, listed in
-``requirements.txt``.  These packages are all installed automatically
-when you install using ``pip`` or another python package manager such as ``conda``, as discussed below.  If you prefer to
-install via ``python setup.py install`` or ``python setup.py
-develop``, you will need to install these python packages manually
-using ``pip`` or ``conda``.
-
-Mandatory Packages
-------------------
-- numpy
-- jax
-- jaxlib
-- scipy
-- nptyping
-- ruamel.yaml
+``simsopt`` is a python package focused on stellarator optimization
+and requires python version 3.7 or higher.  ``simsopt`` also requires
+some mandatory python packages, listed in
+`requirements.txt <https://github.com/hiddenSymmetries/simsopt/blob/master/requirements.txt>`_
+and in the ``[options]`` section of
+`setup.cfg <https://github.com/hiddenSymmetries/simsopt/blob/master/setup.cfg>`_.
+These packages are all installed automatically when you install using
+``pip`` or another python package manager such as ``conda``, as
+discussed below.  If you prefer to install via ``python setup.py
+install`` or ``python setup.py develop``, you will need to install
+these python packages manually using ``pip`` or ``conda``, e.g.
+with ``pip install -r requirements.txt``.
 
 Optional Packages
 -----------------
+
+Several other optional packages are needed for certain aspects of
+simsopt, such as visualization/graphics and building the documentation.  These
+requirements can be found in the ``[options.extras_require]`` section
+of
+`setup.cfg <https://github.com/hiddenSymmetries/simsopt/blob/master/setup.cfg>`_.
+Also,
+
 - For MPI support:
     * mpi4py
-- For SPEC support:
-    * py_spec
-    * pyoculus
-    * h5py
-    * f90nml
 - For VMEC support:
     * https://github.com/hiddenSymmetries/vmec2000
 - For computing Boozer coordinates:
     * `booz_xform <https://hiddensymmetries.github.io/booz_xform/>`_
+- For SPEC support:
+    * py_spec
+    * pyoculus
+    * h5py
 
 For requirements of separate physics modules like VMEC, see the
 documentation of the module you wish to use.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,13 @@
-numpy>=1.19.4
-jax>=0.2.5
-scipy>=1.5.4
-nptyping>=1.3.0
-Deprecated>=1.2.10
+setuptools_scm >= 6.0
+numpy >= 1.19.4
+jax >= 0.2.5
+jaxlib >= 0.1.56
+scipy >= 1.5.4
+Deprecated >= 1.2.10
+nptyping >= 1.3.0
+monty >= 2021.6.10
+ruamel.yaml
+sympy
 f90nml
 randomgen
+pyevtk

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = simsopt
-description: Simplified framework for optimizing stellarators
+description: Framework for optimizing stellarators
 long_description = file: README.md
 long_description_content_type = text/markdown
 license = GNU Lesser General Public License Version 3
@@ -43,18 +43,18 @@ keywords =
 
 [options]
 install_requires = 
-    numpy >= 1.16.0
-    jax >= 0.2.4
+    numpy >= 1.19.4
+    jax >= 0.2.5
     jaxlib >= 0.1.56
     scipy >= 1.5.4
     Deprecated >= 1.2.10
     nptyping >= 1.3.0
     monty >= 2021.6.10
     ruamel.yaml
-    matplotlib
     sympy
     f90nml
     randomgen
+    pyevtk
 package_dir =
     =src
 packages = find:
@@ -64,14 +64,16 @@ SPEC =
     py_spec >= 3.0.1
     pyoculus >= 0.1.1
     h5py >= 3.1.0
-    f90nml >= 1.2
 MPI =
     mpi4py >= 3.0.3
 VIS =
+    matplotlib
     vtk >= 8.1.2
     PyQt5 
     mayavi
-    pyevtk
+DOCS =
+    sphinx
+    sphinx-rtd-theme
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Trying to tidy up a few things related to requirements.

- Some items and version numbers synchronized between `requirements.txt`, `setup.cfg`, and `conda.recipe/meta.yaml`.
- Added pyevtk to requirements and conda `meta.yml` since it is needed for the `stage_two_optimization.py` example.
- The list of required packages in the ReadTheDocs installation page was removed, so we don't have to keep it synchronized with the lists in `requirements.txt` and `setup.cfg`. It was already a bit out of date.
- Added optional `[DOCS]` requirements in `setup.cfg` for building the docs.