### PR TITLE
Pybind11 changes

### DIFF
--- a/src/simsoptpp/python_surfaces.cpp
+++ b/src/simsoptpp/python_surfaces.cpp
@@ -175,7 +175,6 @@ void init_surfaces(py::module_ &m){
         .def_readwrite("nfp", &PySurfaceRZFourier::nfp)
         .def_readwrite("stellsym", &PySurfaceRZFourier::stellsym)
         .def("allocate", &PySurfaceRZFourier::allocate);
-    // register_common_surface_methods<PySurfaceRZFourier>(pysurfacerzfourier);
 
     auto pysurfacexyzfourier = py::class_<PySurfaceXYZFourier, shared_ptr<PySurfaceXYZFourier>, PySurfaceXYZFourierTrampoline<PySurfaceXYZFourier>, PySurface>(m, "SurfaceXYZFourier")
         .def(py::init<int, int, int, bool, vector<double>, vector<double>>())
@@ -189,7 +188,6 @@ void init_surfaces(py::module_ &m){
         .def_readwrite("ntor",&PySurfaceXYZFourier::ntor)
         .def_readwrite("nfp", &PySurfaceXYZFourier::nfp)
         .def_readwrite("stellsym", &PySurfaceXYZFourier::stellsym);
-    // register_common_surface_methods<PySurfaceXYZFourier>(pysurfacexyzfourier);
 
     auto pysurfacexyztensorfourier = py::class_<PySurfaceXYZTensorFourier, shared_ptr<PySurfaceXYZTensorFourier>, PySurfaceXYZTensorFourierTrampoline<PySurfaceXYZTensorFourier>, PySurface>(m, "SurfaceXYZTensorFourier")
         .def(py::init<int, int, int, bool, vector<bool>, vector<double>, vector<double>>())
@@ -202,5 +200,4 @@ void init_surfaces(py::module_ &m){
         .def_readwrite("nfp", &PySurfaceXYZTensorFourier::nfp)
         .def_readwrite("stellsym", &PySurfaceXYZTensorFourier::stellsym)
         .def_readwrite("clamped_dims", &PySurfaceXYZTensorFourier::clamped_dims);
-    // register_common_surface_methods<PySurfaceXYZTensorFourier>(pysurfacexyztensorfourier);
 }

--- a/src/simsoptpp/python_surfaces.cpp
+++ b/src/simsoptpp/python_surfaces.cpp
@@ -111,7 +111,6 @@ template <class PySurfaceXYZTensorFourierBase = PySurfaceXYZTensorFourier> class
 
 template <typename T, typename S> void register_common_surface_methods(S &s) {
     s.def("gamma", &T::gamma)
-     .def("gamma_impl", &T::gamma_impl)
      .def("gamma_lin", &T::gamma_lin)
      .def("dgamma_by_dcoeff", &T::dgamma_by_dcoeff)
      .def("dgamma_by_dcoeff_vjp", &T::dgamma_by_dcoeff_vjp)

--- a/src/simsoptpp/python_surfaces.cpp
+++ b/src/simsoptpp/python_surfaces.cpp
@@ -164,7 +164,7 @@ void init_surfaces(py::module_ &m){
         .def(py::init<vector<double>,vector<double>>());
     register_common_surface_methods<PySurface>(pysurface);
 
-    auto pysurfacerzfourier = py::class_<PySurfaceRZFourier, shared_ptr<PySurfaceRZFourier>, PySurfaceRZFourierTrampoline<PySurfaceRZFourier>>(m, "SurfaceRZFourier")
+    auto pysurfacerzfourier = py::class_<PySurfaceRZFourier, shared_ptr<PySurfaceRZFourier>, PySurfaceRZFourierTrampoline<PySurfaceRZFourier>, PySurface>(m, "SurfaceRZFourier")
         .def(py::init<int, int, int, bool, vector<double>, vector<double>>())
         .def_readwrite("rc", &PySurfaceRZFourier::rc)
         .def_readwrite("rs", &PySurfaceRZFourier::rs)
@@ -175,9 +175,9 @@ void init_surfaces(py::module_ &m){
         .def_readwrite("nfp", &PySurfaceRZFourier::nfp)
         .def_readwrite("stellsym", &PySurfaceRZFourier::stellsym)
         .def("allocate", &PySurfaceRZFourier::allocate);
-    register_common_surface_methods<PySurfaceRZFourier>(pysurfacerzfourier);
+    // register_common_surface_methods<PySurfaceRZFourier>(pysurfacerzfourier);
 
-    auto pysurfacexyzfourier = py::class_<PySurfaceXYZFourier, shared_ptr<PySurfaceXYZFourier>, PySurfaceXYZFourierTrampoline<PySurfaceXYZFourier>>(m, "SurfaceXYZFourier")
+    auto pysurfacexyzfourier = py::class_<PySurfaceXYZFourier, shared_ptr<PySurfaceXYZFourier>, PySurfaceXYZFourierTrampoline<PySurfaceXYZFourier>, PySurface>(m, "SurfaceXYZFourier")
         .def(py::init<int, int, int, bool, vector<double>, vector<double>>())
         .def_readwrite("xc", &PySurfaceXYZFourier::xc)
         .def_readwrite("xs", &PySurfaceXYZFourier::xs)
@@ -189,9 +189,9 @@ void init_surfaces(py::module_ &m){
         .def_readwrite("ntor",&PySurfaceXYZFourier::ntor)
         .def_readwrite("nfp", &PySurfaceXYZFourier::nfp)
         .def_readwrite("stellsym", &PySurfaceXYZFourier::stellsym);
-    register_common_surface_methods<PySurfaceXYZFourier>(pysurfacexyzfourier);
+    // register_common_surface_methods<PySurfaceXYZFourier>(pysurfacexyzfourier);
 
-    auto pysurfacexyztensorfourier = py::class_<PySurfaceXYZTensorFourier, shared_ptr<PySurfaceXYZTensorFourier>, PySurfaceXYZTensorFourierTrampoline<PySurfaceXYZTensorFourier>>(m, "SurfaceXYZTensorFourier")
+    auto pysurfacexyztensorfourier = py::class_<PySurfaceXYZTensorFourier, shared_ptr<PySurfaceXYZTensorFourier>, PySurfaceXYZTensorFourierTrampoline<PySurfaceXYZTensorFourier>, PySurface>(m, "SurfaceXYZTensorFourier")
         .def(py::init<int, int, int, bool, vector<bool>, vector<double>, vector<double>>())
         .def_readwrite("xcs", &PySurfaceXYZTensorFourier::x)
         .def_readwrite("ycs", &PySurfaceXYZTensorFourier::y)
@@ -202,5 +202,5 @@ void init_surfaces(py::module_ &m){
         .def_readwrite("nfp", &PySurfaceXYZTensorFourier::nfp)
         .def_readwrite("stellsym", &PySurfaceXYZTensorFourier::stellsym)
         .def_readwrite("clamped_dims", &PySurfaceXYZTensorFourier::clamped_dims);
-    register_common_surface_methods<PySurfaceXYZTensorFourier>(pysurfacexyztensorfourier);
+    // register_common_surface_methods<PySurfaceXYZTensorFourier>(pysurfacexyztensorfourier);
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,6 +8,24 @@ The layout of the subfolders within **tests** nearly mimics that of the simsopt 
 
 ## Running tests
 
+### With unittest 
+
 To run the tests, you must first install simsopt with `pip install .` from the main simsopt directory.
 Then, change to the `tests` directory, and run `python -m unittest` to run all tests.
+
+To run unittests only in one folder, for example, `geo`, run `python -m unittest -t . -s geo`.
+
+To run unittests only in one file for example `geo/test_surface.py", run `python -m unittest geo.test_surface`.
+
+To run only a single suite of unittests such as `QuadpointsTests` in `geo/test_surface.py` run `python -m unittest geo.test_surface.QuadpointsTests`
+
+In this fashion, we can run only a single unit test: `python -m unittest geo.test_surface.QuadpointsTests.test_theta`.
+
 See the [python unittest documentation](https://docs.python.org/3/library/unittest.html) for more options.
+
+
+### Parallel testing with pytest
+
+Requires installing pytest-xdist or pytest-parallel.  Install either of them with pip. With pytest-xdist, run `pytest -n auto geo` to run all tests in the `geo` folder in parallel. With pytest-parallel run `pytest --workers <N> geo`, where <N> is the number of cores you want to use.
+
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,6 +26,4 @@ See the [python unittest documentation](https://docs.python.org/3/library/unitte
 
 ### Parallel testing with pytest
 
-Requires installing pytest-xdist or pytest-parallel.  Install either of them with pip. With pytest-xdist, run `pytest -n auto geo` to run all tests in the `geo` folder in parallel. With pytest-parallel run `pytest --workers <N> geo`, where <N> is the number of cores you want to use.
-
-
+Requires installing pytest along with pytest-xdist or pytest-parallel.  Install either of them with pip. With pytest-xdist, run `pytest -n <N> geo` to run all tests in the `geo` folder in parallel. For pytest-parallel, use `pytest --workers <N> geo`. Here <N> is the number of cores you want to use. In place of a specific number for <N>, use `auto` to automatically use all the avaialable cores in the machine.


### PR DESCRIPTION
When implementing SurfaceNewQuadPoints class, I noticed that some of the pybind11 code is not canonical. Minor change, but properly captures the underlying inheritance and polymorphism.