### PR TITLE
Curve-Curve distance improvements and introduction of Curve-Surface distance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ set(XTENSOR_USE_TBB 0)
 
 pybind11_add_module(${PROJECT_NAME}
     src/simsoptpp/python.cpp src/simsoptpp/python_surfaces.cpp src/simsoptpp/python_curves.cpp
-    src/simsoptpp/python_magneticfield.cpp src/simsoptpp/python_tracing.cpp
+    src/simsoptpp/python_magneticfield.cpp src/simsoptpp/python_tracing.cpp src/simsoptpp/python_distance.cpp
     src/simsoptpp/biot_savart_py.cpp src/simsoptpp/biot_savart_vjp_py.cpp
     src/simsoptpp/regular_grid_interpolant_3d_py.cpp
     src/simsoptpp/curve.cpp src/simsoptpp/curverzfourier.cpp src/simsoptpp/curvexyzfourier.cpp

--- a/docs/source/example_coils.rst
+++ b/docs/source/example_coils.rst
@@ -27,7 +27,7 @@ the target field; small values of :math:`\alpha` will give a more
 accurate match to the target field at the cost of complicated coils.
 Finally, :math:`J_{dist}` is a penalty that prevents coils from
 becoming too close.  For its precise definition, see
-:obj:`simsopt.geo.curveobjectives.MinimumDistance`.  The constant
+:obj:`simsopt.geo.curveobjectives.CurveCurveDistance`.  The constant
 :math:`\beta` is selected to balance this minimum distance penalty
 against the other objectives.  Analytic derivatives are used for the
 optimization.
@@ -53,7 +53,7 @@ some classes that will be used::
   from simsopt.geo.curve import curves_to_vtk, create_equally_spaced_curves
   from simsopt.field.biotsavart import BiotSavart
   from simsopt.field.coil import Current, coils_via_symmetries
-  from simsopt.geo.curveobjectives import CurveLength, MinimumDistance
+  from simsopt.geo.curveobjectives import CurveLength, CurveCurveDistance
   from simsopt.geo.plot import plot
 
 The target plasma surface is given in the VMEC input file ``tests/test_files/input.LandremanPaul2021_QA``.
@@ -188,7 +188,7 @@ The result is 0.19 Tesla. We now define the objective function::
   
   Jf = SquaredFlux(s, bs)
   Jls = [CurveLength(c) for c in base_curves]
-  Jdist = MinimumDistance(curves, MIN_DIST)
+  Jdist = CurveCurveDistance(curves, MIN_DIST)
   # Scale and add terms to form the total objective function:
   objective = Jf + ALPHA * sum(Jls) + BETA * Jdist
 

--- a/docs/source/geo.rst
+++ b/docs/source/geo.rst
@@ -60,7 +60,8 @@ A number of quantities are implemented in
 - ``CurveLength``: computes the length of the ``Curve``.
 - ``LpCurveCurvature``: computes a penalty based on the :math:`L_p` norm of the curvature on a curve.
 - ``LpCurveTorsion``: computes a penalty based on the :math:`L_p` norm of the torsion on a curve.
-- ``MinimumDistance``: computes a penalty term on the minimum distance between a set of curves.
+- ``CurveCurveDistance``: computes a penalty term on the minimum distance between a set of curves.
+- ``CurveSurfaceDistance``: computes a penalty term on the minimum distance between a set of curves and a surface.
 
 The value of the quantity and its derivative with respect to the curve
 dofs can be obtained by calling e.g., ``CurveLength.J()`` and

--- a/examples/2_Intermediate/stage_two_optimization.py
+++ b/examples/2_Intermediate/stage_two_optimization.py
@@ -102,7 +102,7 @@ s.to_vtk(OUT_DIR + "surf_init", extra_data=pointData)
 # Define the objective function:
 Jf = SquaredFlux(s, bs)
 Jls = [CurveLength(c) for c in base_curves]
-Jdist = MinimumDistance(curves, DISTANCE_THRESHOLD)
+Jdist = MinimumDistance(curves, DISTANCE_THRESHOLD, num_basecurves=ncoils)
 Jcs = [LpCurveCurvature(c, 2, CURVATURE_THRESHOLD) for c in base_curves]
 Jmscs = [MeanSquaredCurvature(c) for c in base_curves]
 

--- a/examples/2_Intermediate/stage_two_optimization.py
+++ b/examples/2_Intermediate/stage_two_optimization.py
@@ -30,8 +30,8 @@ from simsopt.objectives.utilities import QuadraticPenalty
 from simsopt.geo.curve import curves_to_vtk, create_equally_spaced_curves
 from simsopt.field.biotsavart import BiotSavart
 from simsopt.field.coil import Current, coils_via_symmetries
-from simsopt.geo.curveobjectives import CurveLength, MinimumDistance, \
-    MeanSquaredCurvature, LpCurveCurvature
+from simsopt.geo.curveobjectives import CurveLength, CurveCurveDistance, \
+    MeanSquaredCurvature, LpCurveCurvature, CurveSurfaceDistance
 
 # Number of unique coil shapes, i.e. the number of coils per half field period:
 # (Since the configuration has nfp = 2, multiply by 4 to get the total number of coils.)
@@ -50,8 +50,12 @@ order = 5
 LENGTH_WEIGHT = 1e-6
 
 # Threshold and weight for the coil-to-coil distance penalty in the objective function:
-DISTANCE_THRESHOLD = 0.1
-DISTANCE_WEIGHT = 10
+CC_THRESHOLD = 0.1
+CC_WEIGHT = 10
+
+# Threshold and weight for the coil-to-surface distance penalty in the objective function:
+CS_THRESHOLD = 0.3
+CS_WEIGHT = 10
 
 # Threshold and weight for the curvature penalty in the objective function:
 CURVATURE_THRESHOLD = 5.
@@ -102,7 +106,8 @@ s.to_vtk(OUT_DIR + "surf_init", extra_data=pointData)
 # Define the objective function:
 Jf = SquaredFlux(s, bs)
 Jls = [CurveLength(c) for c in base_curves]
-Jdist = MinimumDistance(curves, DISTANCE_THRESHOLD, num_basecurves=ncoils)
+Jccdist = CurveCurveDistance(curves, CC_THRESHOLD, num_basecurves=ncoils)
+Jcsdist = CurveSurfaceDistance(curves, s, CS_THRESHOLD)
 Jcs = [LpCurveCurvature(c, 2, CURVATURE_THRESHOLD) for c in base_curves]
 Jmscs = [MeanSquaredCurvature(c) for c in base_curves]
 
@@ -112,7 +117,8 @@ Jmscs = [MeanSquaredCurvature(c) for c in base_curves]
 # multiplied by scalars and added:
 JF = Jf \
     + LENGTH_WEIGHT * sum(Jls) \
-    + DISTANCE_WEIGHT * Jdist \
+    + CC_WEIGHT * Jccdist \
+    + CS_WEIGHT * Jcsdist \
     + CURVATURE_WEIGHT * sum(Jcs) \
     + MSC_WEIGHT * sum(QuadraticPenalty(J, MSC_THRESHOLD) for J in Jmscs)
 
@@ -131,7 +137,8 @@ def fun(dofs):
     cl_string = ", ".join([f"{J.J():.1f}" for J in Jls])
     kap_string = ", ".join(f"{np.max(c.kappa()):.1f}" for c in base_curves)
     msc_string = ", ".join(f"{J.J():.1f}" for J in Jmscs)
-    outstr += f", Len=sum([{cl_string}])={sum(J.J() for J in Jls):.1f}, ϰ=[{kap_string}], ∫ϰ²/L=[{msc_string}], C-C-Sep={Jdist.shortest_distance():.2f}"
+    outstr += f", Len=sum([{cl_string}])={sum(J.J() for J in Jls):.1f}, ϰ=[{kap_string}], ∫ϰ²/L=[{msc_string}]"
+    outstr += f", C-C-Sep={Jccdist.shortest_distance():.2f}, C-S-Sep={Jcsdist.shortest_distance():.2f}"
     outstr += f", ║∇J║={np.linalg.norm(grad):.1e}"
     print(outstr)
     return J, grad

--- a/examples/2_Intermediate/stage_two_optimization_stochastic.py
+++ b/examples/2_Intermediate/stage_two_optimization_stochastic.py
@@ -133,7 +133,7 @@ s.to_vtk(OUT_DIR + "surf_init", extra_data=pointData)
 
 Jf = SquaredFlux(s, bs)
 Jls = [CurveLength(c) for c in base_curves]
-Jdist = MinimumDistance(curves, DISTANCE_THRESHOLD)
+Jdist = MinimumDistance(curves, DISTANCE_THRESHOLD, num_basecurves=ncoils)
 Jcs = [LpCurveCurvature(c, 2, CURVATURE_THRESHOLD) for c in base_curves]
 Jmscs = [MeanSquaredCurvature(c) for c in base_curves]
 Jals = [ArclengthVariation(c) for c in base_curves]

--- a/examples/2_Intermediate/stage_two_optimization_stochastic.py
+++ b/examples/2_Intermediate/stage_two_optimization_stochastic.py
@@ -32,7 +32,7 @@ from simsopt.objectives.fluxobjective import SquaredFlux
 from simsopt.geo.curve import RotatedCurve, curves_to_vtk, create_equally_spaced_curves
 from simsopt.field.biotsavart import BiotSavart
 from simsopt.field.coil import Current, Coil, coils_via_symmetries
-from simsopt.geo.curveobjectives import CurveLength, MinimumDistance, \
+from simsopt.geo.curveobjectives import CurveLength, CurveCurveDistance, \
     MeanSquaredCurvature, LpCurveCurvature, ArclengthVariation
 from simsopt.geo.curveperturbed import GaussianSampler, CurvePerturbed, PerturbationSample
 from simsopt.objectives.utilities import QuadraticPenalty, MPIObjective
@@ -133,7 +133,7 @@ s.to_vtk(OUT_DIR + "surf_init", extra_data=pointData)
 
 Jf = SquaredFlux(s, bs)
 Jls = [CurveLength(c) for c in base_curves]
-Jdist = MinimumDistance(curves, DISTANCE_THRESHOLD, num_basecurves=ncoils)
+Jdist = CurveCurveDistance(curves, DISTANCE_THRESHOLD, num_basecurves=ncoils)
 Jcs = [LpCurveCurvature(c, 2, CURVATURE_THRESHOLD) for c in base_curves]
 Jmscs = [MeanSquaredCurvature(c) for c in base_curves]
 Jals = [ArclengthVariation(c) for c in base_curves]

--- a/src/simsopt/geo/curveobjectives.py
+++ b/src/simsopt/geo/curveobjectives.py
@@ -5,6 +5,7 @@ from .jit import jit
 
 from .._core.graph_optimizable import Optimizable
 from .._core.derivative import derivative_dec
+from deprecated import deprecated
 import simsoptpp as sopp
 
 
@@ -461,3 +462,6 @@ class MeanSquaredCurvature(Optimizable):
         return self.curve.dkappa_by_dcoeff_vjp(grad0) + self.curve.dgammadash_by_dcoeff_vjp(grad1)
 
 
+@deprecated("`MinimumDistance` has been deprecated and will be removed. Please use `CurveCurveDistance` instead.")
+class MinimumDistance(CurveCurveDistance):
+    pass

--- a/src/simsopt/geo/curveobjectives.py
+++ b/src/simsopt/geo/curveobjectives.py
@@ -196,6 +196,9 @@ class CurveCurveDistance(Optimizable):
         return min([self.minimum_distance] + [np.min(cdist(self.curves[i].gamma(), self.curves[j].gamma())) for i, j in self.candidates])
 
     def shortest_distance(self):
+        self.compute_candidates()
+        if len(self.candidates) > 0:
+            return self.shortest_distance_among_candidates()
         from scipy.spatial.distance import cdist
         return min([np.min(cdist(self.curves[i].gamma(), self.curves[j].gamma())) for i in range(len(self.curves)) for j in range(i)])
 
@@ -298,6 +301,9 @@ class CurveSurfaceDistance(Optimizable):
         return min([self.minimum_distance] + [np.min(cdist(self.curves[i].gamma(), xyz_surf)) for i, _ in self.candidates])
 
     def shortest_distance(self):
+        self.compute_candidates()
+        if len(self.candidates) > 0:
+            return self.shortest_distance_among_candidates()
         from scipy.spatial.distance import cdist
         xyz_surf = self.surface.gamma().reshape((-1, 3))
         return min([np.min(cdist(self.curves[i].gamma(), xyz_surf)) for i in range(len(self.curves))])

--- a/src/simsopt/geo/curveobjectives.py
+++ b/src/simsopt/geo/curveobjectives.py
@@ -137,18 +137,18 @@ class LpCurveTorsion(Optimizable):
     return_fn_map = {'J': J, 'dJ': dJ}
 
 
-def distance_pure(gamma1, l1, gamma2, l2, minimum_distance):
+def cc_distance_pure(gamma1, l1, gamma2, l2, minimum_distance):
     """
-    This function is used in a Python+Jax implementation of the distance formula.
+    This function is used in a Python+Jax implementation of the curve-curve distance formula.
     """
     dists = jnp.sqrt(jnp.sum((gamma1[:, None, :] - gamma2[None, :, :])**2, axis=2))
     alen = jnp.linalg.norm(l1, axis=1)[:, None] * jnp.linalg.norm(l2, axis=1)[None, :]
     return jnp.sum(alen * jnp.maximum(minimum_distance-dists, 0)**2)/(gamma1.shape[0]*gamma2.shape[0])
 
 
-class MinimumDistance(Optimizable):
+class CurveCurveDistance(Optimizable):
     r"""
-    MinimumDistance is a class that computes
+    CurveCurveDistance is a class that computes
 
     .. math::
         J = \sum_{i = 1}^{\text{num_coils}} \sum_{j = 1}^{i-1} d_{i,j}
@@ -172,7 +172,7 @@ class MinimumDistance(Optimizable):
         self.curves = curves
         self.minimum_distance = minimum_distance
 
-        self.J_jax = jit(lambda gamma1, l1, gamma2, l2: distance_pure(gamma1, l1, gamma2, l2, minimum_distance))
+        self.J_jax = jit(lambda gamma1, l1, gamma2, l2: cc_distance_pure(gamma1, l1, gamma2, l2, minimum_distance))
         self.thisgrad0 = jit(lambda gamma1, l1, gamma2, l2: grad(self.J_jax, argnums=0)(gamma1, l1, gamma2, l2))
         self.thisgrad1 = jit(lambda gamma1, l1, gamma2, l2: grad(self.J_jax, argnums=1)(gamma1, l1, gamma2, l2))
         self.thisgrad2 = jit(lambda gamma1, l1, gamma2, l2: grad(self.J_jax, argnums=2)(gamma1, l1, gamma2, l2))
@@ -186,7 +186,7 @@ class MinimumDistance(Optimizable):
 
     def compute_candidates(self):
         if self.candidates is None:
-            candidates = sopp.get_close_candidates(
+            candidates = sopp.get_pointclouds_closer_than_threshold_within_collection(
                 [c.gamma() for c in self.curves], self.minimum_distance, self.num_basecurves)
             self.candidates = candidates
 
@@ -233,6 +233,106 @@ class MinimumDistance(Optimizable):
             dgamma_by_dcoeff_vjp_vecs[j] += self.thisgrad2(gamma1, l1, gamma2, l2)
             dgammadash_by_dcoeff_vjp_vecs[j] += self.thisgrad3(gamma1, l1, gamma2, l2)
 
+        res = [self.curves[i].dgamma_by_dcoeff_vjp(dgamma_by_dcoeff_vjp_vecs[i]) + self.curves[i].dgammadash_by_dcoeff_vjp(dgammadash_by_dcoeff_vjp_vecs[i]) for i in range(len(self.curves))]
+        return sum(res)
+
+    return_fn_map = {'J': J, 'dJ': dJ}
+
+
+def cs_distance_pure(gammac, lc, gammas, ns, minimum_distance):
+    """
+    This function is used in a Python+Jax implementation of the curve-surface distance
+    formula.
+    """
+    dists = jnp.sqrt(jnp.sum(
+        (gammac[:, None, :] - gammas[None, :, :])**2, axis=2))
+    integralweight = jnp.linalg.norm(lc, axis=1)[:, None] \
+        * jnp.linalg.norm(ns, axis=1)[None, :]
+    return jnp.mean(integralweight * jnp.maximum(minimum_distance-dists, 0)**2)
+
+
+class CurveSurfaceDistance(Optimizable):
+    r"""
+    CurveSurfaceDistance is a class that computes
+
+    .. math::
+        J = \sum_{i = 1}^{\text{num_coils}} d_{i}
+
+    where
+
+    .. math::
+        d_{i} = \int_{\text{curve}_i} \int_{surface} \max(0, d_{\min} - \| \mathbf{r}_i - \mathbf{s} \|_2)^2 ~dl_i ~ds\\
+
+    and :math:`\mathbf{r}_i`, :math:`\mathbf{s}` are points on coil :math:`i`
+    and the surface, respectively. :math:`d_\min` is a desired threshold
+    minimum coil-to-surface distance.  This penalty term is zero when the
+    points on all coils :math:`i` and on the surface lie more than
+    :math:`d_\min` away from one another.
+
+    """
+
+    def __init__(self, curves, surface, minimum_distance):
+        self.curves = curves
+        self.surface = surface
+        self.minimum_distance = minimum_distance
+
+        self.J_jax = jit(lambda gammac, lc, gammas, ns: cs_distance_pure(gammac, lc, gammas, ns, minimum_distance))
+        self.thisgrad0 = jit(lambda gammac, lc, gammas, ns: grad(self.J_jax, argnums=0)(gammac, lc, gammas, ns))
+        self.thisgrad1 = jit(lambda gammac, lc, gammas, ns: grad(self.J_jax, argnums=1)(gammac, lc, gammas, ns))
+        self.candidates = None
+        super().__init__(depends_on=curves)
+
+    def recompute_bell(self, parent=None):
+        self.candidates = None
+
+    def compute_candidates(self):
+        if self.candidates is None:
+            candidates = sopp.get_pointclouds_closer_than_threshold_between_two_collections(
+                [c.gamma() for c in self.curves], [self.surface.gamma().reshape((-1, 3))], self.minimum_distance)
+            self.candidates = candidates
+
+    def shortest_distance_among_candidates(self):
+        self.compute_candidates()
+        from scipy.spatial.distance import cdist
+        xyz_surf = self.surface.gamma().reshape((-1, 3))
+        return min([self.minimum_distance] + [np.min(cdist(self.curves[i].gamma(), xyz_surf)) for i, _ in self.candidates])
+
+    def shortest_distance(self):
+        from scipy.spatial.distance import cdist
+        xyz_surf = self.surface.gamma().reshape((-1, 3))
+        return min([np.min(cdist(self.curves[i].gamma(), xyz_surf)) for i in range(len(self.curves))])
+
+    def J(self):
+        """
+        This returns the value of the quantity.
+        """
+        self.compute_candidates()
+        res = 0
+        gammas = self.surface.gamma().reshape((-1, 3))
+        ns = self.surface.normal().reshape((-1, 3))
+        for i, _ in self.candidates:
+            gammac = self.curves[i].gamma()
+            lc = self.curves[i].gammadash()
+            res += self.J_jax(gammac, lc, gammas, ns)
+        return res
+
+    @derivative_dec
+    def dJ(self):
+        """
+        This returns the derivative of the quantity with respect to the curve dofs.
+        """
+        self.compute_candidates()
+        dgamma_by_dcoeff_vjp_vecs = [np.zeros_like(c.gamma()) for c in self.curves]
+        dgammadash_by_dcoeff_vjp_vecs = [np.zeros_like(c.gammadash()) for c in self.curves]
+        gammas = self.surface.gamma().reshape((-1, 3))
+
+        gammas = self.surface.gamma().reshape((-1, 3))
+        ns = self.surface.normal().reshape((-1, 3))
+        for i, _ in self.candidates:
+            gammac = self.curves[i].gamma()
+            lc = self.curves[i].gammadash()
+            dgamma_by_dcoeff_vjp_vecs[i] += self.thisgrad0(gammac, lc, gammas, ns)
+            dgammadash_by_dcoeff_vjp_vecs[i] += self.thisgrad1(gammac, lc, gammas, ns)
         res = [self.curves[i].dgamma_by_dcoeff_vjp(dgamma_by_dcoeff_vjp_vecs[i]) + self.curves[i].dgammadash_by_dcoeff_vjp(dgammadash_by_dcoeff_vjp_vecs[i]) for i in range(len(self.curves))]
         return sum(res)
 
@@ -353,3 +453,5 @@ class MeanSquaredCurvature(Optimizable):
         grad0 = self.thisgrad0(self.curve.kappa(), self.curve.gammadash())
         grad1 = self.thisgrad1(self.curve.kappa(), self.curve.gammadash())
         return self.curve.dkappa_by_dcoeff_vjp(grad0) + self.curve.dgammadash_by_dcoeff_vjp(grad1)
+
+

--- a/src/simsoptpp/python.cpp
+++ b/src/simsoptpp/python.cpp
@@ -167,6 +167,7 @@ PYBIND11_MODULE(simsoptpp, m) {
                 for (int ii = -mesh_factor; ii <= mesh_factor; ++ii) {
                     for (int jj = -mesh_factor; jj <= mesh_factor; ++jj) {
                         for (int kk = -mesh_factor; kk <= mesh_factor; ++kk) {
+                            // without this condition we're marking cells in a cube around the point and not a sphere
                             if(std::abs(kk) + std::abs(jj) + std::abs(kk) - 3 < std::sqrt(3)*mesh_factor)
                                 s_extended.insert({i + ii, j + jj, k + kk});
                         }

--- a/src/simsoptpp/python_distance.cpp
+++ b/src/simsoptpp/python_distance.cpp
@@ -1,0 +1,177 @@
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
+namespace py = pybind11;
+#include "xtensor-python/pyarray.hpp"     // Numpy bindings
+typedef xt::pyarray<double> PyArray;
+using std::vector;
+using std::tuple;
+using std::set;
+using std::floor;
+
+
+template<class T>
+bool empty_intersection(const set<T>& x, const set<T>& y)
+{
+    auto i = x.begin();
+    auto j = y.begin();
+    while (i != x.end() && j != y.end())
+    {
+        if (*i == *j)
+            return false;
+        else if (*i < *j)
+            ++i;
+        else
+            ++j;
+    }
+    return true;
+}
+
+bool two_points_too_close_exist(PyArray& XA, PyArray& XB, double threshold_squared){
+    for (int k = 0; k < XA.shape(0); ++k) {
+        for (int l = 0; l < XB.shape(0); ++l) {
+            double dist = std::pow(XA(k, 0) - XB(l, 0), 2) + std::pow(XA(k, 1) - XB(l, 1), 2) + std::pow(XA(k, 2) - XB(l, 2), 2);
+            if(dist < threshold_squared)
+                return true;
+        }
+    }
+    return false;
+}
+
+vector<tuple<int, int>> get_close_candidates_pdist(vector<PyArray>& pointClouds, double threshold, int num_base_curves) {
+    /*
+       Returns all pairings of the given pointClouds that have two points that
+       are less than `threshold` away. The estimate is approximate (for
+       speed), so this function may return too many (but not too few!)
+       pairings.
+
+       The basic idea of this function is the following:
+       - Assume we want to compare pointcloud A and B.
+       - We create a uniform grid of cell size threshold.
+       - Loop over points in cloud A, mark all cells that have a point in it (via the `set` variables below).
+       - Loop over points in cloud B, mark all cells that have a point in it and also all cells in the 8 neighbouring cells around it.
+       - Check whether the intersection between the two sets is non-empty.
+       */
+    vector<set<tuple<int, int, int>>> sets(pointClouds.size());
+    vector<set<tuple<int, int, int>>> sets_extended(pointClouds.size());
+#pragma omp parallel for
+    for (int p = 0; p < pointClouds.size(); ++p) {
+        PyArray& points = pointClouds[p];
+        for (int l = 0; l < points.shape(0); ++l) {
+            int i = floor(points(l, 0)/threshold);
+            int j = floor(points(l, 1)/threshold);
+            int k = floor(points(l, 2)/threshold);
+            sets[p].insert({i, j, k});
+            for (int ii = -1; ii <= 1; ++ii) {
+                for (int jj = -1; jj <= 1; ++jj) {
+                    for (int kk = -1; kk <= 1; ++kk) {
+                        sets_extended[p].insert({i + ii, j + jj, k + kk});
+                    }
+                }
+            }
+        }
+    }
+
+
+    vector<tuple<int, int>> candidates_1;
+    for (int i = 0; i < pointClouds.size(); ++i) {
+        for (int j = 0; j < i; ++j) {
+            if(j < num_base_curves)
+                candidates_1.push_back({i, j});
+        }
+    }
+    vector<tuple<int, int>> candidates_2;
+#pragma omp parallel for
+    for (int k = 0; k < candidates_1.size(); ++k) {
+        int i = std::get<0>(candidates_1[k]);
+        int j = std::get<1>(candidates_1[k]);
+        bool check = empty_intersection(sets_extended[i], sets[j]);
+#pragma omp critical
+        if(!check)
+            candidates_2.push_back({i, j});
+    }
+
+    double t2 = threshold*threshold;
+    vector<tuple<int, int>> candidates_3;
+#pragma omp parallel for
+    for (int k = 0; k < candidates_2.size(); ++k) {
+        int i = std::get<0>(candidates_2[k]);
+        int j = std::get<1>(candidates_2[k]);
+        bool check = two_points_too_close_exist(pointClouds[i], pointClouds[j], t2);
+#pragma omp critical
+        if(check)
+            candidates_3.push_back({i, j});
+    }
+    return candidates_3;
+}
+
+vector<tuple<int, int>> get_close_candidates_cdist(vector<PyArray>& pointCloudsA, vector<PyArray>& pointCloudsB, double threshold) {
+    /*
+       */
+    vector<set<tuple<int, int, int>>> sets_A(pointCloudsA.size());
+    vector<set<tuple<int, int, int>>> sets_B_extended(pointCloudsB.size());
+#pragma omp parallel for
+    for (int p = 0; p < pointCloudsA.size(); ++p) {
+        PyArray& points = pointCloudsA[p];
+        for (int l = 0; l < points.shape(0); ++l) {
+            int i = floor(points(l, 0)/threshold);
+            int j = floor(points(l, 1)/threshold);
+            int k = floor(points(l, 2)/threshold);
+            sets_A[p].insert({i, j, k});
+        }
+    }
+    for (int p = 0; p < pointCloudsB.size(); ++p) {
+        set<tuple<int, int, int>> s;
+        set<tuple<int, int, int>> s_extended;
+        PyArray& points = pointCloudsB[p];
+        for (int l = 0; l < points.shape(0); ++l) {
+            int i = floor(points(l, 0)/threshold);
+            int j = floor(points(l, 1)/threshold);
+            int k = floor(points(l, 2)/threshold);
+            for (int ii = -1; ii <= 1; ++ii) {
+                for (int jj = -1; jj <= 1; ++jj) {
+                    for (int kk = -1; kk <= 1; ++kk) {
+                        sets_B_extended[p].insert({i + ii, j + jj, k + kk});
+                    }
+                }
+            }
+        }
+    }
+
+
+    vector<tuple<int, int>> candidates_1;
+    for (int i = 0; i < pointCloudsA.size(); ++i) {
+        for (int j = 0; j < pointCloudsB.size(); ++j) {
+            candidates_1.push_back({i, j});
+        }
+    }
+    vector<tuple<int, int>> candidates_2;
+#pragma omp parallel for
+    for (int k = 0; k < candidates_1.size(); ++k) {
+        int i = std::get<0>(candidates_1[k]);
+        int j = std::get<1>(candidates_1[k]);
+        bool check = empty_intersection(sets_A[i], sets_B_extended[j]);
+#pragma omp critical
+        if(!check)
+            candidates_2.push_back({i, j});
+    }
+
+    double t2 = threshold*threshold;
+    vector<tuple<int, int>> candidates_3;
+#pragma omp parallel for
+    for (int k = 0; k < candidates_2.size(); ++k) {
+        int i = std::get<0>(candidates_2[k]);
+        int j = std::get<1>(candidates_2[k]);
+        bool check = two_points_too_close_exist(pointCloudsA[i], pointCloudsB[j], t2);
+#pragma omp critical
+        if(check)
+            candidates_3.push_back({i, j});
+    }
+    return candidates_3;
+}
+
+void init_distance(py::module_ &m){
+
+    m.def("get_pointclouds_closer_than_threshold_within_collection", &get_close_candidates_pdist, "In a list of point clouds, get all pairings that are closer than threshold to each other.", py::arg("pointClouds"), py::arg("threshold"), py::arg("num_base_curves"));
+    m.def("get_pointclouds_closer_than_threshold_between_two_collections", &get_close_candidates_cdist, "Between two lists of pointclouds, get all pairings that are closer than threshold to each other.", py::arg("pointCloudsA"), py::arg("pointCloudsB"), py::arg("threshold"));
+
+}

--- a/tests/geo/test_curve_objectives.py
+++ b/tests/geo/test_curve_objectives.py
@@ -319,7 +319,5 @@ class Testing(unittest.TestCase):
             err = err_new
 
 
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/geo/test_curve_objectives.py
+++ b/tests/geo/test_curve_objectives.py
@@ -7,7 +7,7 @@ from simsopt.geo.curve import RotatedCurve
 from simsopt.geo.curvexyzfourier import CurveXYZFourier, JaxCurveXYZFourier
 from simsopt.geo.curverzfourier import CurveRZFourier
 from simsopt.geo.curveobjectives import CurveLength, LpCurveCurvature, \
-    LpCurveTorsion, MinimumDistance, ArclengthVariation, MeanSquaredCurvature
+    LpCurveTorsion, CurveCurveDistance, ArclengthVariation, MeanSquaredCurvature
 from simsopt.field.coil import coils_via_symmetries
 from simsopt.util.zoo import get_ncsx_data
 import simsoptpp as sopp
@@ -132,7 +132,7 @@ class Testing(unittest.TestCase):
         ncurves = 3
         curve_t = curve.curve.__class__.__name__ if isinstance(curve, RotatedCurve) else curve.__class__.__name__
         curves = [curve] + [RotatedCurve(self.create_curve(curve_t, False), 0.1*i, True) for i in range(1, ncurves)]
-        J = MinimumDistance(curves, 0.2)
+        J = CurveCurveDistance(curves, 0.2)
         mindist = 1e10
         for i in range(len(curves)):
             for j in range(i):
@@ -256,8 +256,8 @@ class Testing(unittest.TestCase):
         base_curves, base_currents, _ = get_ncsx_data(Nt_coils=10)
         curves = [c.curve for c in coils_via_symmetries(base_curves, base_currents, 3, True)]
         for t in np.linspace(0.05, 0.5, num=10):
-            Jnosym = MinimumDistance(curves, t)
-            Jsym = MinimumDistance(curves, t, num_basecurves=3)
+            Jnosym = CurveCurveDistance(curves, t)
+            Jsym = CurveCurveDistance(curves, t, num_basecurves=3)
             assert abs(Jnosym.shortest_distance_among_candidates() - Jsym.shortest_distance_among_candidates()) < 1e-15
             print(len(Jnosym.candidates), len(Jsym.candidates), Jnosym.shortest_distance_among_candidates())
             distsnosym = [np.min(cdist(Jnosym.curves[i].gamma(), Jnosym.curves[j].gamma())) for i, j in Jnosym.candidates]

--- a/tests/geo/test_curve_objectives.py
+++ b/tests/geo/test_curve_objectives.py
@@ -335,7 +335,7 @@ class Testing(unittest.TestCase):
             err_new = np.linalg.norm(deriv_est-deriv)
             print("err_new %s" % (err_new))
             print(err_new/err)
-            # assert err_new < 0.3 * err
+            assert err_new < 0.3 * err
             err = err_new
 
 

--- a/tests/geo/test_curve_objectives.py
+++ b/tests/geo/test_curve_objectives.py
@@ -234,7 +234,7 @@ class Testing(unittest.TestCase):
                     curve = self.create_curve(curvetype, rotated)
                     self.subtest_curve_meansquaredcurvature_taylor_test(curve)
 
-    def test_minimum_distance_candidates(self):
+    def test_minimum_distance_candidates_one_collection(self):
         np.random.seed(0)
         n_clouds = 4
         pointClouds = [np.random.uniform(low=-1.0, high=+1.0, size=(5, 3)) for _ in range(n_clouds)]
@@ -251,6 +251,26 @@ class Testing(unittest.TestCase):
 
         threshold = min(true_min_dists.values()) * 1.0001
         candidates = sopp.get_pointclouds_closer_than_threshold_within_collection(pointClouds, threshold, n_clouds)
+        assert len(candidates) == 1
+
+    def test_minimum_distance_candidates_two_collections(self):
+        np.random.seed(0)
+        n_clouds = 4
+        pointCloudsA = [np.random.uniform(low=-1.0, high=+1.0, size=(5, 3)) for _ in range(n_clouds)]
+        pointCloudsB = [np.random.uniform(low=-1.0, high=+1.0, size=(5, 3)) for _ in range(n_clouds)]
+        true_min_dists = {}
+        from scipy.spatial.distance import cdist
+
+        for i in range(n_clouds):
+            for j in range(n_clouds):
+                true_min_dists[(i, j)] = np.min(cdist(pointCloudsA[i], pointCloudsB[j]))
+
+        threshold = max(true_min_dists.values()) * 1.0001
+        candidates = sopp.get_pointclouds_closer_than_threshold_between_two_collections(pointCloudsA, pointCloudsB, threshold)
+        assert len(candidates) == len(true_min_dists)
+
+        threshold = min(true_min_dists.values()) * 1.0001
+        candidates = sopp.get_pointclouds_closer_than_threshold_between_two_collections(pointCloudsA, pointCloudsB, threshold)
         assert len(candidates) == 1
 
     def test_minimum_distance_candidates_symmetry(self):

--- a/tests/geo/test_curve_objectives.py
+++ b/tests/geo/test_curve_objectives.py
@@ -271,5 +271,6 @@ class Testing(unittest.TestCase):
                 np.unique(np.round(distssym, 8))
             )
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/geo/test_curve_objectives.py
+++ b/tests/geo/test_curve_objectives.py
@@ -283,8 +283,6 @@ class Testing(unittest.TestCase):
         surface.set(f'rc(0,{ntor})', 1.6)
         surface.set(f'rc(1,{ntor})', 0.2)
         surface.set(f'zs(1,{ntor})', 0.2)
-        surface.to_vtk("/tmp/tmp")
-        curves_to_vtk(curves, "/tmp/tmp")
 
         last_num_candidates = 0
         for t in np.linspace(0.01, 1.0, num=10):

--- a/tests/geo/test_curve_objectives.py
+++ b/tests/geo/test_curve_objectives.py
@@ -246,11 +246,11 @@ class Testing(unittest.TestCase):
                 true_min_dists[(i, j)] = np.min(cdist(pointClouds[i], pointClouds[j]))
 
         threshold = max(true_min_dists.values()) * 1.0001
-        candidates = sopp.get_close_candidates(pointClouds, threshold, n_clouds)
+        candidates = sopp.get_pointclouds_closer_than_threshold_within_collection(pointClouds, threshold, n_clouds)
         assert len(candidates) == len(true_min_dists)
 
         threshold = min(true_min_dists.values()) * 1.0001
-        candidates = sopp.get_close_candidates(pointClouds, threshold, n_clouds)
+        candidates = sopp.get_pointclouds_closer_than_threshold_within_collection(pointClouds, threshold, n_clouds)
         assert len(candidates) == 1
 
     def test_minimum_distance_candidates_symmetry(self):

--- a/tests/geo/test_curveperturbed.py
+++ b/tests/geo/test_curveperturbed.py
@@ -3,7 +3,7 @@ from simsopt.geo.curveperturbed import GaussianSampler, PerturbationSample, Curv
 from simsopt.geo.curvexyzfourier import CurveXYZFourier
 from randomgen import PCG64
 import numpy as np
-from simsopt.geo.curveobjectives import LpCurveTorsion, MinimumDistance
+from simsopt.geo.curveobjectives import LpCurveTorsion, CurveCurveDistance
 
 
 class CurvePerturbationTesting(unittest.TestCase):
@@ -113,7 +113,7 @@ class CurvePerturbationTesting(unittest.TestCase):
         curve1 = CurvePerturbed(curve1, sample1)
         curve2 = CurvePerturbed(curve2, sample2)
 
-        J = MinimumDistance([curve1, curve2], 2.0)
+        J = CurveCurveDistance([curve1, curve2], 2.0)
         J0 = J.J()
         curve1.resample()
         assert J0 != J.J()


### PR DESCRIPTION
Summary

- introduced `CurveSurfaceDistance` objective to enforce minimum distance constraints between the coils and a surface
- renamed `MinimumDistance` to `CurveCurveDistance`
- exploit symmetries to avoid computing redundant distances
- added C++ routines that return which pairs of curves are within a certain threshold of each other and which curves are within a threshold of a surface.

The idea behind the last point is:
- Assume we want to compare pointcloud A and B.
- We create a uniform grid of size `threshold`.
- Loop over points in cloud A, mark all cells that have a point in it (blue in the image).
- Loop over points in cloud B, mark all cells that have a point in it (green) and also all neighbouring cells around it (red).
- Check whether the intersection `(green ∪ red) ∩ blue` between the two sets is non-empty.
  - if empty: the two point clouds are *definitely* more than `threshold` apart
  - if non-empty: they *may* be points in the pointclouds closer than `threshold` to each other

![image](https://user-images.githubusercontent.com/5160278/163298659-959ba95e-50c2-4e51-ba15-ad7ed71d3ecd.png)


The above is a necessary condition for two point clouds to have points that are within `threshold`. We then do the exact check afterwards (O(n^2) cost) for all pairs that are still candidates after the above step. 

