### PR TITLE
Updated SurfaceRZFourier.from_vmec_input() to be faster.

### DIFF
--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -71,8 +71,9 @@ Here is a list of publications in which simsopt results appear:
    |
 
 #. | F Wechsung, A Giuliani, M Landreman, A Cerfon, and G Stadler,
-     "A-posteriori optimization for increasing manufacturing tolerances in stellarator coil design",
-     *Submitted*, (2022).
+     "Stochastic and a-posteriori optimization to mitigate coil manufacturing errors in stellarator design",
+     *Plasma Physics and Controlled Fusion*, **64**, 105021 (2022).
+     `[journal version] <https://doi.org/10.1088/1361-6587/ac89ee>`__
      `[arXiv version] <https://arxiv.org/pdf/2203.10164>`__
    |
 

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -297,31 +297,34 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
                    **kwargs)
 
         # Transfer boundary shape data from the namelist to the surface object:
+        # In these loops, we set surf.rc/zs rather than call surf.set_rc() for speed.
         for jm in range(rc.shape[0]):
             m = jm + nml.start_index['rbc'][1]
             for jn in range(rc.shape[1]):
                 n = jn + nml.start_index['rbc'][0]
-                surf.set_rc(m, n, rc[jm, jn])
+                surf.rc[m, n + ntor_boundary] = rc[jm, jn]
 
         for jm in range(zs.shape[0]):
             m = jm + nml.start_index['zbs'][1]
             for jn in range(zs.shape[1]):
                 n = jn + nml.start_index['zbs'][0]
-                surf.set_zs(m, n, zs[jm, jn])
+                surf.zs[m, n + ntor_boundary] = zs[jm, jn]
 
         if lasym:
             for jm in range(rs.shape[0]):
                 m = jm + nml.start_index['rbs'][1]
                 for jn in range(rs.shape[1]):
                     n = jn + nml.start_index['rbs'][0]
-                    surf.set_rs(m, n, rs[jm, jn])
+                    surf.rs[m, n + ntor_boundary] = rs[jm, jn]
 
             for jm in range(zc.shape[0]):
                 m = jm + nml.start_index['zbc'][1]
                 for jn in range(zc.shape[1]):
                     n = jn + nml.start_index['zbc'][0]
-                    surf.set_zc(m, n, zc[jm, jn])
+                    surf.zc[m, n + ntor_boundary] = zc[jm, jn]
 
+        # Sync the dofs:
+        surf.local_full_x = surf.get_dofs()
         return surf
 
     @classmethod


### PR DESCRIPTION
For high Fourier resolution, e.g. mpol=ntor=50, the function `SurfaceRZFourier.from_vmec_input()` can take several seconds. This small change makes it substantially faster.