### PR TITLE
ag/minor bug fixes and changes

### DIFF
--- a/src/simsopt/geo/surfacexyztensorfourier.py
+++ b/src/simsopt/geo/surfacexyztensorfourier.py
@@ -166,7 +166,4 @@ class SurfaceXYZTensorFourier(sopp.SurfaceXYZTensorFourier, Surface):
         if npsame(phis, np.linspace(0, 1/(2*self.nfp), ntor+1, endpoint=False)) and \
                 npsame(thetas, np.linspace(0, 1, 2*mpol+1, endpoint=False)):
             mask[0, mpol+1:] = False
-        if npsame(phis, np.linspace(0, 1/self.nfp, 2*ntor+1, endpoint=False)[:ntor+1]) and \
-                npsame(thetas, np.linspace(0, 1, 2*mpol+1, endpoint=False)):
-            mask[0, mpol+1:] = False
         return mask

--- a/src/simsopt/geo/surfacexyztensorfourier.py
+++ b/src/simsopt/geo/surfacexyztensorfourier.py
@@ -99,13 +99,20 @@ class SurfaceXYZTensorFourier(sopp.SurfaceXYZTensorFourier, Surface):
         Return a SurfaceRZFourier instance corresponding to the shape of this
         surface.
         """
-        surf = SurfaceRZFourier(self.mpol, self.ntor, self.nfp, self.stellsym,
-                                self.quadpoints_phi, self.quadpoints_theta)
+        ntor = self.ntor
+        mpol = self.mpol 
+        surf = SurfaceRZFourier(nfp=self.nfp, 
+                                stellsym=self.stellsym, 
+                                mpol=mpol, 
+                                ntor=ntor, 
+                                quadpoints_phi=self.quadpoints_phi, 
+                                quadpoints_theta=self.quadpoints_theta)
+
         gamma = np.zeros((surf.quadpoints_phi.size, surf.quadpoints_theta.size, 3))
         for idx in range(gamma.shape[0]):
-            gamma[idx, :, :] = self.cross_section(
-                surf.quadpoints_phi[idx]*2*np.pi)
-        surf.least_squares_fit(self.gamma())
+            gamma[idx, :, :] = self.cross_section(surf.quadpoints_phi[idx]*2*np.pi)
+
+        surf.least_squares_fit(gamma)
         return surf
 
     def get_stellsym_mask(self):
@@ -157,6 +164,9 @@ class SurfaceXYZTensorFourier(sopp.SurfaceXYZTensorFourier, Surface):
                 npsame(thetas, np.linspace(0, 0.5, mpol+1, endpoint=False)):
             mask[ntor+1:, 0] = False
         if npsame(phis, np.linspace(0, 1/(2*self.nfp), ntor+1, endpoint=False)) and \
+                npsame(thetas, np.linspace(0, 1, 2*mpol+1, endpoint=False)):
+            mask[0, mpol+1:] = False
+        if npsame(phis, np.linspace(0, 1/self.nfp, 2*ntor+1, endpoint=False)[:ntor+1]) and \
                 npsame(thetas, np.linspace(0, 1, 2*mpol+1, endpoint=False)):
             mask[0, mpol+1:] = False
         return mask

--- a/tests/geo/surface_test_helpers.py
+++ b/tests/geo/surface_test_helpers.py
@@ -66,7 +66,7 @@ def get_exact_surface(surface_type='SurfaceXYZFourier'):
                               quadpoints_phi=phis, quadpoints_theta=thetas)
     elif surface_type == 'SurfaceXYZTensorFourier':
         s = SurfaceXYZTensorFourier(mpol=mpol, ntor=ntor, nfp=nfp, stellsym=stellsym,
-                              quadpoints_phi=phis, quadpoints_theta=thetas)
+                                    quadpoints_phi=phis, quadpoints_theta=thetas)
     else:
         raise Exception("surface type not implemented")
     s.least_squares_fit(xyz)

--- a/tests/geo/surface_test_helpers.py
+++ b/tests/geo/surface_test_helpers.py
@@ -39,7 +39,7 @@ def get_surface(surfacetype, stellsym, phis=None, thetas=None, mpol=5, ntor=5,
     return s
 
 
-def get_exact_surface():
+def get_exact_surface(surface_type='SurfaceXYZFourier'):
     """
     Returns a boozer exact surface that will be used in unit tests.
     """
@@ -61,8 +61,14 @@ def get_exact_surface():
 
     phis = np.linspace(0, 1, nphi, endpoint=False)
     thetas = np.linspace(0, 1, ntheta, endpoint=False)
-    s = SurfaceXYZFourier(mpol=mpol, ntor=ntor, nfp=nfp, stellsym=stellsym,
-                          quadpoints_phi=phis, quadpoints_theta=thetas)
+    if surface_type == 'SurfaceXYZFourier':
+        s = SurfaceXYZFourier(mpol=mpol, ntor=ntor, nfp=nfp, stellsym=stellsym,
+                              quadpoints_phi=phis, quadpoints_theta=thetas)
+    elif surface_type == 'SurfaceXYZTensorFourier':
+        s = SurfaceXYZTensorFourier(mpol=mpol, ntor=ntor, nfp=nfp, stellsym=stellsym,
+                              quadpoints_phi=phis, quadpoints_theta=thetas)
+    else:
+        raise Exception("surface type not implemented")
     s.least_squares_fit(xyz)
 
     return s

--- a/tests/geo/test_boozersurface.py
+++ b/tests/geo/test_boozersurface.py
@@ -230,7 +230,7 @@ class BoozerSurfaceTests(unittest.TestCase):
             ("SurfaceXYZFourier", True, False, 'ls'),  # noqa
         ]
         for surfacetype, stellsym, optimize_G, second_stage in configs:
-            for get_data in [get_giuliani_data]:
+            for get_data in [get_hsx_data, get_ncsx_data, get_giuliani_data]:
                 with self.subTest(
                     surfacetype=surfacetype, stellsym=stellsym,
                         optimize_G=optimize_G, second_stage=second_stage, get_data=get_data):

--- a/tests/geo/test_surface_xyzfourier.py
+++ b/tests/geo/test_surface_xyzfourier.py
@@ -5,8 +5,7 @@ import os
 
 import numpy as np
 
-from simsopt.geo.surfacexyzfourier import SurfaceXYZFourier
-from simsopt.geo.surface import Surface
+from simsopt.geo import Surface, SurfaceXYZFourier, SurfaceXYZTensorFourier
 from .surface_test_helpers import get_surface, get_exact_surface
 from simsopt._core.json import GSONDecoder, GSONEncoder, SIMSON
 from simsopt._core.optimizable import load, save
@@ -27,8 +26,9 @@ class SurfaceXYZFourierTests(unittest.TestCase):
         completely losslessly.
         """
         for stellsym in stellsym_list:
-            with self.subTest(stellsym=stellsym):
-                self.subtest_toRZFourier_perfect_torus("SurfaceXYZFourier", stellsym)
+            for surface_type in ['SurfaceXYZFourier', 'SurfaceXYZTensorFourier']:
+                with self.subTest(stellsym=stellsym, surface_type=surface_type):
+                    self.subtest_toRZFourier_perfect_torus(surface_type, stellsym)
 
     def subtest_toRZFourier_perfect_torus(self, surfacetype, stellsym):
         """
@@ -61,7 +61,7 @@ class SurfaceXYZFourierTests(unittest.TestCase):
         # check that the pointwise error is what we expect
         assert max_pointwise_err < 1e-12
 
-    def test_toRZFourier_lossless_at_quadraturepoints(self):
+    def test_toRZFourier_lossless_at_quadrature_points(self):
         """
         This test obtains a more complex surface (not a perfect torus) as a SurfaceXYZFourier, then
         converts that surface to the SurfaceRZFourier representation.  Then, the test checks that both
@@ -70,7 +70,12 @@ class SurfaceXYZFourierTests(unittest.TestCase):
 
         Additionally, this test checks that the cross sectional angle is correct.
         """
-        s = get_exact_surface()
+        for surface_type in ['SurfaceXYZFourier', 'SurfaceXYZTensorFourier']:
+            with self.subTest(surface_type=surface_type):
+                self.subtest_toRZFourier_lossless_at_quadraturepoints(surface_type)
+        
+    def subtest_toRZFourier_lossless_at_quadraturepoints(self, surface_type):
+        s = get_exact_surface(surface_type=surface_type)
         sRZ = s.to_RZFourier()
 
         max_angle_error = -1


### PR DESCRIPTION
This PR introduces a few minor changes:

(1) the implementation of `to_RZFourier` in the SurfaceXYZTensorFourier class is incorrect and untested.  That's how this was missed.  It seems like the previous version was using an old interface to the `SurfaceRZFourier` constructor. 
(2) A unit test that computes BoozerSurfaces in some of the included configurations was only running on the JPP (get_giuliani_data) data set, whereas previously it would also run on the NCSX and HSX datasets.  I have added those back in to the unit test.
(3) additional unittests for SurfaceXYZTensorFourier.  I have added these to the `test_surfacexyzfourier.py` file.

-Andrew