### PR TITLE
Mac openmp fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,12 @@ else()
     endif()
 endif()
 
+if(DEFINED ENV{CONDA_PREFIX})
+  include_directories($ENV{CONDA_PREFIX}/include)
+  link_directories("$ENV{CONDA_PREFIX}/lib")
+  message(STATUS "Conda prefix is $ENV{CONDA_PREFIX}")
+endif()
+
 find_package(OpenMP)
 find_package(Boost 1.60.0)
 if(Boost_FOUND)


### PR DESCRIPTION
Getting CMake to recognize OpenMP on Mac is very hard. The homebrew is releasing only ARM64 arch for M1 and CMake insists on universal binary. To circumvent this, we can leverage conda toolchain to find OpenMP. 

1. Install llvm-openmp from conda
    `conda install -c conda-forge llvm-openmp`
2. Install dependencies from conda
3. Use no-build-isolation to find openmp from conda when installing simsopt locally.
     `pip install --no-build-isloation .`  

In this PR, CMakeLists.txt is updated to use headers and libraries installed in the conda virtual environment.

Edit: PR #293  is also included in this PR.