### PR TITLE
Updated workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Step to get tag name
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       
       - name: Build and push
         uses: docker/build-push-action@v3

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build_wheels:
-    name: Build wheels on ubuntu
+    name: Build wheels on ${{ matrix.os }}
     # runs-on: ubuntu-latest
     runs-on: ${{ matrix.os }}
     strategy:
@@ -21,8 +21,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.4
         # to supply options, put them in 'env', like:
         env:
-          # Only build for python 3.{7,8,9,10,11}
-          CIBW_BUILD : cp37-* cp38-* cp39-* cp310-* cp311-*
+          # Only build for python 3.{7,8,9,10}
+          CIBW_BUILD : cp37-* cp38-* cp39-* cp310-*
           # Supports only x86_64 arch for linux
           CIBW_ARCHS_LINUX: x86_64
           # Use manylinux2014

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -5,7 +5,6 @@ on: [push, pull_request]
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
-    # runs-on: ubuntu-latest
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -19,57 +18,19 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.4
-        # to supply options, put them in 'env', like:
+        # To supply options, put them in 'env'
         env:
           # Only build for python 3.{7,8,9,10}
           CIBW_BUILD : cp37-* cp38-* cp39-* cp310-*
           # Supports only x86_64 arch for linux
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_MACOS: "x86_64 arm64"
-          # Use manylinux2014
-          #CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_SKIP: cp27-* cp36-*
           CIBW_DEPENDENCY_VERSIONS: latest
-          # CIBW_BEFORE_BUILD: pip install --upgrade pip setuptools wheel numpy cmake ninja setuptools_scm[toml]
 
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-
-
-  # Alternate setup for mac_wheel because cibuildwheel is failing for mac
-#  mac_wheels:
-#    name: Build wheels on mac 
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      matrix:
-#        python: [3.7, 3.8, 3.9, "3.10"]
-#        os: [macos-11, macos-12]
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: Fetch all history for all tags
-#        run: git fetch --prune --unshallow
-#
-#      - name: Set up Python
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: ${{ matrix.python }}
-#
-#      - name: Upgrade pip
-#        run: python -m pip install --upgrade pip 
-#
-#      - name: Install wheel builder packages 
-#        run: python -m pip install setuptools wheel delocate
-#
-#      - name: Build and repair wheels
-#        run: |
-#          python -m pip wheel -w wheel --no-deps .
-#          delocate-wheel --require-archs x86_64 -w ./wheelhouse ./wheel/simsopt*.whl
-#         
-#      - uses: actions/upload-artifact@v3
-#        with:
-#          path: ./wheelhouse/*.whl
 
   build_sdist:
     name: Build source distribution
@@ -100,7 +61,6 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
-    # needs: [linux_wheels, mac_wheels, build_sdist]
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'v'

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -25,6 +25,7 @@ jobs:
           CIBW_BUILD : cp37-* cp38-* cp39-* cp310-*
           # Supports only x86_64 arch for linux
           CIBW_ARCHS_LINUX: x86_64
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
           # Use manylinux2014
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_SKIP: cp27-* cp36-*

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -3,7 +3,7 @@ name: Wheel Builder
 on: [push, pull_request]
 
 jobs:
-  linux_wheels:
+  build_wheels:
     name: Build wheels on ubuntu
     # runs-on: ubuntu-latest
     runs-on: ${{ matrix.os }}
@@ -99,7 +99,8 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
-    needs: [linux_wheels, mac_wheels, build_sdist]
+    # needs: [linux_wheels, mac_wheels, build_sdist]
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -29,7 +29,7 @@ jobs:
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_SKIP: cp27-* cp36-*
           CIBW_DEPENDENCY_VERSIONS: latest
-          CIBW_BEFORE_BUILD: pip install --upgrade pip setuptools wheel numpy cmake ninja setuptools_scm[toml]
+          # CIBW_BEFORE_BUILD: pip install --upgrade pip setuptools wheel numpy cmake ninja setuptools_scm[toml]
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -27,9 +27,9 @@ jobs:
           CIBW_ARCHS_LINUX: x86_64
           # Use manylinux2014
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_SKIP: cp27-*
+          CIBW_SKIP: cp27-* cp36-*
           CIBW_DEPENDENCY_VERSIONS: latest
-          # CIBW_BEFORE_BUILD: pip install --upgrade pip setuptools wheel numpy cmake ninja setuptools_scm[toml]
+          CIBW_BEFORE_BUILD: pip install --upgrade pip setuptools wheel numpy cmake ninja setuptools_scm[toml]
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, macos-12, ubuntu-20.04]
+        os: [macos-11, ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -5,7 +5,11 @@ on: [push, pull_request]
 jobs:
   linux_wheels:
     name: Build wheels on ubuntu
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-11, macos-12, ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3
@@ -14,18 +18,18 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Build wheels
-        uses: joerick/cibuildwheel@v1.9.0
+        uses: pypa/cibuildwheel@v2.11.4
         # to supply options, put them in 'env', like:
         env:
-          # Only build for python 3.{7,8,9}
-          CIBW_BUILD : cp37-* cp38-* cp39-* cp310-*
+          # Only build for python 3.{7,8,9,10,11}
+          CIBW_BUILD : cp37-* cp38-* cp39-* cp310-* cp311-*
           # Supports only x86_64 arch for linux
           CIBW_ARCHS_LINUX: x86_64
           # Use manylinux2014
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_SKIP: cp27-*
           CIBW_DEPENDENCY_VERSIONS: latest
-          CIBW_BEFORE_BUILD_LINUX: pip install --upgrade pip setuptools wheel numpy cmake ninja setuptools_scm[toml]
+          # CIBW_BEFORE_BUILD: pip install --upgrade pip setuptools wheel numpy cmake ninja setuptools_scm[toml]
 
       - uses: actions/upload-artifact@v3
         with:
@@ -33,38 +37,38 @@ jobs:
 
 
   # Alternate setup for mac_wheel because cibuildwheel is failing for mac
-  mac_wheels:
-    name: Build wheels on mac 
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python: [3.7, 3.8, 3.9, "3.10"]
-        os: [macos-11, macos-12]
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Fetch all history for all tags
-        run: git fetch --prune --unshallow
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
-
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip 
-
-      - name: Install wheel builder packages 
-        run: python -m pip install setuptools wheel delocate
-
-      - name: Build and repair wheels
-        run: |
-          python -m pip wheel -w wheel --no-deps .
-          delocate-wheel --require-archs x86_64 -w ./wheelhouse ./wheel/simsopt*.whl
-         
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./wheelhouse/*.whl
+#  mac_wheels:
+#    name: Build wheels on mac 
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      matrix:
+#        python: [3.7, 3.8, 3.9, "3.10"]
+#        os: [macos-11, macos-12]
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: Fetch all history for all tags
+#        run: git fetch --prune --unshallow
+#
+#      - name: Set up Python
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: ${{ matrix.python }}
+#
+#      - name: Upgrade pip
+#        run: python -m pip install --upgrade pip 
+#
+#      - name: Install wheel builder packages 
+#        run: python -m pip install setuptools wheel delocate
+#
+#      - name: Build and repair wheels
+#        run: |
+#          python -m pip wheel -w wheel --no-deps .
+#          delocate-wheel --require-archs x86_64 -w ./wheelhouse ./wheel/simsopt*.whl
+#         
+#      - uses: actions/upload-artifact@v3
+#        with:
+#          path: ./wheelhouse/*.whl
 
   build_sdist:
     name: Build source distribution


### PR DESCRIPTION
Mac wheel building is updated to use `cibuildwheel`. `cibuildwheel` version is upgraded to the latest. Support for arm64 arch added for macOS.