### PR TITLE
Skip matplotlib-dependent tests if it's not installed

### DIFF
--- a/tests/mhd/test_profiles.py
+++ b/tests/mhd/test_profiles.py
@@ -6,6 +6,11 @@ from simsopt.mhd.profiles import ProfilePolynomial, ProfileScaled, ProfileSpline
 
 logger = logging.getLogger(__name__)
 #logging.basicConfig(level=logging.DEBUG)
+try:
+    import matplotlib
+    matplotlib_found = True
+except:
+    matplotlib_found = False
 
 
 class ProfilesTests(unittest.TestCase):
@@ -20,6 +25,7 @@ class ProfilesTests(unittest.TestCase):
         np.testing.assert_allclose(prof(s), 3 * (1 - s ** 3))
         np.testing.assert_allclose(prof.dfds(s), 3 * (- 3 * s ** 2))
 
+    @unittest.skipIf(not matplotlib_found, "Matplotlib python module not found")
     def test_plot(self):
         """
         Test the plotting function.

--- a/tests/mhd/test_vmec_diagnostics.py
+++ b/tests/mhd/test_vmec_diagnostics.py
@@ -9,6 +9,12 @@ from simsopt.mhd.vmec_diagnostics import QuasisymmetryRatioResidual, \
 from simsopt.objectives.least_squares import LeastSquaresProblem
 
 try:
+    import matplotlib
+    matplotlib_found = True
+except:
+    matplotlib_found = False
+
+try:
     import vmec
 except ImportError as e:
     vmec = None
@@ -607,6 +613,7 @@ class VmecFieldlinesTests(unittest.TestCase):
                                    fl.toroidal_flux_sign * (B0 / Aminor) * (-np.cos(theta) / R + phi * d_iota_d_r * eps * np.sin(theta)),
                                    atol=0.006)
 
+    @unittest.skipIf(not matplotlib_found, "Matplotlib python module not found")
     def test_plot(self):
         """
         Test the plotting function of vmec_fieldlines()


### PR DESCRIPTION
Closes #214. A pretty simple fix :)