### PR TITLE
Updated pypa/gh-action-pypi-publish from master to release/v1

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -107,7 +107,7 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
At the last release, [the wheel CI](https://github.com/hiddenSymmetries/simsopt/actions/runs/3210554344) gave this warning:
<img width="906" alt="image" src="https://user-images.githubusercontent.com/5229699/194930937-12f13e74-81b9-4bfd-87a1-d522c0a87368.png">
(which I think is unrelated to the CI failure). This PR addresses the warning.