### PR TITLE
mpi barrier to avoid wout not found error

### DIFF
--- a/src/simsopt/mhd/vmec.py
+++ b/src/simsopt/mhd/vmec.py
@@ -710,6 +710,8 @@ class Vmec(Optimizable):
 
         logger.info("VMEC run complete. Now loading output.")
         self.load_wout()
+        # Make sure all procs have finished loading the wout file before we delete it:
+        self.mpi.comm_groups.barrier()
         logger.info("Done loading VMEC output.")
 
         # Group leaders handle deletion of files:


### PR DESCRIPTION
In stage one optimization, if there are multiple mpi processes per worker group, there can be a problem where proc 0 deletes a wout file before other procs have read it. In this PR an MPI barrier is added to avoid this condition.