### PR TITLE
Update Github Actions Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
 
     - name: Upload coverage to github
       if: contains(matrix.test-type, 'unit')
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: tox-gh-actions-coverage
         path: coverage.xml
@@ -213,7 +213,7 @@ jobs:
     - name: Upload coverage to Codecov
       # The last conditional on the next line prevents github from trying to upload to Codecov on forks of the repository, avoiding a permissions error
       if: contains(matrix.test-type, 'unit') && github.repository_owner == 'hiddenSymmetries'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y build-essential gfortran openmpi-bin libopenmpi-dev libnetcdf-dev libnetcdff-dev liblapack-dev libscalapack-mpi-dev libhdf5-dev libhdf5-serial-dev git m4 libfftw3-dev libboost-all-dev libopenblas-dev
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Fetch all history for all tags
       run: git fetch --all --tags --prune --unshallow
 
-    # We must run actions/checkout@v2 before downloading and building VMEC, since checkout deletes the contents of the directory.
+    # We must run actions/checkout@v3 before downloading and building VMEC, since checkout deletes the contents of the directory.
     - name: Download the VMEC2000 standalone repository
       run: git clone --depth=1 https://github.com/hiddensymmetries/VMEC2000.git
 
@@ -100,7 +100,7 @@ jobs:
     # https://stackoverflow.com/questions/57612428/cloning-private-github-repository-within-organisation-in-actions
     # https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token
     - name: Check out SPEC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: PrincetonUniversity/SPEC
         path: SPEC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         pwd
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -26,7 +26,7 @@ jobs:
         shell: "bash -l {0}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -34,7 +34,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Get conda
-        uses: conda-incubator/setup-miniconda@v2.1.1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,10 +23,10 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: medbha
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
       
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         if: ${{ startsWith(github.ref, 'refs/heads') && github.ref == 'refs/heads/master' }}
         with:
           context: ci
@@ -50,7 +50,7 @@ jobs:
           tags: hiddensymmetries/simsopt:latest
 
       - name: Build  for branches
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         if: ${{ startsWith(github.ref, 'refs/heads') && github.ref != 'refs/heads/master' }}
         with:
           context: ci
@@ -59,7 +59,7 @@ jobs:
           tags: hiddensymmetries/simsopt:test
 
       - name: Build and push for tag
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         if: startsWith(github.event.ref, 'refs/tags/v')
         with:
           context: ci

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Fetch all history for all tags and branches
         run: git fetch --prune --unshallow

--- a/.github/workflows/extensive_ci.yml
+++ b/.github/workflows/extensive_ci.yml
@@ -80,7 +80,7 @@ jobs:
         pwd
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/extensive_ci.yml
+++ b/.github/workflows/extensive_ci.yml
@@ -239,7 +239,7 @@ jobs:
         if-no-files-found: error
 
   coverage:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: [ test ]
     steps:
 

--- a/.github/workflows/extensive_ci.yml
+++ b/.github/workflows/extensive_ci.yml
@@ -232,7 +232,7 @@ jobs:
 
     - name: Upload uncombined coverage to github
       if: contains(matrix.test-type, 'unit')
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: gh-actions-parallel-coverage
         path: .coverage.*
@@ -244,7 +244,7 @@ jobs:
     steps:
 
     - name: Set up Python 
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.8.13
 
@@ -258,7 +258,7 @@ jobs:
       run: pip install .
 
     - name: Download artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: gh-actions-parallel-coverage
         path: ./
@@ -273,7 +273,7 @@ jobs:
         coverage xml
 
     - name: Upload coverage to github
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: tox-gh-actions-coverage
         path: coverage.xml
@@ -282,7 +282,7 @@ jobs:
     - name: Upload coverage to Codecov
       # The next line prevents github from trying to upload to Codecov on forks of the repository, avoiding a permissions error
       if: github.repository_owner == 'hiddenSymmetries'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/.github/workflows/extensive_ci.yml
+++ b/.github/workflows/extensive_ci.yml
@@ -63,12 +63,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y build-essential gfortran openmpi-bin libopenmpi-dev libnetcdf-dev libnetcdff-dev liblapack-dev libscalapack-mpi-dev libhdf5-dev libhdf5-serial-dev git m4 libfftw3-dev libopenblas-dev libboost-all-dev
     
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       # If we want submodules downloaded, uncomment the next 2 lines:
       #with:
       #  submodules: true
 
-    # We must run actions/checkout@v2 before downloading and building VMEC, since checkout deletes the contents of the directory.
+    # We must run actions/checkout@v3 before downloading and building VMEC, since checkout deletes the contents of the directory.
     - name: Download the VMEC2000 standalone repository
       if: contains(matrix.packages, 'vmec') || contains(matrix.packages, 'all')
       run: git clone https://github.com/hiddensymmetries/VMEC2000.git
@@ -112,7 +112,7 @@ jobs:
     # https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token
     - name: Check out SPEC
       if: contains(matrix.packages, 'spec') || contains(matrix.packages, 'all')
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: PrincetonUniversity/SPEC
         path: SPEC
@@ -252,7 +252,7 @@ jobs:
       run: pip install coverage
 
     - name: Checkout simsopt 
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install simsopt before running coverage
       run: pip install .

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -26,7 +26,7 @@ jobs:
         test-type: [linting]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       # If we want submodules downloaded, uncomment the next 2 lines:
       #with:
       #  submodules: true

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -32,7 +32,7 @@ jobs:
       #  submodules: true
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,7 +13,7 @@ on: [push, pull_request]
 
 jobs:
   CI:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     env:
       OMPI_ALLOW_RUN_AS_ROOT: 1

--- a/.github/workflows/singularity.yml
+++ b/.github/workflows/singularity.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
 
       - name: Check out code for the container build
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: eWaterCycle/setup-singularity@v7
         with:
           singularity-version: 3.8.3

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -27,7 +27,7 @@ jobs:
           CIBW_DEPENDENCY_VERSIONS: latest
           CIBW_BEFORE_BUILD_LINUX: pip install --upgrade pip setuptools wheel numpy cmake ninja setuptools_scm[toml]
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -62,7 +62,7 @@ jobs:
           python -m pip wheel -w wheel --no-deps .
           delocate-wheel --require-archs x86_64 -w ./wheelhouse ./wheel/simsopt*.whl
          
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -90,7 +90,7 @@ jobs:
       - name: Build sdist
         run: python -m build -s -o dist .
         
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -102,7 +102,7 @@ jobs:
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -47,7 +47,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
 
@@ -76,7 +76,7 @@ jobs:
       - name: Fetch all history for all tags
         run: git fetch --prune --unshallow
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         name: Install Python
         with:
           python-version: '3.8'

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Fetch all history for all tags
         run: git fetch --prune --unshallow
@@ -41,7 +41,7 @@ jobs:
         python: [3.7, 3.8, 3.9, "3.10"]
         os: [macos-11, macos-12]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Fetch all history for all tags
         run: git fetch --prune --unshallow
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Fetch all history for all tags
         run: git fetch --prune --unshallow


### PR DESCRIPTION
The github actions we use are dependent on node.js v12, which has been deprecated and going out of service sometime in 2023. In this PR, the actions are updated to use node.js v16, the current default.