### PR TITLE
Add a Weight object that encapsules a scalar

### DIFF
--- a/examples/2_Intermediate/stage_two_optimization.py
+++ b/examples/2_Intermediate/stage_two_optimization.py
@@ -15,7 +15,8 @@ The objective is given by
 
 if any of the weights are increased, or the thresholds are tightened, the coils
 are more regular and better separated, but the target normal field may not be
-achieved as well.
+achieved as well. This example demonstrates the adjustment of weights and
+penalties via the use of the `Weight` class.
 
 The target equilibrium is the QA configuration of arXiv:2108.03711.
 """
@@ -24,6 +25,7 @@ import os
 from pathlib import Path
 import numpy as np
 from scipy.optimize import minimize
+from simsopt._core.optimizable import Weight
 from simsopt.geo.surfacerzfourier import SurfaceRZFourier
 from simsopt.objectives.fluxobjective import SquaredFlux
 from simsopt.objectives.utilities import QuadraticPenalty
@@ -46,12 +48,14 @@ R1 = 0.5
 # Number of Fourier modes describing each Cartesian component of each coil:
 order = 5
 
-# Weight on the curve lengths in the objective function:
-LENGTH_WEIGHT = 1e-6
+# Weight on the curve lengths in the objective function. We use the `Weight`
+# class here to later easily adjust the scalar value and rerun the optimization
+# without having to rebuild the objective.
+LENGTH_WEIGHT = Weight(1e-6)
 
 # Threshold and weight for the coil-to-coil distance penalty in the objective function:
 CC_THRESHOLD = 0.1
-CC_WEIGHT = 10
+CC_WEIGHT = 1000
 
 # Threshold and weight for the coil-to-surface distance penalty in the objective function:
 CS_THRESHOLD = 0.3
@@ -166,6 +170,17 @@ print("""
 ################################################################################
 """)
 res = minimize(fun, dofs, jac=True, method='L-BFGS-B', options={'maxiter': MAXITER, 'maxcor': 300}, tol=1e-15)
-curves_to_vtk(curves, OUT_DIR + f"curves_opt")
+curves_to_vtk(curves, OUT_DIR + f"curves_opt_short")
 pointData = {"B_N": np.sum(bs.B().reshape((nphi, ntheta, 3)) * s.unitnormal(), axis=2)[:, :, None]}
-s.to_vtk(OUT_DIR + "surf_opt", extra_data=pointData)
+s.to_vtk(OUT_DIR + "surf_opt_short", extra_data=pointData)
+
+
+# We now use the result from the optimization as the initial guess for a
+# subsequent optimization with reduced penalty for the coil length. This will
+# result in slightly longer coils but smaller `B·n` on the surface.
+dofs = res.x
+LENGTH_WEIGHT *= 0.1
+res = minimize(fun, dofs, jac=True, method='L-BFGS-B', options={'maxiter': MAXITER, 'maxcor': 300}, tol=1e-15)
+curves_to_vtk(curves, OUT_DIR + f"curves_opt_long")
+pointData = {"B_N": np.sum(bs.B().reshape((nphi, ntheta, 3)) * s.unitnormal(), axis=2)[:, :, None]}
+s.to_vtk(OUT_DIR + "surf_opt_long", extra_data=pointData)

--- a/src/simsopt/_core/optimizable.py
+++ b/src/simsopt/_core/optimizable.py
@@ -1402,6 +1402,19 @@ def make_optimizable(func, *args, dof_indicators=None, **kwargs):
     return TempOptimizable(func, *args, dof_indicators=dof_indicators, **kwargs)
 
 
+class Weight(object):
+
+    def __init__(self, value):
+        self.value = float(value)
+
+    def __float__(self):
+        return float(self.value)
+
+    def __imul__(self, alpha):
+        self.value *= alpha
+        return self
+
+
 class ScaledOptimizable(Optimizable):
     """
     Represents an :obj:`~simsopt._core.optimizable.Optimizable`
@@ -1422,12 +1435,12 @@ class ScaledOptimizable(Optimizable):
         super().__init__(depends_on=[opt])
 
     def J(self):
-        return self.factor * self.opt.J()
+        return float(self.factor) * self.opt.J()
 
     @derivative_dec
     def dJ(self):
         # Next line uses __rmul__ function for the Derivative class
-        return self.factor * self.opt.dJ(partials=True)
+        return float(self.factor) * self.opt.dJ(partials=True)
 
 
 class OptimizableSum(Optimizable):

--- a/tests/core/test_derivative.py
+++ b/tests/core/test_derivative.py
@@ -177,10 +177,15 @@ class DerivativeTests(unittest.TestCase):
         np.testing.assert_allclose(obj2.dJ(), factor * obj1.dJ())
 
         factor = -10
-        obj3 = Weight(factor) * obj1
+        w = Weight(factor)
+        obj3 = w * obj1
         taylor_test(obj3)
         np.testing.assert_allclose(obj3.J(), factor * obj1.J())
         np.testing.assert_allclose(obj3.dJ(), factor * obj1.dJ())
+        w *= 3
+        taylor_test(obj3)
+        np.testing.assert_allclose(obj3.J(), 3*factor * obj1.J())
+        np.testing.assert_allclose(obj3.dJ(), 3*factor * obj1.dJ())
 
     def test_optimizable_sum(self):
         """

--- a/tests/core/test_derivative.py
+++ b/tests/core/test_derivative.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-from simsopt._core.optimizable import Optimizable, ScaledOptimizable, OptimizableSum
+from simsopt._core.optimizable import Optimizable, ScaledOptimizable, OptimizableSum, Weight
 from simsopt._core.derivative import Derivative, derivative_dec
 
 
@@ -153,6 +153,11 @@ class DerivativeTests(unittest.TestCase):
         np.testing.assert_allclose(obj2.J(), factor * obj1.J())
         np.testing.assert_allclose(obj2.dJ(), factor * obj1.dJ())
 
+        obj3 = ScaledOptimizable(Weight(factor), obj1)
+        taylor_test(obj3)
+        np.testing.assert_allclose(obj3.J(), factor * obj1.J())
+        np.testing.assert_allclose(obj3.dJ(), factor * obj1.dJ())
+
     def test_scaled_optimizable_operator(self):
         """
         Confirm that values and derivatives behave correctly when an
@@ -170,6 +175,12 @@ class DerivativeTests(unittest.TestCase):
         taylor_test(obj2)
         np.testing.assert_allclose(obj2.J(), factor * obj1.J())
         np.testing.assert_allclose(obj2.dJ(), factor * obj1.dJ())
+
+        factor = -10
+        obj3 = Weight(factor) * obj1
+        taylor_test(obj3)
+        np.testing.assert_allclose(obj3.J(), factor * obj1.J())
+        np.testing.assert_allclose(obj3.dJ(), factor * obj1.dJ())
 
     def test_optimizable_sum(self):
         """


### PR DESCRIPTION
Often we use a weight in front of a penalty, then solve and optimization problem, and then we want to adjust the weight and solve the problem again.

With this PR one can now write

```
J1 = SomeObjective()
J2 = SomePenalty()
alpha = Weight(1e1)

J = J1 + alpha * J2

minimize(J,...)
alpha *= 100
minimize(J, ...)
```