### PR TITLE
Update sdist build

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -85,10 +85,10 @@ jobs:
         run: git submodule update --init
         
       - name: Install setuptools_scm
-        run: python -m pip install setuptools_scm
+        run: python -m pip install setuptools_scm build
 
       - name: Build sdist
-        run: python setup.py sdist
+        run: python -m build -s -o dist .
         
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
With this PR, the source distribution is built in PEP-517 compliant manner. This addresses  the issue faced by Caoxiang's student in installing simsopt from source. I tested it by installing simsopt from the newly built source distribution.