### PR TITLE
Adds netcdf4 support

### DIFF
--- a/src/simsopt/geo/surfaceobjectives.py
+++ b/src/simsopt/geo/surfaceobjectives.py
@@ -77,7 +77,7 @@ class Volume(Optimizable):
             self.surface = in_surface
 
         super().__init__(depends_on=[self.surface])
-    
+
     def J(self):
         """
         Compute the volume enclosed by the surface.
@@ -126,7 +126,7 @@ class ToroidalFlux(Optimizable):
             self.surface = surface
         else:
             self.surface = in_surface
-        
+
         self.biotsavart = biotsavart
         self.idx = idx
         super().__init__(depends_on=[self.surface, biotsavart])

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -1,7 +1,6 @@
 import logging
 
 import numpy as np
-from scipy.io import netcdf_file
 from scipy.interpolate import interp1d
 import f90nml
 

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -7,6 +7,7 @@ import f90nml
 
 import simsoptpp as sopp
 from .surface import Surface
+from ..util.netcdf import netcdf_file
 from .._core.optimizable import DOFs, Optimizable
 from .._core.util import nested_lists_to_array
 from .._core.json import GSONDecoder

--- a/src/simsopt/mhd/virtual_casing.py
+++ b/src/simsopt/mhd/virtual_casing.py
@@ -18,8 +18,8 @@ import logging
 from datetime import datetime
 
 import numpy as np
-from scipy.io import netcdf_file
 
+from ..util.netcdf import netcdf_file
 from .vmec_diagnostics import B_cartesian
 from .vmec import Vmec
 from ..geo.surfacerzfourier import SurfaceRZFourier

--- a/src/simsopt/mhd/vmec.py
+++ b/src/simsopt/mhd/vmec.py
@@ -12,7 +12,6 @@ from typing import Union
 from datetime import datetime
 
 import numpy as np
-from scipy.io import netcdf_file
 from scipy.integrate import quad
 
 logger = logging.getLogger(__name__)
@@ -29,6 +28,7 @@ except ImportError as e:
     vmec = None
     logger.debug(str(e))
 
+from ..util.netcdf import netcdf_file
 from .._core.optimizable import Optimizable
 from .._core.util import Struct, ObjectiveFailure
 from ..geo.surfacerzfourier import SurfaceRZFourier

--- a/src/simsopt/util/__init__.py
+++ b/src/simsopt/util/__init__.py
@@ -1,4 +1,0 @@
-from .mpi import *
-from .logger import *
-
-__all__ = (mpi.__all__ + logger.__all__)

--- a/src/simsopt/util/netcdf.py
+++ b/src/simsopt/util/netcdf.py
@@ -17,6 +17,8 @@ class NetCDF(Enum):
     netCDF4 = 0
     scipy = 1
 
+logger = logging.getLogger(__name__)
+    
 try:
     from netCDF4 import Dataset
 except ImportError as e:

--- a/src/simsopt/util/netcdf.py
+++ b/src/simsopt/util/netcdf.py
@@ -10,7 +10,6 @@ _all__ = ['netcdf_file']
 
 import logging
 from enum import Enum
-from abc import ABC, abstractmethod
 
 
 class NetCDF(Enum):
@@ -25,52 +24,10 @@ try:
     from netCDF4 import Dataset
 except ImportError as e:
     logger.debug(str(e))
-    try:
-        from scipy.io import netcdf_file as scipy_netcdf_file
-    except ImportError as e:
-        # this error is fatal
-        logger.debug(str(e))
-        raise e
-    else:
-        netcdf = NetCDF.scipy
+    from scipy.io import netcdf_file as scipy_netcdf_file
+    netcdf = NetCDF.scipy
 else:
     netcdf = NetCDF.netCDF4
-
-
-class AbstractNetCDF:
-    """
-    This class is not used, it merely defines the interface that
-    the objects 'netcdf_file' from scipy and 'Dataset' from NetCDF4 
-    both satisfy. 
-    """
-    @abstractmethod
-    def __setattr__(self, attr, value):
-        pass
-
-    @abstractmethod
-    def close(self):
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self.close()
-
-    @abstractmethod
-    def createDimension(self, name, length):
-        pass
-
-    @abstractmethod
-    def createVariable(self, name, type, dimensions):
-        pass
-
-    @abstractmethod
-    def flush(self):
-        pass
-
-    def sync(self):
-        self.flush()
 
 
 def netcdf_file(filename, mode='r', mmap=None, format='NETCDF3_CLASSIC'):

--- a/src/simsopt/util/netcdf.py
+++ b/src/simsopt/util/netcdf.py
@@ -31,11 +31,22 @@ else:
 
 
 def netcdf_file(filename, mode='r', mmap=None, format='NETCDF3_CLASSIC'):
-    """Wrapper around scipy.io's netcdf_file or Dataset from NetCDF4."""
+    r"""
+    Wrapper that initializes and returns a scipy.io's netcdf_file or Dataset from NetCDF4.
+    See  `scipy.io.netcdf_file <https://docs.scipy.org/doc/scipy/reference/generated/scipy.io.netcdf_file.html#scipy.io.netcdf_file>`_.
+    The output object should satisfy the interface of the object returned by scipy.io.netcdf_file, with methods: close(), flush(), sync(), createDimension(name, length), createVariable(name, type, dimensions), __enter__(), __exit__().
+
+    Args:
+        filename : string or file-like. File to read or write from or to.
+        mode: {'r', 'w', 'a'}. read ('r'), write ('w') or append ('a') mode. Default: 'r'
+        mmap: None or bool. Whether to mmap when reading the file.
+        format: {1, 2, 'NETCDF3_CLASSIC', 'NETCDF3_64BIT_OFFSET'). Netcdf format. Only used when mode='w'.
+
+    """
     if netcdf == NetCDF.scipy:
-        if format == 'NETCDF3_CLASSIC':
+        if (format == 'NETCDF3_CLASSIC') or (format == 1):
             version = 1
-        elif format == 'NETCDF3_64BIT_OFFSET':
+        elif (format == 'NETCDF3_64BIT_OFFSET') or (format == 2):
             version = 2
         else:
             raise ValueError('scipy.io netcdf_file only supports "NETCDF3_CLASSIC" or "NETCDF3_64BIT_OFFSET" formats.')

--- a/src/simsopt/util/netcdf.py
+++ b/src/simsopt/util/netcdf.py
@@ -12,13 +12,15 @@ import logging
 from enum import Enum
 from abc import ABC, abstractmethod
 
+
 class NetCDF(Enum):
     """Supported netCDF libraries."""
     netCDF4 = 0
     scipy = 1
 
+
 logger = logging.getLogger(__name__)
-    
+
 try:
     from netCDF4 import Dataset
 except ImportError as e:
@@ -33,6 +35,7 @@ except ImportError as e:
         netcdf = NetCDF.scipy
 else:
     netcdf = NetCDF.netCDF4
+
 
 class AbstractNetCDF:
     """
@@ -70,7 +73,7 @@ class AbstractNetCDF:
         self.flush()
 
 
-def netcdf_file(filename, mode='r', mmap=None, format ='NETCDF3_CLASSIC'):
+def netcdf_file(filename, mode='r', mmap=None, format='NETCDF3_CLASSIC'):
     """Wrapper around scipy.io's netcdf_file or Dataset from NetCDF4."""
     if netcdf == NetCDF.scipy:
         if format == 'NETCDF3_CLASSIC':
@@ -82,6 +85,6 @@ def netcdf_file(filename, mode='r', mmap=None, format ='NETCDF3_CLASSIC'):
         ret = scipy_netcdf_file(filename, mode, mmap, version)
 
     elif netcdf == NetCDF.netCDF4:
-        ret =  Dataset(filename, mode, format)
+        ret = Dataset(filename, mode, format)
         ret.set_always_mask(False)
     return ret

--- a/src/simsopt/util/netcdf.py
+++ b/src/simsopt/util/netcdf.py
@@ -1,0 +1,85 @@
+# coding: utf-8
+
+"""
+The purpose of this module is to hide the details of the 
+netCDF library to allow the user to replace scipy.io.netcdf_file 
+with netCDF4's Dataset class if they need netCDF4 support.
+"""
+
+_all__ = ['netcdf_file']
+
+import logging
+from enum import Enum
+from abc import ABC, abstractmethod
+
+class NetCDF(Enum):
+    """Supported netCDF libraries."""
+    netCDF4 = 0
+    scipy = 1
+
+try:
+    from netCDF4 import Dataset
+except ImportError as e:
+    logger.debug(str(e))
+    try:
+        from scipy.io import netcdf_file as scipy_netcdf_file
+    except ImportError as e:
+        # this error is fatal
+        logger.debug(str(e))
+        raise e
+    else:
+        netcdf = NetCDF.scipy
+else:
+    netcdf = NetCDF.netCDF4
+
+class AbstractNetCDF:
+    """
+    This class is not used, it merely defines the interface that
+    the objects 'netcdf_file' from scipy and 'Dataset' from NetCDF4 
+    both satisfy. 
+    """
+    @abstractmethod
+    def __setattr__(self, attr, value):
+        pass
+
+    @abstractmethod
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    @abstractmethod
+    def createDimension(self, name, length):
+        pass
+
+    @abstractmethod
+    def createVariable(self, name, type, dimensions):
+        pass
+
+    @abstractmethod
+    def flush(self):
+        pass
+
+    def sync(self):
+        self.flush()
+
+
+def netcdf_file(filename, mode='r', mmap=None, format ='NETCDF3_CLASSIC'):
+    """Wrapper around scipy.io's netcdf_file or Dataset from NetCDF4."""
+    if netcdf == NetCDF.scipy:
+        if format == 'NETCDF3_CLASSIC':
+            version = 1
+        elif format == 'NETCDF3_64BIT_OFFSET':
+            version = 2
+        else:
+            raise ValueError('scipy.io netcdf_file only supports "NETCDF3_CLASSIC" or "NETCDF3_64BIT_OFFSET" formats.')
+        ret = scipy_netcdf_file(filename, mode, mmap, version)
+
+    elif netcdf == NetCDF.netCDF4:
+        ret =  Dataset(filename, mode, format)
+        ret.set_always_mask(False)
+    return ret

--- a/tests/mhd/test_boozer.py
+++ b/tests/mhd/test_boozer.py
@@ -2,7 +2,6 @@ import unittest
 import numpy as np
 import os
 import logging
-from scipy.io import netcdf_file
 try:
     import booz_xform
 except ImportError as e:
@@ -18,6 +17,7 @@ try:
 except ImportError as e:
     MPI = None
 
+from simsopt.util.netcdf import netcdf_file
 from simsopt._core.optimizable import Optimizable
 if MPI is not None:
     from simsopt.mhd.boozer import Boozer, Quasisymmetry  # , booz_xform_found


### PR DESCRIPTION
scipy.io.netcdf_file cannot read netcdf4 files. It may thus be desirable to allow different netcdf libraries to be used.
This branch adds support for netCDF4 if the user has it installed, using the existing scipy.io.netcdf_file import as a fall-back.
This is achieved using a thin abstraction layer between simsopt and the netcdf library. Since scipy.io netcdf_file implements a subset of the methods of netCDF4's Dataset object, simsopt is already compatible with both, and no wrapper class is needed. The abstract class in util/netcdf.py merely documents this shared interface.

This may solve the problems Tony had with not being able to read certain mgrid files.
As further motivation, gyrokinetic code stella now only supports writing to netcdf4 files, since it uses neasy-f for its netcdf output (https://github.com/PlasmaFAIR/neasy-f). If neasy-f becomes widespread, equilibrium codes may follow suit, and wout files in netcdf4 format could start appearing in the wild.