### PR TITLE
PR: Added a surface.from_pyQSC method and tests

### DIFF
--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -392,6 +392,9 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
         Args:
             stel: Qsc object with a near-axis equilibrium.
             r: the near-axis coordinate radius (in meters).
+            ntheta: number of points in the theta direction for the Fourier transform.
+            mpol: number of poloidal Fourier modes for the surface.
+            ntor: number of toroidal Fourier modes for the surface.
             kwargs: Any other arguments to pass to the ``SurfaceRZFourier`` constructor.
               You can specify ``quadpoints_theta`` and ``quadpoints_phi`` here.
         """

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -10,6 +10,13 @@ from .surface import Surface
 from .._core.optimizable import DOFs, Optimizable
 from .._core.util import nested_lists_to_array
 from .._core.json import GSONDecoder
+from .._core.dev import SimsoptRequires
+
+try:
+    from qsc import Qsc
+    from qsc.util import to_Fourier
+except ImportError:
+    Qsc = None
 
 logger = logging.getLogger(__name__)
 
@@ -371,6 +378,36 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
             if not stellsym:
                 surf.rs[m[j], n[j] + ntor] = rs[j]
                 surf.zc[m[j], n[j] + ntor] = zc[j]
+
+        surf.local_full_x = surf.get_dofs()
+        return surf
+
+    @classmethod
+    @SimsoptRequires(Qsc is not None, "from_pyQSC method requires pyQSC module")
+    def from_pyQSC(cls, stel: Qsc, r: float = 0.1, ntheta=20, mpol=10, ntor=20, **kwargs):
+        """
+        Initialize the surface from a pyQSC object. This creates a surface
+        from a near-axis equilibrium with a specified minor radius `r` (in meters).
+
+        Args:
+            stel: Qsc object with a near-axis equilibrium.
+            r: the near-axis coordinate radius (in meters).
+            kwargs: Any other arguments to pass to the ``SurfaceRZFourier`` constructor.
+              You can specify ``quadpoints_theta`` and ``quadpoints_phi`` here.
+        """
+        # Get surface shape at fixed off-axis toroidal angle phi
+        R_2D, Z_2D, _ = stel.Frenet_to_cylindrical(r, ntheta)
+
+        # Fourier transform the result.
+        RBC, RBS, ZBC, ZBS = to_Fourier(R_2D, Z_2D, stel.nfp, mpol, ntor, stel.lasym)
+
+        surf = cls(mpol=mpol, ntor=ntor, nfp=stel.nfp, stellsym=not stel.lasym, **kwargs)
+
+        surf.rc = RBC.transpose()
+        surf.zs = ZBS.transpose()
+        if stel.lasym:
+            surf.rs = RBS.transpose()
+            surf.zc = ZBC.transpose()
 
         surf.local_full_x = surf.get_dofs()
         return surf

--- a/tests/geo/test_surface_rzfourier.py
+++ b/tests/geo/test_surface_rzfourier.py
@@ -2,6 +2,8 @@ import unittest
 from pathlib import Path
 import json
 
+from qsc import Qsc
+
 import numpy as np
 from simsopt import save, load
 
@@ -379,6 +381,30 @@ class SurfaceRZFourierTests(unittest.TestCase):
         #    true_volume, ", difference:", volume - true_volume)
         self.assertAlmostEqual(s.area(), true_area, places=4)
         self.assertAlmostEqual(s.volume(), true_volume, places=3)
+
+    def test_from_pyQSC(self):
+        """
+        Try reading in a near-axis pyQSC equilibrium.
+        """
+        stel = Qsc.from_paper(1)
+        filename = TEST_DIR / 'input.near_axis_test'
+
+        ntheta = 20
+        mpol = 10
+        ntor = 10
+        r = 0.1
+
+        stel.to_vmec(filename, r=r, ntheta=ntheta, ntorMax=ntor, params={'mpol': mpol, 'ntor': ntor})
+
+        s1 = SurfaceRZFourier.from_pyQSC(stel, r=r, ntheta=ntheta, ntor=ntor, mpol=mpol)
+        s2 = SurfaceRZFourier.from_vmec_input(filename)
+
+        np.testing.assert_allclose(s1.rc, s2.rc)
+        np.testing.assert_allclose(s1.zs, s2.zs)
+        np.testing.assert_allclose(s1.nfp, s2.nfp)
+        np.testing.assert_allclose(s1.stellsym, s2.stellsym)
+        np.testing.assert_allclose(s1.area(), s2.area())
+        np.testing.assert_allclose(s1.volume(), s2.volume())
 
     def test_change_resolution(self):
         """


### PR DESCRIPTION
This PR allows users to generate a SurfaceRZFourier directly from a pyQSC instance (a Qsc class).
It helps users perform stage 1 and stage 2 optimizations involving near-axis expansions, either as initial conditions or not.