### PR TITLE
Setup numpy dependency in the recommended way

### DIFF
--- a/conda.recipe/conda_build_config.yaml
+++ b/conda.recipe/conda_build_config.yaml
@@ -1,12 +1,7 @@
-numpy:
-  - 1.19
-  - 1.20
-  - 1.21
 python:
   - 3.7
   - 3.8
   - 3.9
 
 pin_run_as_build:
-  numpy: x.x
   python: x.x

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,13 +29,13 @@ requirements:
     - pip
     - wheel
     - setuptools
-    - numpy {{ numpy }}
+    - numpy 
     - "setuptools_scm[toml]"
     - python {{ python }}
 
   run:
     - python
-    - numpy {{ numpy }}
+    - numpy {{ pin_compatible("numpy") }}
     - jax >=0.2.5
     - jaxlib >=0.1.56
     - scipy >=1.5.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "numpy", "cmake", "ninja", "setuptools_scm[toml]>=6.0"]
+requires = ["setuptools>=45", "wheel", "oldest-supported-numpy", "cmake", "ninja", "setuptools_scm[toml]>=6.0"]
 build-backend = "setuptools.build_meta"
 
 [tools.setuptools_scm]


### PR DESCRIPTION
Instead of specifying a numpy version at build time, we use the oldest version of numpy that is ABI compatible with newer versions of numpy for building simsopt.