### PR TITLE
Remove assert in tracing.cpp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       run: python -c "print(dir()); import vmec; print(dir()); print(dir(vmec)); print('package:', vmec.__package__); print('spec:', vmec.__spec__); print('doc:', vmec.__doc__); print('file:', vmec.__file__); print('path:', vmec.__path__)"
 
     - name: Install simsopt package
-      run: pip install -v .[MPI,SPEC]
+      run: env CMAKE_BUILD_TYPE=Debug pip install -v .[MPI,SPEC]
 
     - name: Verify that importing simsopt does not automatically initialize MPI
       run: ./tests/verify_MPI_not_initialized.py

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ class CMakeBuild(build_ext):
             extdir += os.path.sep
 
         cfg = "Debug" if self.debug else "Release"
+        cfg = os.getenv("CMAKE_BUILD_TYPE", cfg)
+        print(f"Choose CMAKE_BUILD_TYPE={cfg}", flush=True)
 
         # CMake lets you override the generator - we need to check this.
         # Can be set with Conda-Build, for example.

--- a/src/simsoptpp/tracing.cpp
+++ b/src/simsoptpp/tracing.cpp
@@ -111,8 +111,6 @@ class GuidingCenterVacuumBoozerRHS {
             stz(0, 1) = ys[1];
             stz(0, 2) = ys[2];
 
-            assert(ys[0]>0);
-
             field->set_points(stz);
             auto psi0 = field->psi0;
             double modB = field->modB_ref()(0);

--- a/src/simsoptpp/tracing.cpp
+++ b/src/simsoptpp/tracing.cpp
@@ -167,8 +167,6 @@ class GuidingCenterNoKBoozerRHS {
             stz(0, 1) = ys[1];
             stz(0, 2) = ys[2];
 
-            assert(ys[0]>0);
-
             field->set_points(stz);
             auto psi0 = field->psi0;
             double modB = field->modB_ref()(0);


### PR DESCRIPTION
I noticed that one of the tests triggered this assert, when running the test suite on a Debug build of simsoptpp. It never failed on CI because asserts are not active when building in Release mode.

I checked with @ejpaul and she confirmed that this can go.