### PR TITLE
fieldlines refactor

### DIFF
--- a/src/simsopt/mhd/vmec_diagnostics.py
+++ b/src/simsopt/mhd/vmec_diagnostics.py
@@ -24,7 +24,7 @@ from ..geo.surfacerzfourier import SurfaceRZFourier
 logger = logging.getLogger(__name__)
 
 __all__ = ['QuasisymmetryRatioResidual', 'IotaTargetMetric', 'IotaWeighted',
-           'WellWeighted']
+           'WellWeighted', 'vmec_splines', 'vmec_compute_geometry', 'vmec_fieldlines']
 
 
 class QuasisymmetryRatioResidual(Optimizable):
@@ -778,11 +778,100 @@ def vmec_splines(vmec):
 
 
 def vmec_compute_geometry(vs, s, theta, phi, phi_center=0):
-    """
+    r"""
+    Compute many geometric quantities of interest from a vmec configuration.
+
+    Some of the quantities computed by this function refer to
+    ``alpha``, a field line label coordinate defined by
+
+    .. math::
+
+        \alpha = \theta_{pest} - \iota (\phi - \phi_{center}).
+
+    Here, :math:`\phi_{center}` is a constant, usually 0, which can be
+    set to a nonzero value if desired so the magnetic shear
+    contribution to :math:`\nabla\alpha` vanishes at a toroidal angle
+    different than 0.  Also, wherever the term ``psi`` appears in
+    variable names in this function and the returned arrays, it means
+    :math:`\psi =` the toroidal flux divided by :math:`2\pi`, so
+
+    .. math::
+
+        \vec{B} = \nabla\psi\times\nabla\theta_{pest} + \iota\nabla\phi\times\nabla\psi = \nabla\psi\times\nabla\alpha.
+
+    Most of the arrays that are returned by this function have shape
+    ``(ns, ntheta, nphi)``, where ``ns`` is the number of flux
+    surfaces, ``ntheta`` is the number of grid points in VMEC's
+    poloidal angle, and ``nphi`` is the number of grid points in the
+    standard toroidal angle. For the arguments ``theta`` and ``phi``,
+    you can either provide 1D arrays, in which case a tensor product
+    grid is used, or you can provide 3D arrays of shape ``(ns, ntheta,
+    nphi)``. In this latter case, the grids are not necessarily
+    tensor-product grids.  Note that all angles in this function have
+    period :math:`2\pi`, not period 1.
+
+    The output arrays are returned as attributes of the
+    returned object. Many intermediate quantities are included, such
+    as the Cartesian components of the covariant and contravariant
+    basis vectors. Some of the most useful of these output arrays are (all with SI units):
+
+    - ``phi``: The standard toroidal angle :math:`\phi`.
+    - ``theta_vmec``: VMEC's poloidal angle :math:`\theta_{vmec}`.
+    - ``theta_pest``: The straight-field-line angle :math:`\theta_{pest}` associated with :math:`\phi`.
+    - ``modB``: The magnetic field magnitude :math:`|B|`.
+    - ``B_sup_theta_vmec``: :math:`\vec{B}\cdot\nabla\theta_{vmec}`.
+    - ``B_sup_phi``: :math:`\vec{B}\cdot\nabla\phi`.
+    - ``B_cross_grad_B_dot_grad_alpha``: :math:`\vec{B}\times\nabla|B|\cdot\nabla\alpha`.
+    - ``B_cross_grad_B_dot_grad_psi``: :math:`\vec{B}\times\nabla|B|\cdot\nabla\psi`.
+    - ``B_cross_kappa_dot_grad_alpha``: :math:`\vec{B}\times\vec{\kappa}\cdot\nabla\alpha`,
+      where :math:`\vec{\kappa}=\vec{b}\cdot\nabla\vec{b}` is the curvature and :math:`\vec{b}=|B|^{-1}\vec{B}`.
+    - ``B_cross_kappa_dot_grad_psi``: :math:`\vec{B}\times\vec{\kappa}\cdot\nabla\psi`.
+    - ``grad_alpha_dot_grad_alpha``: :math:`|\nabla\alpha|^2 = \nabla\alpha\cdot\nabla\alpha`.
+    - ``grad_alpha_dot_grad_psi``: :math:`\nabla\alpha\cdot\nabla\psi`.
+    - ``grad_psi_dot_grad_psi``: :math:`|\nabla\psi|^2 = \nabla\psi\cdot\nabla\psi`.
+    - ``iota``: The rotational transform :math:`\iota`. This array has shape ``(ns,)``.
+    - ``shat``: The magnetic shear :math:`\hat s= (x/q) (d q / d x)` where 
+      :math:`x = \mathrm{Aminor_p} \, \sqrt{s}` and :math:`q=1/\iota`. This array has shape ``(ns,)``.
+
+    The following normalized versions of these quantities used in the
+    gyrokinetic codes ``stella``, ``gs2``, and ``GX`` are also
+    returned: ``bmag``, ``gbdrift``, ``gbdrift0``, ``cvdrift``,
+    ``cvdrift0``, ``gds2``, ``gds21``, and ``gds22``, along with
+    ``L_reference`` and ``B_reference``.  Instead of ``gradpar``, two
+    variants are returned, ``gradpar_theta_pest`` and ``gradpar_phi``,
+    corresponding to choosing either :math:`\theta_{pest}` or
+    :math:`\phi` as the parallel coordinate.
+
+    The value(s) of ``s`` provided as input need not coincide with the
+    full grid or half grid in VMEC, as spline interpolation will be
+    used radially.
+
+    The implementation in this routine is similar to the one in the
+    gyrokinetic code ``stella``.
+
+    Example usage::
+
+        import numpy as np
+        from simsopt.mhd import Vmec, vmec_compute_geometry
+
+        v = Vmec("wout_li383_1.4m.nc")
+        s = 1
+        theta = np.linspace(0, 2 * np.pi, 50)
+        phi = np.linspace(0, 2 * np.pi / 3, 60)
+        data = vmec_compute_geometry(v, s, theta, phi)
+        print(data.grad_s_dot_grad_s)
+
     Args:
-        s: Either a float or a 1d array.
-        theta: A float, 1d array of size (ntheta,), or a 3d array of size (ns, ntheta, nphi)
-        phi: A float, a 1d array of size (nphi,) or a 3d array of size (ns, ntheta, nphi)
+        vs: Either an instance of :obj:`simsopt.mhd.vmec.Vmec`
+          or the structure returned by :func:`vmec_splines`.
+        s: Values of normalized toroidal flux on which to construct the field lines.
+          You can give a single number, or a list or numpy array.
+        theta: Values of vmec's poloidal angle. You can provide a float, a 1d array of size
+          ``(ntheta,)``, or a 3d array of size ``(ns, ntheta, nphi)``.
+        phi: Values of the standard toroidal angle. You can provide a float, a 1d array of size
+          ``(nphi,)`` or a 3d array of size ``(ns, ntheta, nphi)``.
+        phi_center: :math:`\phi_{center}`, an optional shift to the toroidal angle
+          in the definition of :math:`\alpha`.
     """
     # If given a Vmec object, convert it to vmec_splines:
     if isinstance(vs, Vmec):
@@ -935,11 +1024,11 @@ def vmec_compute_geometry(vs, s, theta, phi, phi_center=0):
     # *********************************************************************
     sinphi = np.sin(phi)
     cosphi = np.cos(phi)
-    # X = R * cos(phi):   
+    X = R * cosphi
     d_X_d_theta_vmec = d_R_d_theta_vmec * cosphi
     d_X_d_phi = d_R_d_phi * cosphi - R * sinphi
     d_X_d_s = d_R_d_s * cosphi
-    # Y = R * sin(phi):
+    Y = R * sinphi
     d_Y_d_theta_vmec = d_R_d_theta_vmec * sinphi
     d_Y_d_phi = d_R_d_phi * sinphi + R * cosphi
     d_Y_d_s = d_R_d_s * sinphi
@@ -1023,6 +1112,8 @@ def vmec_compute_geometry(vs, s, theta, phi, phi_center=0):
 
     grad_psi_dot_grad_psi = grad_psi_X * grad_psi_X + grad_psi_Y * grad_psi_Y + grad_psi_Z * grad_psi_Z
 
+    grad_s_dot_grad_s = grad_s_X * grad_s_X + grad_s_Y * grad_s_Y + grad_s_Z * grad_s_Z
+
     B_cross_grad_B_dot_grad_psi = (B_sub_theta_vmec * d_B_d_phi - B_sub_phi * d_B_d_theta_vmec) / sqrt_g_vmec * edge_toroidal_flux_over_2pi
 
     B_cross_kappa_dot_grad_psi = B_cross_grad_B_dot_grad_psi / modB
@@ -1066,12 +1157,12 @@ def vmec_compute_geometry(vs, s, theta, phi, phi_center=0):
                  'd_lambda_d_s', 'd_lambda_d_theta_vmec', 'd_lambda_d_phi', 'sqrt_g_vmec', 'sqrt_g_vmec_alt',
                  'modB', 'd_B_d_s', 'd_B_d_theta_vmec', 'd_B_d_phi', 'B_sup_theta_vmec', 'B_sup_theta_pest', 'B_sup_phi',
                  'B_sub_s', 'B_sub_theta_vmec', 'B_sub_phi', 'edge_toroidal_flux_over_2pi', 'sinphi', 'cosphi',
-                 'R', 'd_R_d_s', 'd_R_d_theta_vmec', 'd_R_d_phi', 'Z', 'd_Z_d_s', 'd_Z_d_theta_vmec', 'd_Z_d_phi',
+                 'R', 'd_R_d_s', 'd_R_d_theta_vmec', 'd_R_d_phi', 'X', 'Y', 'Z', 'd_Z_d_s', 'd_Z_d_theta_vmec', 'd_Z_d_phi',
                  'd_X_d_theta_vmec', 'd_X_d_phi', 'd_X_d_s', 'd_Y_d_theta_vmec', 'd_Y_d_phi', 'd_Y_d_s',
                  'grad_s_X', 'grad_s_Y', 'grad_s_Z', 'grad_theta_vmec_X', 'grad_theta_vmec_Y', 'grad_theta_vmec_Z',
                  'grad_phi_X', 'grad_phi_Y', 'grad_phi_Z', 'grad_psi_X', 'grad_psi_Y', 'grad_psi_Z',
                  'grad_alpha_X', 'grad_alpha_Y', 'grad_alpha_Z', 'grad_B_X', 'grad_B_Y', 'grad_B_Z',
-                 'B_X', 'B_Y', 'B_Z',
+                 'B_X', 'B_Y', 'B_Z', "grad_s_dot_grad_s",
                  'B_cross_grad_s_dot_grad_alpha', 'B_cross_grad_s_dot_grad_alpha_alternate',
                  'B_cross_grad_B_dot_grad_alpha', 'B_cross_grad_B_dot_grad_alpha_alternate',
                  'B_cross_grad_B_dot_grad_psi', 'B_cross_kappa_dot_grad_psi', 'B_cross_kappa_dot_grad_alpha',
@@ -1091,86 +1182,39 @@ def vmec_fieldlines(vs, s, alpha, theta1d=None, phi1d=None, phi_center=0, plot=F
     particular, this routine computes the geometric quantities that
     enter the gyrokinetic equation.
 
-    One of the tasks performed by this function is to convert between
+    One task performed by this function is to convert between
     the poloidal angles :math:`\theta_{vmec}` and
     :math:`\theta_{pest}`. The latter is the angle in which the field
     lines are straight when used in combination with the standard
     toroidal angle :math:`\phi`. Note that all angles in this function
     have period :math:`2\pi`, not period 1.
 
-    For the inputs and outputs of this function, a field line label
-    coordinate is defined by
-
-    .. math::
-
-        \alpha = \theta_{pest} - \iota (\phi - \phi_{center}).
-
-    Here, :math:`\phi_{center}` is a constant, usually 0, which can be
-    set to a nonzero value if desired so the magnetic shear
-    contribution to :math:`\nabla\alpha` vanishes at a toroidal angle
-    different than 0.  Also, wherever the term ``psi`` appears in
-    variable names in this function and the returned arrays, it means
-    :math:`\psi =` the toroidal flux divided by :math:`2\pi`, so
-
-    .. math::
-
-        \vec{B} = \nabla\psi\times\nabla\theta_{pest} + \iota\nabla\phi\times\nabla\psi = \nabla\psi\times\nabla\alpha.
-
     To specify the parallel extent of the field lines, you can provide
     either a grid of :math:`\theta_{pest}` values or a grid of
     :math:`\phi` values. If you specify both or neither, ``ValueError``
     will be raised.
 
-    Most of the arrays that are computed have shape ``(ns, nalpha,
-    nl)``, where ``ns`` is the number of flux surfaces, ``nalpha`` is the
-    number of field lines on each flux surface, and ``nl`` is the number
-    of grid points along each field line. In other words, ``ns`` is the
-    size of the input ``s`` array, ``nalpha`` is the size of the input
-    ``alpha`` array, and ``nl`` is the size of the input ``theta1d`` or
-    ``phi1d`` array. The output arrays are returned as attributes of the
-    returned object. Many intermediate quantities are included, such
-    as the Cartesian components of the covariant and contravariant
-    basis vectors. Some of the most useful of these output arrays are (all with SI units):
+    The geometric quanties computed by this function are the same as for
+    :func:`vmec_compute_geometry()`. See the documentation of that
+    function for details.
 
-    - ``phi``: The standard toroidal angle :math:`\phi`.
-    - ``theta_vmec``: VMEC's poloidal angle :math:`\theta_{vmec}`.
-    - ``theta_pest``: The straight-field-line angle :math:`\theta_{pest}` associated with :math:`\phi`.
-    - ``modB``: The magnetic field magnitude :math:`|B|`.
-    - ``B_sup_theta_vmec``: :math:`\vec{B}\cdot\nabla\theta_{vmec}`.
-    - ``B_sup_phi``: :math:`\vec{B}\cdot\nabla\phi`.
-    - ``B_cross_grad_B_dot_grad_alpha``: :math:`\vec{B}\times\nabla|B|\cdot\nabla\alpha`.
-    - ``B_cross_grad_B_dot_grad_psi``: :math:`\vec{B}\times\nabla|B|\cdot\nabla\psi`.
-    - ``B_cross_kappa_dot_grad_alpha``: :math:`\vec{B}\times\vec{\kappa}\cdot\nabla\alpha`,
-      where :math:`\vec{\kappa}=\vec{b}\cdot\nabla\vec{b}` is the curvature and :math:`\vec{b}=|B|^{-1}\vec{B}`.
-    - ``B_cross_kappa_dot_grad_psi``: :math:`\vec{B}\times\vec{\kappa}\cdot\nabla\psi`.
-    - ``grad_alpha_dot_grad_alpha``: :math:`|\nabla\alpha|^2 = \nabla\alpha\cdot\nabla\alpha`.
-    - ``grad_alpha_dot_grad_psi``: :math:`\nabla\alpha\cdot\nabla\psi`.
-    - ``grad_psi_dot_grad_psi``: :math:`|\nabla\psi|^2 = \nabla\psi\cdot\nabla\psi`.
-    - ``iota``: The rotational transform :math:`\iota`. This array has shape ``(ns,)``.
-    - ``shat``: The magnetic shear :math:`\hat s= (x/q) (d q / d x)` where 
-      :math:`x = \mathrm{Aminor_p} \, \sqrt{s}` and :math:`q=1/\iota`. This array has shape ``(ns,)``.
-
-    The following normalized versions of these quantities used in the
-    gyrokinetic codes ``stella``, ``gs2``, and ``GX`` are also
-    returned: ``bmag``, ``gbdrift``, ``gbdrift0``, ``cvdrift``,
-    ``cvdrift0``, ``gds2``, ``gds21``, and ``gds22``, along with
-    ``L_reference`` and ``B_reference``.  Instead of ``gradpar``, two
-    variants are returned, ``gradpar_theta_pest`` and ``gradpar_phi``,
-    corresponding to choosing either :math:`\theta_{pest}` or
-    :math:`\phi` as the parallel coordinate.
+    Most of the arrays that are returned by this function have shape
+    ``(ns, nalpha, nl)``, where ``ns`` is the number of flux surfaces,
+    ``nalpha`` is the number of field lines on each flux surface, and
+    ``nl`` is the number of grid points along each field line. In
+    other words, ``ns`` is the size of the input ``s`` array,
+    ``nalpha`` is the size of the input ``alpha`` array, and ``nl`` is
+    the size of the input ``theta1d`` or ``phi1d`` array. The output
+    arrays are returned as attributes of the returned object.
 
     The value(s) of ``s`` provided as input need not coincide with the
     full grid or half grid in VMEC, as spline interpolation will be
     used radially.
 
-    The implementation in this routine is similar to the one in the
-    gyrokinetic code ``stella``.
-
     Example usage::
 
         import numpy as np
-        from simsopt.mhd.vmec import Vmec
-        from simsopt.mhd.vmec_diagnostics import vmec_fieldlines
+        from simsopt.mhd import Vmec, vmec_fieldlines
 
         v = Vmec('wout_li383_1.4m.nc')
         theta = np.linspace(-np.pi, np.pi, 50)

--- a/tests/mhd/test_vmec_diagnostics.py
+++ b/tests/mhd/test_vmec_diagnostics.py
@@ -454,6 +454,32 @@ class VmecComputeGeometryTests(unittest.TestCase):
         for v in variables:
             np.testing.assert_allclose(eval("results1." + v), eval("results2." + v))
 
+    def test_compare_to_desc(self):
+        """
+        Compare some values to an independent calculation in desc.
+        """
+        vmec = Vmec(os.path.join(TEST_DIR, "wout_LandremanPaul2021_QA_lowres.nc"))
+
+        s = [0.25, 1.0]
+        ntheta = 4
+        nphi = 5
+        theta = np.linspace(0, 2 * np.pi, ntheta, endpoint=False)
+        phi = np.linspace(0, 2 * np.pi / vmec.wout.nfp, nphi, endpoint=False)
+
+        simsopt_data = vmec_compute_geometry(vmec, s, theta, phi)
+
+        desc_data = np.zeros((len(s), ntheta, nphi))
+        desc_data[0, :, :] = np.array([[0.0232505427, 0.0136928264, 0.0045250425, 0.0045250425, 0.0136928264],
+                                       [0.001595767, 0.006868957, 0.0126580432, 0.0124698027, 0.0069361438],
+                                       [0.0418344846, 0.0234485798, 0.0058187257, 0.0058187257, 0.0234485798],
+                                       [0.001595767, 0.0069361438, 0.0124698027, 0.0126580432, 0.006868957]])
+        desc_data[1, :, :] = np.array([[0.0682776505, 0.0419440941, 0.0159952307, 0.0159952307, 0.0419440941],
+                                       [0.006650641, 0.0301276863, 0.0552814479, 0.0525678846, 0.0244553647],
+                                       [0.2151059496, 0.1238328858, 0.0297237057, 0.0297237057, 0.1238328858],
+                                       [0.006650641, 0.0244553647, 0.0525678846, 0.0552814479, 0.0301276863]])
+
+        np.testing.assert_allclose(simsopt_data.grad_psi_dot_grad_psi, desc_data, rtol=0.005, atol=0.0005)
+
 
 class VmecFieldlinesTests(unittest.TestCase):
     def test_fieldline_grids(self):


### PR DESCRIPTION
In this pull request, some of the calculations inside `vmec_fieldlines()` are separated out into a new function `vmec_compute_geometry()`. This new function can be called to get geometric quantities of interest on grids that are not grids along a field line. In particular, you can now get the geometric quantities on a tensor product grid in (theta, phi). The main purpose of `vmec_fieldlines()` is now just the root-finding problem (solving for theta_vmec along a field line), with all the other geometry calculations delegated to `vmec_compute_geometry()`. Users of `vmec_fieldlines()` will not notice any changes - all results of that function are identical to before.