### PR TITLE
vectorized d2area_dcdc and d2volume_dcdc

### DIFF
--- a/src/simsoptpp/surface.cpp
+++ b/src/simsoptpp/surface.cpp
@@ -519,37 +519,6 @@ Array Surface<Array>::dnormal_by_dcoeff_vjp(Array& v) {
     return dgammadash1_by_dcoeff_vjp(res_dgammadash1) + dgammadash2_by_dcoeff_vjp(res_dgammadash2);
 }
 
-template<class Array>
-void Surface<Array>::d2area_by_dcoeffdcoeff_impl(Array& data) {
-    data *= 0.;
-    double norm, dnorm_dcoeffn;
-    auto nor = this->normal();
-    auto dnor_dc = this->dnormal_by_dcoeff();
-    auto d2nor_dcdc = this->d2normal_by_dcoeffdcoeff();
-    int ndofs = num_dofs();
-    for (int i = 0; i < numquadpoints_phi; ++i) {
-        for (int j = 0; j < numquadpoints_theta; ++j) {
-            for (int m = 0; m < ndofs; ++m) {
-                for (int n = 0; n < ndofs; ++n) {
-                    norm = sqrt(nor(i,j,0)*nor(i,j,0)
-                            + nor(i,j,1)*nor(i,j,1)
-                            + nor(i,j,2)*nor(i,j,2));
-                    dnorm_dcoeffn = (dnor_dc(i,j,0,n)*nor(i,j,0)
-                            + dnor_dc(i,j,1,n)*nor(i,j,1)
-                            + dnor_dc(i,j,2,n)*nor(i,j,2)) / norm;
-                    data(m,n) +=  dnor_dc(i,j,0,m) * (dnor_dc(i,j,0,n) * norm - dnorm_dcoeffn * nor(i,j,0)) / (norm*norm)
-                        + dnor_dc(i,j,1,m) * (dnor_dc(i,j,1,n) * norm - dnorm_dcoeffn * nor(i,j,1)) / (norm*norm)
-                        + dnor_dc(i,j,2,m) * (dnor_dc(i,j,2,n) * norm - dnorm_dcoeffn * nor(i,j,2)) / (norm*norm)
-                        + d2nor_dcdc(i,j,0,m,n) * nor(i,j,0) / norm
-                        + d2nor_dcdc(i,j,1,m,n) * nor(i,j,1) / norm
-                        + d2nor_dcdc(i,j,2,m,n) * nor(i,j,2) / norm;
-                }
-            }
-        }
-    }
-    data *= 1./ (numquadpoints_phi*numquadpoints_theta);
-}
-
 
 template<class Array>
 double Surface<Array>::volume() {
@@ -603,31 +572,230 @@ void Surface<Array>::dvolume_by_dcoeff_impl(Array& data) {
         data(m) = temp(m);
     }
 }
+
+
+
+#include "xsimd/xsimd.hpp"
+#include "simdhelpers.h"
+
 template<class Array>
 void Surface<Array>::d2volume_by_dcoeffdcoeff_impl(Array& data) {
+    constexpr int simd_size = xsimd::simd_type<double>::size;
     data *= 0.;
     auto nor = this->normal();
-    auto dnor_dc = this->dnormal_by_dcoeff();
-    auto d2nor_dcdc = this->d2normal_by_dcoeffdcoeff();
     auto xyz = this->gamma();
     auto dxyz_dc = this->dgamma_by_dcoeff();
+    auto dnor_dc = this->dnormal_by_dcoeff();
+    auto dg1_dc = this->dgammadash1_by_dcoeff();
+    auto dg2_dc = this->dgammadash2_by_dcoeff();
     int ndofs = num_dofs();
+    
+    auto dg1x_dc = AlignedPaddedVec(ndofs, 0);
+    auto dg1y_dc = AlignedPaddedVec(ndofs, 0);
+    auto dg1z_dc = AlignedPaddedVec(ndofs, 0);
+
+    auto dg2x_dc = AlignedPaddedVec(ndofs, 0);
+    auto dg2y_dc = AlignedPaddedVec(ndofs, 0);
+    auto dg2z_dc = AlignedPaddedVec(ndofs, 0);
+
+    auto dnorx_dc = AlignedPaddedVec(ndofs, 0);
+    auto dnory_dc = AlignedPaddedVec(ndofs, 0);
+    auto dnorz_dc = AlignedPaddedVec(ndofs, 0);
+
+    auto dxyzx_dc = AlignedPaddedVec(ndofs, 0);
+    auto dxyzy_dc = AlignedPaddedVec(ndofs, 0);
+    auto dxyzz_dc = AlignedPaddedVec(ndofs, 0);
+
     for (int i = 0; i < numquadpoints_phi; ++i) {
         for (int j = 0; j < numquadpoints_theta; ++j) {
-            for (int m = 0; m < ndofs; ++m){
-                for (int n = 0; n < ndofs; ++n){
-                    data(m,n) += (1./3) * (dxyz_dc(i,j,0,m)*dnor_dc(i,j,0,n)
-                            +dxyz_dc(i,j,1,m)*dnor_dc(i,j,1,n)
-                            +dxyz_dc(i,j,2,m)*dnor_dc(i,j,2,n));
-                    data(m,n) += (1./3) * (xyz(i,j,0)*d2nor_dcdc(i,j,0,m,n) + dxyz_dc(i,j,0,n) * dnor_dc(i,j,0,m)
-                            +xyz(i,j,1)*d2nor_dcdc(i,j,1,m,n) + dxyz_dc(i,j,1,n) * dnor_dc(i,j,1,m)
-                            +xyz(i,j,2)*d2nor_dcdc(i,j,2,m,n) + dxyz_dc(i,j,2,n) * dnor_dc(i,j,2,m));
+            simd_t xyzij0(xyz(i,j,0));
+            simd_t xyzij1(xyz(i,j,1));
+            simd_t xyzij2(xyz(i,j,2));
+
+            for (int n = 0; n < ndofs; ++n) {
+                dg1x_dc[n] = dg1_dc(i, j, 0, n);
+                dg1y_dc[n] = dg1_dc(i, j, 1, n);
+                dg1z_dc[n] = dg1_dc(i, j, 2, n);
+
+                dg2x_dc[n] = dg2_dc(i, j, 0, n);
+                dg2y_dc[n] = dg2_dc(i, j, 1, n);
+                dg2z_dc[n] = dg2_dc(i, j, 2, n);
+
+                dnorx_dc[n] = dnor_dc(i, j, 0, n);
+                dnory_dc[n] = dnor_dc(i, j, 1, n);
+                dnorz_dc[n] = dnor_dc(i, j, 2, n);
+ 
+                dxyzx_dc[n] = dxyz_dc(i, j, 0, n);
+                dxyzy_dc[n] = dxyz_dc(i, j, 1, n);
+                dxyzz_dc[n] = dxyz_dc(i, j, 2, n);
+            }
+
+            for (int m = 0; m < ndofs; ++m){ 
+                simd_t dg1_dc_ij0m(dg1_dc(i, j, 0, m));
+                simd_t dg1_dc_ij1m(dg1_dc(i, j, 1, m));
+                simd_t dg1_dc_ij2m(dg1_dc(i, j, 2, m));
+                
+                simd_t dg2_dc_ij0m(dg2_dc(i, j, 0, m));
+                simd_t dg2_dc_ij1m(dg2_dc(i, j, 1, m));
+                simd_t dg2_dc_ij2m(dg2_dc(i, j, 2, m));
+                
+                simd_t dxyz_dc_ij0m(dxyz_dc(i, j, 0, m));
+                simd_t dxyz_dc_ij1m(dxyz_dc(i, j, 1, m));
+                simd_t dxyz_dc_ij2m(dxyz_dc(i, j, 2, m));
+                
+                simd_t dnor_dc_ij0m(dnor_dc(i, j, 0, m));
+                simd_t dnor_dc_ij1m(dnor_dc(i, j, 1, m));
+                simd_t dnor_dc_ij2m(dnor_dc(i, j, 2, m));
+
+                for (int n = 0; n < ndofs; n+=simd_size){ 
+                    simd_t dg1_dc_ij0n = xs::load_aligned(&dg1x_dc[n]);
+                    simd_t dg1_dc_ij1n = xs::load_aligned(&dg1y_dc[n]);
+                    simd_t dg1_dc_ij2n = xs::load_aligned(&dg1z_dc[n]);
+                    
+                    simd_t dg2_dc_ij0n = xs::load_aligned(&dg2x_dc[n]);
+                    simd_t dg2_dc_ij1n = xs::load_aligned(&dg2y_dc[n]);
+                    simd_t dg2_dc_ij2n = xs::load_aligned(&dg2z_dc[n]);
+                    
+                    simd_t dnor_dc_ij0n = xs::load_aligned(&dnorx_dc[n]);
+                    simd_t dnor_dc_ij1n = xs::load_aligned(&dnory_dc[n]);
+                    simd_t dnor_dc_ij2n = xs::load_aligned(&dnorz_dc[n]);
+
+                    simd_t dxyz_dc_ij0n = xs::load_aligned(&dxyzx_dc[n]);
+                    simd_t dxyz_dc_ij1n = xs::load_aligned(&dxyzy_dc[n]);
+                    simd_t dxyz_dc_ij2n = xs::load_aligned(&dxyzz_dc[n]);
+
+                    auto d2nor_dcdc_ij0mn =  xsimd::fms(dg1_dc_ij1m, dg2_dc_ij2n,  dg1_dc_ij2m*dg2_dc_ij1n);
+                         d2nor_dcdc_ij0mn += xsimd::fms(dg1_dc_ij1n, dg2_dc_ij2m,  dg1_dc_ij2n*dg2_dc_ij1m);
+                    auto d2nor_dcdc_ij1mn =  xsimd::fms(dg1_dc_ij2m, dg2_dc_ij0n,  dg1_dc_ij0m*dg2_dc_ij2n);
+                         d2nor_dcdc_ij1mn += xsimd::fms(dg1_dc_ij2n, dg2_dc_ij0m,  dg1_dc_ij0n*dg2_dc_ij2m);
+                    auto d2nor_dcdc_ij2mn =  xsimd::fms(dg1_dc_ij0m, dg2_dc_ij1n,  dg1_dc_ij1m*dg2_dc_ij0n);
+                         d2nor_dcdc_ij2mn += xsimd::fms(dg1_dc_ij0n, dg2_dc_ij1m,  dg1_dc_ij1n*dg2_dc_ij0m);
+                    
+                    auto temp = xsimd::fma(dxyz_dc_ij0m, dnor_dc_ij0n, dxyz_dc_ij1m*dnor_dc_ij1n);
+                    auto data1  = (1./3) * xsimd::fma(dxyz_dc_ij2m, dnor_dc_ij2n, temp);
+                    auto data2  = (1./3) * (xsimd::fma(xyzij0, d2nor_dcdc_ij0mn , dxyz_dc_ij0n * dnor_dc_ij0m)
+                                           +xsimd::fma(xyzij1, d2nor_dcdc_ij1mn , dxyz_dc_ij1n * dnor_dc_ij1m)
+                                           +xsimd::fma(xyzij2, d2nor_dcdc_ij2mn , dxyz_dc_ij2n * dnor_dc_ij2m) );
+
+                    int jjlimit = std::min(simd_size, ndofs-n);
+                    for(int jj=0; jj<jjlimit; jj++){
+                        data(m, n+jj) += data1[jj]+data2[jj];
+                    }
                 }
             }
         }
     }
     data *= 1./ (numquadpoints_phi*numquadpoints_theta);
 }
+
+template<class Array>
+void Surface<Array>::d2area_by_dcoeffdcoeff_impl(Array& data) {
+    data *= 0.;
+    auto nor = this->normal();
+    auto dnor_dc = this->dnormal_by_dcoeff();
+    auto dg1 = this->gammadash1();
+    auto dg2 = this->gammadash2();
+    auto dg1_dc = this->dgammadash1_by_dcoeff();
+    auto dg2_dc = this->dgammadash2_by_dcoeff();
+    int ndofs = num_dofs();
+    constexpr int simd_size = xsimd::simd_type<double>::size;
+
+    auto dg1x_dc = AlignedPaddedVec(ndofs, 0);
+    auto dg1y_dc = AlignedPaddedVec(ndofs, 0);
+    auto dg1z_dc = AlignedPaddedVec(ndofs, 0);
+
+    auto dg2x_dc = AlignedPaddedVec(ndofs, 0);
+    auto dg2y_dc = AlignedPaddedVec(ndofs, 0);
+    auto dg2z_dc = AlignedPaddedVec(ndofs, 0);
+
+    auto dnorx_dc = AlignedPaddedVec(ndofs, 0);
+    auto dnory_dc = AlignedPaddedVec(ndofs, 0);
+    auto dnorz_dc = AlignedPaddedVec(ndofs, 0);
+
+    for (int i = 0; i < numquadpoints_phi; ++i) {
+        for (int j = 0; j < numquadpoints_theta; ++j) {
+            
+            double val_norm2 =  nor(i,j,0)*nor(i,j,0)+ nor(i,j,1)*nor(i,j,1) + nor(i,j,2)*nor(i,j,2);
+            double val_norm = sqrt(val_norm2);
+            
+            simd_t norm2(val_norm2);
+            simd_t norm(val_norm);
+            
+            simd_t rnorm2(1./val_norm2);
+            simd_t rnorm(1./val_norm);
+
+            for (int n = 0; n < ndofs; ++n) {
+                dg1x_dc[n] = dg1_dc(i, j, 0, n);
+                dg1y_dc[n] = dg1_dc(i, j, 1, n);
+                dg1z_dc[n] = dg1_dc(i, j, 2, n);
+
+                dg2x_dc[n] = dg2_dc(i, j, 0, n);
+                dg2y_dc[n] = dg2_dc(i, j, 1, n);
+                dg2z_dc[n] = dg2_dc(i, j, 2, n);
+
+                dnorx_dc[n] = dnor_dc(i, j, 0, n);
+                dnory_dc[n] = dnor_dc(i, j, 1, n);
+                dnorz_dc[n] = dnor_dc(i, j, 2, n);
+            }
+            
+            simd_t nor_ij0(nor(i,j,0));
+            simd_t nor_ij1(nor(i,j,1));
+            simd_t nor_ij2(nor(i,j,2));
+
+            for (int m = 0; m < ndofs; ++m) {
+                simd_t dg1_dc_ij0m(dg1_dc(i,j,0,m));
+                simd_t dg1_dc_ij1m(dg1_dc(i,j,1,m));
+                simd_t dg1_dc_ij2m(dg1_dc(i,j,2,m));
+
+                simd_t dg2_dc_ij0m(dg2_dc(i,j,0,m));
+                simd_t dg2_dc_ij1m(dg2_dc(i,j,1,m));
+                simd_t dg2_dc_ij2m(dg2_dc(i,j,2,m));
+
+                simd_t dnor_dc_ij0m(dnor_dc(i, j, 0, m));
+                simd_t dnor_dc_ij1m(dnor_dc(i, j, 1, m));
+                simd_t dnor_dc_ij2m(dnor_dc(i, j, 2, m));
+
+                for (int n = 0; n < ndofs; n+=simd_size) {
+                    simd_t dg1_dc_ij0n = xs::load_aligned(&dg1x_dc[n]);
+                    simd_t dg1_dc_ij1n = xs::load_aligned(&dg1y_dc[n]);
+                    simd_t dg1_dc_ij2n = xs::load_aligned(&dg1z_dc[n]);
+                    
+                    simd_t dg2_dc_ij0n = xs::load_aligned(&dg2x_dc[n]);
+                    simd_t dg2_dc_ij1n = xs::load_aligned(&dg2y_dc[n]);
+                    simd_t dg2_dc_ij2n = xs::load_aligned(&dg2z_dc[n]);
+                    
+                    simd_t dnor_dc_ij0n = xs::load_aligned(&dnorx_dc[n]);
+                    simd_t dnor_dc_ij1n = xs::load_aligned(&dnory_dc[n]);
+                    simd_t dnor_dc_ij2n = xs::load_aligned(&dnorz_dc[n]);
+
+                    auto dnorm_dcoeffn = (dnor_dc_ij0n*nor_ij0 + dnor_dc_ij1n*nor_ij1 + dnor_dc_ij2n*nor_ij2) * rnorm;
+                    auto d2nor_dcdc_ij0mn =  xsimd::fms(dg1_dc_ij1m, dg2_dc_ij2n, dg1_dc_ij2m*dg2_dc_ij1n);
+                    d2nor_dcdc_ij0mn     +=  xsimd::fms(dg1_dc_ij1n, dg2_dc_ij2m, dg1_dc_ij2n*dg2_dc_ij1m);
+                    auto d2nor_dcdc_ij1mn =  xsimd::fms(dg1_dc_ij2m, dg2_dc_ij0n, dg1_dc_ij0m*dg2_dc_ij2n);
+                    d2nor_dcdc_ij1mn     +=  xsimd::fms(dg1_dc_ij2n, dg2_dc_ij0m, dg1_dc_ij0n*dg2_dc_ij2m);
+                    auto d2nor_dcdc_ij2mn =  xsimd::fms(dg1_dc_ij0m, dg2_dc_ij1n, dg1_dc_ij1m*dg2_dc_ij0n);
+                    d2nor_dcdc_ij2mn     +=  xsimd::fms(dg1_dc_ij0n, dg2_dc_ij1m, dg1_dc_ij1n*dg2_dc_ij0m);
+
+                    auto batch =  dnor_dc_ij0m * (xsimd::fms(dnor_dc_ij0n , norm , dnorm_dcoeffn * nor_ij0)) * rnorm2
+                                + dnor_dc_ij1m * (xsimd::fms(dnor_dc_ij1n , norm , dnorm_dcoeffn * nor_ij1)) * rnorm2
+                                + dnor_dc_ij2m * (xsimd::fms(dnor_dc_ij2n , norm , dnorm_dcoeffn * nor_ij2)) * rnorm2
+                                + d2nor_dcdc_ij0mn * nor_ij0 * rnorm
+                                + d2nor_dcdc_ij1mn * nor_ij1 * rnorm
+                                + d2nor_dcdc_ij2mn * nor_ij2 * rnorm;
+
+                    int jjlimit = std::min(simd_size, ndofs-n);
+                    for(int jj=0; jj<jjlimit; jj++){
+                        data(m, n+jj) += batch[jj];
+                    }
+
+                }
+            }
+        }
+    }
+    data *= 1./ (numquadpoints_phi*numquadpoints_theta);
+}
+
+
 
 #include "xtensor-python/pyarray.hpp"     // Numpy bindings
 typedef xt::pyarray<double> Array;


### PR DESCRIPTION
The current implementations of d2volume_dcdc and d2_area_dcdc are simple, but use too much buffer memory.  In fact, I can't compute the Hessian's of these quantities for `mpol=ntor>11` because I run out of RAM.  This is due to the how these functions are currently written as well as the fact that we are using basis functions (tensor product Fourier) that are globally defined rather than compactly supported.  Rather than introducing a new surface representation, I've rewritten these subroutines using SIMD parallelization.  In the process, I have also reduced the use of buffer memory.  These functions are an order of magnitude faster now.

timings before optimization
```
mpol=ntor, volume, area
1, 4.158e-04,6.168e-04
2, 3.837e-03,4.037e-03
3, 2.821e-02,2.583e-02
4, 9.770e-02,1.028e-01
5, 3.127e-01,3.372e-01
6, 8.417e-01,8.978e-01
7, 1.986e+00,2.167e+00
8, 4.293e+00,4.509e+00
9, 8.306e+00,8.714e+00
10,1.513e+01,1.561e+01
11,2.818e+01,2.740e+01
```

timings after optimization
```
mpol=ntor, volume, area
1, 3.004e-04, 2.937e-04
2, 5.429e-04, 5.405e-04
3, 2.390e-03, 3.595e-03
4, 4.491e-03, 4.411e-03
5, 1.454e-02, 1.316e-02
6, 3.405e-02, 3.191e-02
7, 7.233e-02, 6.698e-02
8, 1.422e-01, 1.395e-01
9, 2.600e-01, 2.700e-01
10,4.598e-01, 4.965e-01
11,7.818e-01, 8.667e-01
12,1.279e+00, 1.382e+00
13,2.009e+00, 2.200e+00
14,3.108e+00, 3.406e+00
```