### PR TITLE
Fix: graph framework dofs out of sync

### DIFF
--- a/src/simsopt/geo/surfacehenneberg.py
+++ b/src/simsopt/geo/surfacehenneberg.py
@@ -584,6 +584,7 @@ class SurfaceHenneberg(sopp.Surface, Surface):
         #print('rho_alt:   ', rho_alt)
         print('Diff in rho:', np.max(np.abs(rho_realsp - rho_alt)))
 
+        surf_H.local_full_x = surf_H.get_dofs()
         return surf_H
 
     def gamma_lin(self, data, quadpoints_phi, quadpoints_theta):

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -201,6 +201,7 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
                 surf.rs[m, n + ntor] = rbs[j]
                 surf.zc[m, n + ntor] = zbc[j]
 
+        surf.local_full_x = surf.get_dofs()
         return surf
 
     @classmethod
@@ -356,6 +357,7 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
                 surf.rs[m[j], n[j] + ntor] = rs[j]
                 surf.zc[m[j], n[j] + ntor] = zc[j]
 
+        surf.local_full_x = surf.get_dofs()
         return surf
 
     def change_resolution(self, mpol, ntor):

--- a/tests/geo/test_surface_rzfourier.py
+++ b/tests/geo/test_surface_rzfourier.py
@@ -140,6 +140,9 @@ class SurfaceRZFourierTests(unittest.TestCase):
         # First try a stellarator-symmetric example:
         filename = TEST_DIR / 'wout_li383_low_res_reference.nc'
         s = SurfaceRZFourier.from_wout(filename)
+        # Make sure that the graph framework dofs are sync-ed with
+        # the rc/zs arrays:
+        np.testing.assert_allclose(s.x, s.get_dofs())
         # The value in the next line includes m values up to 4 even
         # though the RBC/ZBS arrays for the input file go up to m=6,
         # since mpol is only 4.
@@ -173,6 +176,9 @@ class SurfaceRZFourierTests(unittest.TestCase):
         # First try some stellarator-symmetric examples:
         filename = TEST_DIR / 'input.li383_low_res'
         s = SurfaceRZFourier.from_vmec_input(filename)
+        # Make sure that the graph framework dofs are sync-ed with
+        # the rc/zs arrays:
+        np.testing.assert_allclose(s.x, s.get_dofs())
         # The value in the next line includes m values up through 6,
         # even though mpol in the file is 4.
         true_volume = 2.97871721453671
@@ -322,6 +328,10 @@ class SurfaceRZFourierTests(unittest.TestCase):
         filename = TEST_DIR / 'tf_only_half_tesla.plasma'
 
         s = SurfaceRZFourier.from_focus(filename)
+
+        # Make sure that the graph framework dofs are sync-ed with
+        # the rc/zs arrays:
+        np.testing.assert_allclose(s.x, s.get_dofs())
 
         self.assertEqual(s.nfp, 3)
         self.assertTrue(s.stellsym)

--- a/tests/geo/test_surfacehenneberg.py
+++ b/tests/geo/test_surfacehenneberg.py
@@ -212,8 +212,14 @@ class SurfaceHennebergTests(unittest.TestCase):
             vmec = Vmec(os.path.join(TEST_DIR, test_file))
             surf1 = vmec.boundary
             surf2 = SurfaceHenneberg.from_RZFourier(surf1, alpha_fac)
+            # Make sure that the graph framework dofs are sync-ed with
+            # the rc/zs arrays:
+            np.testing.assert_allclose(surf2.x, surf2.get_dofs())
             self.assertEqual(surf2.num_dofs(), len(surf2.get_dofs()))
             surf3 = surf2.to_RZFourier()
+            # Make sure that the graph framework dofs are sync-ed with
+            # the rc/zs arrays:
+            np.testing.assert_allclose(surf3.x, surf3.get_dofs())
 
             # Test gamma_lin:
             gamma2 = np.zeros((nlist, 3))


### PR DESCRIPTION
Fixed a few issues with the graph framework dofs getting out of sync with arrays owned by Surface objects