### PR TITLE
Visualize voxels

### DIFF
--- a/examples/2_Intermediate/winding_volume_axi.py
+++ b/examples/2_Intermediate/winding_volume_axi.py
@@ -119,7 +119,8 @@ for Nx in params:
     )
     t2 = time.time()
     print('WV grid initialization took time = ', t2 - t1, ' s')
-
+    wv_grid.to_vtk_before_solve(OUT_DIR + 'grid_before_solve_Nx' + str(Nx))
+    
     max_iter = 2000
     rs_max_iter = 5
 
@@ -142,7 +143,7 @@ for Nx in params:
     t_algorithm.append(t2 - t1)
 
     t1 = time.time()
-    wv_grid._toVTK(OUT_DIR + 'grid_after_Tikhonov_solve_Nx' + str(Nx))
+    wv_grid.to_vtk_after_solve(OUT_DIR + 'grid_after_Tikhonov_solve_Nx' + str(Nx))
     t2 = time.time()
     print('Time to plot the optimized grid = ', t2 - t1, ' s')
     print('fB after optimization = ', fB[-1]) 


### PR DESCRIPTION
This PR adds some routines to display the voxels as voxels rather than points. Two files are saved, one with only the base voxels (not applying stellarator symmetry or nfp symmetry), and the other with all voxels (exploiting the symmetries.) Examples:
<img width="663" alt="image" src="https://user-images.githubusercontent.com/5229699/222908071-1a7a5998-ad61-4c9b-be83-5da01628603e.png">
<img width="815" alt="image" src="https://user-images.githubusercontent.com/5229699/222908036-39fd87fe-2945-4849-bdb3-951b9c35cf1c.png">
In Paraview, I like setting "Representation" to "Surface with edges".
The boundaries of each voxel are defined by the max and min of the quadrature points. Therefore the 2nd figure shows gaps between each half period due to the issue we just discussed by email.

Also, a vtk file with the quadrature points is now saved.

For expediency while developing this, for now the voxel data are saved before the solve rather than after, so J data isn't included. But you could add calls to the new`_voxels_to_vtk()` function in `to_vtk_after_solve()` to add the J data to the voxels.