### PR TITLE
options for SquaredFlux definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ pybind11_add_module(${PROJECT_NAME}
     src/simsoptpp/regular_grid_interpolant_3d_py.cpp
     src/simsoptpp/curve.cpp src/simsoptpp/curverzfourier.cpp src/simsoptpp/curvexyzfourier.cpp
     src/simsoptpp/surface.cpp src/simsoptpp/surfacerzfourier.cpp src/simsoptpp/surfacexyzfourier.cpp
+    src/simsoptpp/integral_BdotN.cpp
     src/simsoptpp/dommaschk.cpp src/simsoptpp/reiman.cpp src/simsoptpp/tracing.cpp 
     src/simsoptpp/magneticfield_biotsavart.cpp src/simsoptpp/python_boozermagneticfield.cpp
     src/simsoptpp/boozerradialinterpolant.cpp

--- a/docs/source/example_coils.rst
+++ b/docs/source/example_coils.rst
@@ -228,6 +228,12 @@ for values that are too small or a regular 2-sided quadratic penalty
 by setting the last argument to ``"min"`` or ``"identity"``
 respectively.
 
+Note that the :obj:`~simsopt.objectives.SquaredFlux` objective can be
+defined in several different ways. You can choose among the available
+definitions using the ``definition`` argument. For the available
+definitions, see the documentation for
+:obj:`~simsopt.objectives.SquaredFlux`.
+
 You can check the degrees of freedom that will be varied in the
 optimization by printing the ``dof_names`` property of the objective::
 

--- a/examples/3_Advanced/single_stage_optimization.py
+++ b/examples/3_Advanced/single_stage_optimization.py
@@ -104,7 +104,7 @@ if comm.rank == 0:
     surf.to_vtk(os.path.join(coils_results_path, "surf_init"), extra_data=pointData)
 ##########################################################################################
 ##########################################################################################
-Jf = SquaredFlux(surf, bs, local=True)
+Jf = SquaredFlux(surf, bs, definition="local")
 Jls = [CurveLength(c) for c in base_curves]
 Jccdist = CurveCurveDistance(curves, CC_THRESHOLD, num_basecurves=len(curves))
 Jcs = [LpCurveCurvature(c, 2, CURVATURE_THRESHOLD) for i, c in enumerate(base_curves)]
@@ -178,7 +178,7 @@ def fun(dofs, prob_jacobian=None, info={'Nfeval': 0}):
         B_n = Bcoil_n
         B_diff = Bcoil
         B_N = np.sum(Bcoil * n, axis=2)
-        assert Jf.local
+        assert Jf.definition == "local"
         dJdx = (B_n/mod_Bcoil**2)[:, :, None] * (np.sum(dB_by_dX*(n-B*(B_N/mod_Bcoil**2)[:, :, None])[:, :, None, :], axis=3))
         dJdN = (B_n/mod_Bcoil**2)[:, :, None] * B_diff - 0.5 * (B_N**2/absn**3/mod_Bcoil**2)[:, :, None] * n
         deriv = surf.dnormal_by_dcoeff_vjp(dJdN/(nphi_VMEC*ntheta_VMEC)) + surf.dgamma_by_dcoeff_vjp(dJdx/(nphi_VMEC*ntheta_VMEC))
@@ -212,7 +212,7 @@ objective_tuple = [(vmec.aspect, aspect_ratio_target, aspect_ratio_weight), (qs.
 prob = LeastSquaresProblem.from_tuples(objective_tuple)
 dofs = np.concatenate((JF.x, vmec.x))
 bs.set_points(surf.gamma().reshape((-1, 3)))
-Jf = SquaredFlux(surf, bs, local=True)
+Jf = SquaredFlux(surf, bs, definition="local")
 pprint(f"Aspect ratio before optimization: {vmec.aspect()}")
 pprint(f"Mean iota before optimization: {vmec.mean_iota()}")
 pprint(f"Quasisymmetry objective before optimization: {qs.total()}")

--- a/examples/3_Advanced/single_stage_optimization_finite_beta.py
+++ b/examples/3_Advanced/single_stage_optimization_finite_beta.py
@@ -115,7 +115,7 @@ if comm.rank == 0:
     surf.to_vtk(os.path.join(coils_results_path, "surf_init"), extra_data=pointData)
 ##########################################################################################
 ##########################################################################################
-Jf = SquaredFlux(surf, bs, local=True, target=vc.B_external_normal)
+Jf = SquaredFlux(surf, bs, definition="local", target=vc.B_external_normal)
 Jls = [CurveLength(c) for c in base_curves]
 Jccdist = CurveCurveDistance(curves, CC_THRESHOLD, num_basecurves=len(curves))
 Jcs = [LpCurveCurvature(c, 2, CURVATURE_THRESHOLD) for i, c in enumerate(base_curves)]
@@ -170,7 +170,7 @@ def fun_J(dofs_vmec, dofs_coils):
     if run_vcasing:
         try:
             vc = VirtualCasing.from_vmec(vmec, src_nphi=vc_src_nphi, trgt_nphi=nphi_VMEC, trgt_ntheta=ntheta_VMEC)
-            Jf = SquaredFlux(surf, bs, local=True, target=vc.B_external_normal)
+            Jf = SquaredFlux(surf, bs, definition="local", target=vc.B_external_normal)
             if np.sum(Jf.x != dofs_coils) > 0: Jf.x = dofs_coils
             JF.opts[0].opts[0].opts[0].opts[0].opts[0] = Jf
             if np.sum(JF.x != dofs_coils) > 0: JF.x = dofs_coils
@@ -232,7 +232,7 @@ prob = LeastSquaresProblem.from_tuples(objective_tuple)
 dofs = np.concatenate((JF.x, vmec.x))
 bs.set_points(surf.gamma().reshape((-1, 3)))
 vc = VirtualCasing.from_vmec(vmec, src_nphi=vc_src_nphi, trgt_nphi=nphi_VMEC, trgt_ntheta=ntheta_VMEC)
-Jf = SquaredFlux(surf, bs, local=True, target=vc.B_external_normal)
+Jf = SquaredFlux(surf, bs, definition="local", target=vc.B_external_normal)
 pprint(f"Aspect ratio before optimization: {vmec.aspect()}")
 pprint(f"Mean iota before optimization: {vmec.mean_iota()}")
 pprint(f"Quasisymmetry objective before optimization: {qs.total()}")

--- a/src/simsopt/objectives/fluxobjective.py
+++ b/src/simsopt/objectives/fluxobjective.py
@@ -12,14 +12,32 @@ __all__ = ['SquaredFlux']
 class SquaredFlux(Optimizable):
 
     r"""
-    Objective representing the quadratic flux of a field on a surface, that is
+    Objective representing quadratic-flux-like quantities, useful for stage-2
+    coil optimization. Several variations are available, which can be selected
+    using the ``definition`` argument. For ``definition="quadratic flux"`` 
+    (the default), the objective is defined as
 
     .. math::
-        \frac12 \int_{S} (\mathbf{B}\cdot \mathbf{n} - B_T)^2 ds
+        J = \frac12 \int_{S} (\mathbf{B}\cdot \mathbf{n} - B_T)^2 ds,
 
     where :math:`\mathbf{n}` is the surface unit normal vector and
     :math:`B_T` is an optional (zero by default) target value for the
-    magnetic field.
+    magnetic field. Also :math:`\int_{S} ds` indicates a surface integral.
+    For ``definition="normalized"``, the objective is defined as
+
+    .. math::
+        J = \frac12 \frac{\int_{S} (\mathbf{B}\cdot \mathbf{n} - B_T)^2 ds}
+                         {\int_{S} |\mathbf{B}|^2 ds}.
+
+    For ``definition="local"``, the objective is defined as
+
+    .. math::
+        J = \frac12 \int_{S} \frac{(\mathbf{B}\cdot \mathbf{n} - B_T)^2}{|\mathbf{B}|^2} ds.
+
+    The definition ``"quadratic flux"`` has the advantage of simplicity, and it
+    is used in other contexts such as REGCOIL. However for stage-2 optimization,
+    the optimizer can "cheat", lowering this objective by reducing the magnitude
+    of the field. The definitions ``"normalized"`` and ``"local"`` close this loophole.
 
     Args:
         surface: A :obj:`simsopt.geo.surface.Surface` object on which to compute the flux
@@ -27,51 +45,62 @@ class SquaredFlux(Optimizable):
         target: A ``nphi x ntheta`` numpy array containing target values for the flux. Here 
           ``nphi`` and ``ntheta`` correspond to the number of quadrature points on `surface` 
           in ``phi`` and ``theta`` direction.
-        local: If ``True``, the objective is computed as half the mean of the normal field divided
-            by the magnitude of the magnetic field, squared. If ``False``, the objective is 
-            computed as the mean of the squared normal field divided by the mean of the squared
-            magnetic field.
+        definition: A string to select among the definitions above. The
+          available options are ``"quadratic flux"``, ``"normalized"``, and ``"local"``.
     """
 
-    def __init__(self, surface, field, target=None, local=True):
+    def __init__(self, surface, field, target=None, definition="quadratic flux"):
         self.surface = surface
         self.target = target
         self.field = field
         xyz = self.surface.gamma()
         self.field.set_points(xyz.reshape((-1, 3)))
-        self.local = local
+        if definition not in ["quadratic flux", "normalized", "local"]:
+            raise ValueError("Unrecognized option for 'definition'.")
+        self.definition = definition
         Optimizable.__init__(self, x0=np.asarray([]), depends_on=[field])
 
     def J(self):
         n = self.surface.normal()
         Bcoil = self.field.B().reshape(n.shape)
         Btarget = self.target if self.target is not None else []
-        return sopp.integral_BdotN(Bcoil, Btarget, n, self.local)
+        return sopp.integral_BdotN(Bcoil, Btarget, n, self.definition)
 
     @derivative_dec
     def dJ(self):
         n = self.surface.normal()
         absn = np.linalg.norm(n, axis=2)
-        unitn = n * (1./absn)[:, :, None]
+        unitn = n * (1. / absn)[:, :, None]
         Bcoil = self.field.B().reshape(n.shape)
-        Bcoil_n = np.sum(Bcoil*unitn, axis=2)
+        Bcoil_n = np.sum(Bcoil * unitn, axis=2)
         if self.target is not None:
             B_n = (Bcoil_n - self.target)
         else:
             B_n = Bcoil_n
-        mod_Bcoil = np.linalg.norm(Bcoil, axis=2)
-        if self.local:
+
+        if self.definition == "quadratic flux":
+            dJdB = (B_n[..., None] * unitn * absn[..., None]) / absn.size
+            dJdB = dJdB.reshape((-1, 3))
+
+        elif self.definition == "local":
+            mod_Bcoil = np.linalg.norm(Bcoil, axis=2)
             dJdB = ((
                 (B_n/mod_Bcoil)[..., None] * (
-                    unitn/mod_Bcoil[..., None] - (B_n/mod_Bcoil**3)[..., None] * Bcoil
-                )) * absn[..., None])/absn.size
-        else:
+                    unitn / mod_Bcoil[..., None] - (B_n / mod_Bcoil**3)[..., None] * Bcoil
+                )) * absn[..., None]) / absn.size
+
+        elif self.definition == "normalized":
+            mod_Bcoil = np.linalg.norm(Bcoil, axis=2)
             num = np.mean(B_n**2 * absn)
             denom = np.mean(mod_Bcoil**2 * absn)
 
-            dnum = 2*(B_n[..., None] * unitn * absn[..., None])/absn.size
-            ddenom = 2*(Bcoil * absn[..., None])/absn.size
-            dJdB = dnum/denom - num * ddenom/denom**2
+            dnum = 2 * (B_n[..., None] * unitn * absn[..., None]) / absn.size
+            ddenom = 2 * (Bcoil * absn[..., None]) / absn.size
+            dJdB = 0.5 * (dnum / denom - num * ddenom / denom**2)
+
+        else:
+            raise ValueError("Should never get here")
+
         dJdB = dJdB.reshape((-1, 3))
         return self.field.B_vjp(dJdB)
 

--- a/src/simsoptpp/integral_BdotN.cpp
+++ b/src/simsoptpp/integral_BdotN.cpp
@@ -1,0 +1,106 @@
+#include "xtensor-python/pyarray.hpp"
+typedef xt::pyarray<double> PyArray;
+#include <math.h>
+
+/** Compute quadratic flux and similar quantities.
+ *
+ * This function is used in simsopt.objectives.SquaredFlux.
+ * See the documentation of that class for the definitions of the quantities
+ * computed here.
+ */
+double integral_BdotN(PyArray& Bcoil, PyArray& Btarget, PyArray& n, std::string definition) {
+    int nphi = Bcoil.shape(0);
+    int ntheta = Bcoil.shape(1);
+    double *Bcoil_ptr = Bcoil.data();
+    double *Btarget_ptr = NULL;
+    double *n_ptr = n.data();
+    if(Bcoil.layout() != xt::layout_type::row_major)
+            throw std::runtime_error("Bcoil needs to be in row-major storage order");
+    if(Bcoil.shape(2) != 3)
+        throw std::runtime_error("Bcoil has wrong shape.");
+    if(Bcoil.size() != 3*nphi*ntheta)
+        throw std::runtime_error("Bcoil has wrong size.");
+    if(n.layout() != xt::layout_type::row_major)
+            throw std::runtime_error("n needs to be in row-major storage order");
+    if(n.shape(0) != nphi)
+        throw std::runtime_error("n has wrong shape.");
+    if(n.shape(1) != ntheta)
+        throw std::runtime_error("n has wrong shape.");
+    if(n.shape(2) != 3)
+        throw std::runtime_error("n has wrong shape.");
+    if(n.size() != 3*nphi*ntheta)
+        throw std::runtime_error("n has wrong size.");
+    if(Btarget.size() > 0){
+        if(Btarget.layout() != xt::layout_type::row_major)
+            throw std::runtime_error("Btarget needs to be in row-major storage order");
+        if(Btarget.shape(0) != nphi)
+            throw std::runtime_error("Btarget has wrong shape.");
+        if(Btarget.shape(1) != ntheta)
+            throw std::runtime_error("Btarget has wrong shape.");
+        if(Btarget.size() != nphi*ntheta)
+            throw std::runtime_error("Btarget has wrong size.");
+
+        Btarget_ptr = Btarget.data();
+    }
+    // Convert "definition" from string to int for faster comparisons inside
+    // the loop.
+    enum definition_type {DEFINITION_QUADRATIC_FLUX, DEFINITION_NORMALIZED, DEFINITION_LOCAL};
+    definition_type definition_int;
+    if (definition == "quadratic flux") {
+        definition_int = DEFINITION_QUADRATIC_FLUX;
+    } else if (definition == "normalized") {
+        definition_int = DEFINITION_NORMALIZED;
+    } else if (definition == "local") {
+        definition_int = DEFINITION_LOCAL;
+    } else {
+        throw std::runtime_error("Unrecognized value for 'definition'.");
+    }
+    double numerator_sum = 0.0;
+    double denominator_sum = 0.0;
+    double mod_B_squared;
+
+    #pragma omp parallel for reduction(+:numerator_sum, denominator_sum)
+    for(int i=0; i<nphi*ntheta; i++){
+        double normN = std::sqrt(
+            n_ptr[3 * i + 0] * n_ptr[3 * i + 0] 
+            + n_ptr[3 * i + 1] * n_ptr[3 * i + 1] 
+            + n_ptr[3 * i + 2] * n_ptr[3 * i + 2]
+        );
+        double Nx = n_ptr[3 * i + 0] / normN;
+        double Ny = n_ptr[3 * i + 1] / normN;
+        double Nz = n_ptr[3 * i + 2] / normN;
+        double BcoildotN = (
+            Bcoil_ptr[3 * i + 0] * Nx 
+            + Bcoil_ptr[3 * i + 1] * Ny 
+            + Bcoil_ptr[3 * i + 2] * Nz
+        );
+        if(Btarget_ptr != NULL)
+            BcoildotN -= Btarget_ptr[i];
+
+        if (definition_int != DEFINITION_QUADRATIC_FLUX)
+            mod_B_squared = 
+                Bcoil_ptr[3 * i + 0] * Bcoil_ptr[3 * i + 0] 
+                + Bcoil_ptr[3 * i + 1] * Bcoil_ptr[3 * i + 1] 
+                + Bcoil_ptr[3 * i + 2] * Bcoil_ptr[3 * i + 2];
+        
+        if (definition_int == DEFINITION_QUADRATIC_FLUX) {
+            numerator_sum += (BcoildotN * BcoildotN) * normN;
+        } else if (definition_int == DEFINITION_NORMALIZED){
+            numerator_sum += (BcoildotN * BcoildotN) * normN;
+            denominator_sum += mod_B_squared * normN;
+        } else if (definition_int == DEFINITION_LOCAL) {
+            numerator_sum += (BcoildotN * BcoildotN) / mod_B_squared * normN;
+        } else {
+            throw std::runtime_error("Should never reach this point.");
+        }
+    }
+
+    double result;
+    if (definition_int == DEFINITION_NORMALIZED) {
+        result = 0.5 * numerator_sum / denominator_sum;
+    } else {
+        result = 0.5 * numerator_sum / (nphi * ntheta);
+    }
+
+    return result;
+}

--- a/src/simsoptpp/integral_BdotN.h
+++ b/src/simsoptpp/integral_BdotN.h
@@ -1,0 +1,4 @@
+#include "xtensor-python/pyarray.hpp"
+typedef xt::pyarray<double> PyArray;
+
+double integral_BdotN(PyArray& Bcoil, PyArray& Btarget, PyArray& n, std::string definition);

--- a/src/simsoptpp/python.cpp
+++ b/src/simsoptpp/python.cpp
@@ -13,9 +13,10 @@ typedef xt::pyarray<double> PyArray;
 
 #include "biot_savart_py.h"
 #include "biot_savart_vjp_py.h"
-#include "dommaschk.h"
-#include "reiman.h"
 #include "boozerradialinterpolant.h"
+#include "dommaschk.h"
+#include "integral_BdotN.h"
+#include "reiman.h"
 
 namespace py = pybind11;
 
@@ -49,6 +50,8 @@ PYBIND11_MODULE(simsoptpp, m) {
 
     m.def("DommaschkB" , &DommaschkB);
     m.def("DommaschkdB", &DommaschkdB);
+
+    m.def("integral_BdotN", &integral_BdotN);
 
     m.def("ReimanB" , &ReimanB);
     m.def("ReimandB", &ReimandB);
@@ -119,103 +122,6 @@ PYBIND11_MODULE(simsoptpp, m) {
             eigC = eigv.transpose()*eigB;
             return C;
         });
-
-    m.def("integral_BdotN", [](PyArray& Bcoil, PyArray& Btarget, PyArray& n, std::string definition) {
-        int nphi = Bcoil.shape(0);
-        int ntheta = Bcoil.shape(1);
-        double *Bcoil_ptr = Bcoil.data();
-        double *Btarget_ptr = NULL;
-        double *n_ptr = n.data();
-        if(Bcoil.layout() != xt::layout_type::row_major)
-              throw std::runtime_error("Bcoil needs to be in row-major storage order");
-        if(Bcoil.shape(2) != 3)
-            throw std::runtime_error("Bcoil has wrong shape.");
-        if(Bcoil.size() != 3*nphi*ntheta)
-            throw std::runtime_error("Bcoil has wrong size.");
-        if(n.layout() != xt::layout_type::row_major)
-              throw std::runtime_error("n needs to be in row-major storage order");
-        if(n.shape(0) != nphi)
-            throw std::runtime_error("n has wrong shape.");
-        if(n.shape(1) != ntheta)
-            throw std::runtime_error("n has wrong shape.");
-        if(n.shape(2) != 3)
-            throw std::runtime_error("n has wrong shape.");
-        if(n.size() != 3*nphi*ntheta)
-            throw std::runtime_error("n has wrong size.");
-        if(Btarget.size() > 0){
-            if(Btarget.layout() != xt::layout_type::row_major)
-                throw std::runtime_error("Btarget needs to be in row-major storage order");
-            if(Btarget.shape(0) != nphi)
-                throw std::runtime_error("Btarget has wrong shape.");
-            if(Btarget.shape(1) != ntheta)
-                throw std::runtime_error("Btarget has wrong shape.");
-            if(Btarget.size() != nphi*ntheta)
-                throw std::runtime_error("Btarget has wrong size.");
-
-            Btarget_ptr = Btarget.data();
-        }
-        // Convert "definition" from string to int for faster comparisons inside
-        // the loop.
-        enum definition_type {DEFINITION_QUADRATIC_FLUX, DEFINITION_NORMALIZED, DEFINITION_LOCAL};
-        definition_type definition_int;
-        if (definition == "quadratic flux") {
-            definition_int = DEFINITION_QUADRATIC_FLUX;
-        } else if (definition == "normalized") {
-            definition_int = DEFINITION_NORMALIZED;
-        } else if (definition == "local") {
-            definition_int = DEFINITION_LOCAL;
-        } else {
-            throw std::runtime_error("Unrecognized value for 'definition'.");
-        }
-        double numerator_sum = 0.0;
-        double denominator_sum = 0.0;
-        double mod_B_squared;
-
-        #pragma omp parallel for reduction(+:numerator_sum, denominator_sum)
-        for(int i=0; i<nphi*ntheta; i++){
-            double normN = std::sqrt(
-                n_ptr[3 * i + 0] * n_ptr[3 * i + 0] 
-                + n_ptr[3 * i + 1] * n_ptr[3 * i + 1] 
-                + n_ptr[3 * i + 2] * n_ptr[3 * i + 2]
-            );
-            double Nx = n_ptr[3 * i + 0] / normN;
-            double Ny = n_ptr[3 * i + 1] / normN;
-            double Nz = n_ptr[3 * i + 2] / normN;
-            double BcoildotN = (
-                Bcoil_ptr[3 * i + 0] * Nx 
-                + Bcoil_ptr[3 * i + 1] * Ny 
-                + Bcoil_ptr[3 * i + 2] * Nz
-            );
-            if(Btarget_ptr != NULL)
-                BcoildotN -= Btarget_ptr[i];
-
-            if (definition_int != DEFINITION_QUADRATIC_FLUX)
-                mod_B_squared = 
-                    Bcoil_ptr[3 * i + 0] * Bcoil_ptr[3 * i + 0] 
-                    + Bcoil_ptr[3 * i + 1] * Bcoil_ptr[3 * i + 1] 
-                    + Bcoil_ptr[3 * i + 2] * Bcoil_ptr[3 * i + 2];
-            
-            if (definition_int == DEFINITION_QUADRATIC_FLUX) {
-                numerator_sum += (BcoildotN * BcoildotN) * normN;
-            } else if (definition_int == DEFINITION_NORMALIZED){
-                numerator_sum += (BcoildotN * BcoildotN) * normN;
-                denominator_sum += mod_B_squared * normN;
-            } else if (definition_int == DEFINITION_LOCAL) {
-                numerator_sum += (BcoildotN * BcoildotN) / mod_B_squared * normN;
-            } else {
-                throw std::runtime_error("Should never reach this point.");
-            }
-        }
-
-        double result;
-        if (definition_int == DEFINITION_NORMALIZED) {
-            result = 0.5 * numerator_sum / denominator_sum;
-        } else {
-            result = 0.5 * numerator_sum / (nphi * ntheta);
-        }
-
-        return result;
-    });
 
 #ifdef VERSION_INFO
     m.attr("__version__") = VERSION_INFO;

--- a/tests/objectives/test_fluxobjective.py
+++ b/tests/objectives/test_fluxobjective.py
@@ -19,57 +19,96 @@ filename = TEST_DIR / 'input.LandremanPaul2021_QA'
 
 class FluxObjectiveTests(unittest.TestCase):
 
-    def test_flux(self):
+    def test_definitions(self):
+        """Verify the available definitions."""
+        surf = SurfaceRZFourier.from_vmec_input(filename)
+        ntheta = len(surf.quadpoints_theta)
+        nphi = len(surf.quadpoints_phi)
+        ncoils = 3
 
-        def check_taylor_test(J):
-            dofs = J.x
-            np.random.seed(1)
-            h = np.random.uniform(size=dofs.shape)
-            J0, dJ0 = J.J(), J.dJ()
-            dJh = sum(dJ0 * h)
-            err_old = 1e10
-            for i in range(11, 17):
-                eps = 0.5 ** i
-                J.x = dofs + eps * h
-                J1 = J.J()
-                J.x = dofs - eps * h
-                J2 = J.J()
-                err = np.abs((J1 - J2) / (2 * eps) - dJh)
-                # print(i, "err", err)
-                # print(i, "err/err_old", err/err_old)
-                assert err < 0.6 ** 2 * err_old
-                err_old = err
+        base_curves = create_equally_spaced_curves(
+            ncoils, surf.nfp, stellsym=surf.stellsym, R0=1.0, R1=0.5, order=6
+        )
+        base_currents = [Current(1e5) for i in range(ncoils)]
+        coils = coils_via_symmetries(base_curves, base_currents, surf.nfp, surf.stellsym)
+        bs = BiotSavart(coils)
 
-            J_str = json.dumps(SIMSON(J), cls=GSONEncoder)
-            J_regen = json.loads(J_str, cls=GSONDecoder)
-            self.assertAlmostEqual(J.J(), J_regen.J())
+        # Test definition = "quadratic flux":
+        target = np.ones(surf.gamma().shape[0:2])
+        J = SquaredFlux(surf, bs, target, definition="quadratic flux").J()
+        bs.set_points(surf.gamma().reshape((-1, 3)))
+        B = bs.B()
+        normal = surf.normal().reshape((-1, 3))
+        norm_normal = np.sqrt(normal[:, 0]**2 + normal[:, 1]**2 + normal[:, 2]**2)
+        B_dot_n = np.sum(B * surf.unitnormal().reshape((-1, 3)), axis=1)
+        should_be = 0.5 * sum((B_dot_n - target.reshape((-1,)))**2 * norm_normal) / (ntheta * nphi)
+        np.testing.assert_allclose(J, should_be)
 
+        # Test definition = "normalized":
+        J2 = SquaredFlux(surf, bs, target, definition="normalized").J()
+        mod_B_squared = np.sum(B * B, axis=1)
+        numerator = 0.5 * sum(
+            (B_dot_n - target.reshape((-1,)))**2 * norm_normal
+        ) / (ntheta * nphi)
+        denominator = sum(mod_B_squared * norm_normal) / (ntheta * nphi)
+        np.testing.assert_allclose(J2, numerator / denominator)
+
+        # Test definition = "local":
+        J3 = SquaredFlux(surf, bs, target, definition="local").J()
+        should_be3 = 0.5 * sum(
+            (B_dot_n - target.reshape((-1,)))**2 / mod_B_squared * norm_normal
+        ) / (ntheta * nphi)
+        np.testing.assert_allclose(J3, should_be3)
+
+        with self.assertRaises(ValueError):
+            J4 = SquaredFlux(surf, bs, target, definition="foobar")
+
+    def check_taylor_test(self, J):
+        dofs = J.x
+        np.random.seed(1)
+        h = np.random.uniform(size=dofs.shape)
+        J0, dJ0 = J.J(), J.dJ()
+        dJh = sum(dJ0 * h)
+        err_old = 1e10
+        for i in range(11, 17):
+            eps = 0.5 ** i
+            J.x = dofs + eps * h
+            J1 = J.J()
+            J.x = dofs - eps * h
+            J2 = J.J()
+            err = np.abs((J1 - J2) / (2 * eps) - dJh)
+            # print(f"i: {i}  err: {err}  err_old: {err_old}  err/err_old: {err/err_old}")
+            assert err < 0.6 ** 2 * err_old
+            err_old = err
+
+        J_str = json.dumps(SIMSON(J), cls=GSONEncoder)
+        J_regen = json.loads(J_str, cls=GSONDecoder)
+        self.assertAlmostEqual(J.J(), J_regen.J())
+
+    def test_derivatives(self):
+        """Verify correctness of SquaredFlux.dJ()"""
         s = SurfaceRZFourier.from_vmec_input(filename)
         ncoils = 4
-        ALPHA = 1e-5
 
         base_curves = create_equally_spaced_curves(ncoils, s.nfp, stellsym=s.stellsym, R0=1.0, R1=0.5, order=6)
-        base_currents = []
-        for i in range(ncoils):
-            curr = Current(1e5)
-            if i == 0:
-                curr.local_fix_all()
-            base_currents.append(curr)
-
+        base_currents = [Current(1e5) for i in range(ncoils)]
         coils = coils_via_symmetries(base_curves, base_currents, s.nfp, s.stellsym)
         bs = BiotSavart(coils)
 
-        Jf = SquaredFlux(s, bs)
-        check_taylor_test(Jf)
+        for definition in ["quadratic flux", "normalized", "local"]:
+            with self.subTest(definition=definition):
+                Jf = SquaredFlux(s, bs, definition=definition)
+                self.check_taylor_test(Jf)
 
-        target = np.zeros(s.gamma().shape[0:2])
-        Jf2 = SquaredFlux(s, bs, target)
-        check_taylor_test(Jf2)
-        target = np.ones(s.gamma().shape[0:2])
-        Jf3 = SquaredFlux(s, bs, target)
-        check_taylor_test(Jf3)
+                target = np.zeros(s.gamma().shape[0:2])
+                Jf2 = SquaredFlux(s, bs, target, definition=definition)
+                self.check_taylor_test(Jf2)
+                target = np.ones(s.gamma().shape[0:2])
+                Jf3 = SquaredFlux(s, bs, target, definition=definition)
+                self.check_taylor_test(Jf3)
 
-        Jls = [CurveLength(c) for c in base_curves]
+                Jls = [CurveLength(c) for c in base_curves]
 
-        JF_scaled_summed = Jf + ALPHA * sum(Jls)
-        check_taylor_test(JF_scaled_summed)
+                ALPHA = 1e-5
+                JF_scaled_summed = Jf + ALPHA * sum(Jls)
+                self.check_taylor_test(JF_scaled_summed)


### PR DESCRIPTION
*  The PR `rj/single_stage_PR` eliminates the original definition of `SquaredFlux`. I think we should keep this original definition as an option so it doesn't break scripts of other users, and since it may be useful in some circumstances. Therefore in this PR, in `SquaredFlux` I replaced the boolean `local` argument with a `definitions` argument of string type that can take 3 options. These 3 options correspond to the original definition of `SquaredFlux` plus the 2 new definitions in `rj/single_stage_PR`.
* All the available definitions for `SquaredFlux` are now tested, and the derivatives are tested.
* The available definitions of `SquaredFlux` are now documented with displayed equations.
* To simplify `python.cpp`, the `integral_BdotN` function was separated out of `python.cpp` into a new file.
* Eliminated a sqrt from `integral_BdotN` for speed.