### PR TITLE
Removed deprecated jax commands

### DIFF
--- a/src/simsopt/_core/graph_optimizable.py
+++ b/src/simsopt/_core/graph_optimizable.py
@@ -1203,19 +1203,19 @@ class Optimizable(ABC_Callable, Hashable, metaclass=OptimizableMeta):
     @SimsoptRequires(nx is not None, "print method requires networkx")
     @SimsoptRequires(pygraphviz is not None, "print method requires pygraphviz")
     def plot(self):
-        
+
         G = nx.DiGraph()
         G.add_node(self.name) 
-        
+
         def traversal(root):
             for p in root.parents:
                 n1 = root.name
                 n2 = p.name
                 G.add_edge(n1, n2)
                 traversal(p)
-        
+
         traversal(self)
-        
+
         import matplotlib.pyplot as plt
         options = {
             'node_color': 'red',

--- a/src/simsopt/geo/curvehelical.py
+++ b/src/simsopt/geo/curvehelical.py
@@ -1,4 +1,3 @@
-from jax.ops import index, index_add
 import jax.numpy as jnp
 from math import pi
 import numpy as np
@@ -14,9 +13,9 @@ def jaxHelicalfouriercurve_pure(dofs, quadpoints, order, n0, l0, R0, r0):
     BsinArray = jnp.sum(B*jnp.sin(m*phiV*n0/l0), axis=1)
     eta = n0*phi/l0+AcosArray+BsinArray
     gamma = jnp.zeros((len(quadpoints), 3))
-    gamma = index_add(gamma, index[:, 0], (R0+r0*jnp.cos(eta))*jnp.cos(phi))
-    gamma = index_add(gamma, index[:, 1], (R0+r0*jnp.cos(eta))*jnp.sin(phi))
-    gamma = index_add(gamma, index[:, 2], -r0*jnp.sin(eta))
+    gamma = gamma.at[:, 0].add((R0 + r0 * jnp.cos(eta)) * jnp.cos(phi))
+    gamma = gamma.at[:, 1].add((R0 + r0 * jnp.cos(eta)) * jnp.sin(phi))
+    gamma = gamma.at[:, 2].add(-r0 * jnp.sin(eta))
     return gamma
 
 

--- a/src/simsopt/geo/curvexyzfourier.py
+++ b/src/simsopt/geo/curvexyzfourier.py
@@ -2,7 +2,6 @@ from math import pi
 from itertools import chain
 
 import numpy as np
-from jax.ops import index, index_add
 import jax.numpy as jnp
 
 from .curve import Curve, JaxCurve
@@ -102,14 +101,12 @@ def jaxfouriercurve_pure(dofs, quadpoints, order):
     k = len(dofs)//3
     coeffs = [dofs[:k], dofs[k:(2*k)], dofs[(2*k):]]
     points = quadpoints
-    gamma = np.zeros((len(points), 3))
+    gamma = jnp.zeros((len(points), 3))
     for i in range(3):
-        gamma = index_add(gamma, index[:, i], coeffs[i][0])
+        gamma = gamma.at[:, i].add(coeffs[i][0])
         for j in range(1, order+1):
-            gamma = index_add(gamma, index[:, i],
-                              coeffs[i][2*j-1] * jnp.sin(2*pi*j*points))
-            gamma = index_add(gamma, index[:, i],
-                              coeffs[i][2*j] * jnp.cos(2*pi*j*points))
+            gamma = gamma.at[:, i].add(coeffs[i][2 * j - 1] * jnp.sin(2 * pi * j * points))
+            gamma = gamma.at[:, i].add(coeffs[i][2 * j] * jnp.cos(2 * pi * j * points))
     return gamma
 
 


### PR DESCRIPTION
This PR fixes the CI failures that have been happening the past few days. The cause is that Jax removed the command `index_add` in a release a few days ago:
https://jax.readthedocs.io/en/latest/changelog.html#jax-0-3-2-march-16-2022
So in this PR I've replaced `index_add` with the recommended alternative, `.at[idx].add()`.