### PR TITLE
conda build fixes

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -60,3 +60,7 @@ jobs:
         run: |
           conda build --no-test conda.recipe
 
+      - name: Build on PR
+        if: github.event_name == 'pull_request'
+        run: |
+          conda build --no-test conda.recipe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 IF(DEFINED ENV{NO_XSIMD})
    set(NO_XSIMD ON)
 ENDIF()
+set(_HAS_AUTO_PTR_ETC 1)
 configure_file(config.h.in config.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
@@ -94,7 +95,7 @@ else()
             libs/lexical_cast libs/container libs/move libs/smart_ptr libs/multi_array
             libs/functional libs/function libs/type_index libs/container_hash libs/bind
         CONFIGURE_COMMAND ./bootstrap.sh --prefix=<PREFIX>
-        BUILD_COMMAND ./b2 headers define=_HAS_AUTO_PTR_ETC=1 --prefix=${boost_DIR}
+        BUILD_COMMAND ./b2 headers --prefix=${boost_DIR}
         BUILD_IN_SOURCE 1
         INSTALL_COMMAND ""
     )
@@ -124,7 +125,7 @@ pybind11_add_module(${PROJECT_NAME}
 
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON)
 
 target_include_directories(${PROJECT_NAME} PRIVATE "thirdparty/xtensor/include" "thirdparty/xtensor-python/include" "thirdparty/xsimd/include" "thirdparty/xtl/include" "thirdparty/eigen" ${Python_NumPy_INCLUDE_DIRS} "src/simsoptpp/")
@@ -143,7 +144,7 @@ endif()
 add_executable(profiling EXCLUDE_FROM_ALL src/profiling/profiling.cpp src/simsoptpp/biot_savart_c.cpp src/simsoptpp/biot_savart_vjp_c.cpp src/simsoptpp/regular_grid_interpolant_3d_c.cpp)
 set_target_properties(profiling
     PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON)
 target_include_directories(profiling PRIVATE  "thirdparty/xtensor/include" "thirdparty/xsimd/include" "thirdparty/xtl/include" "thirdparty/eigen" "src/simsoptpp/")
 target_link_libraries(profiling PRIVATE fmt::fmt-header-only)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ else()
             libs/lexical_cast libs/container libs/move libs/smart_ptr libs/multi_array
             libs/functional libs/function libs/type_index libs/container_hash libs/bind
         CONFIGURE_COMMAND ./bootstrap.sh --prefix=<PREFIX>
-        BUILD_COMMAND ./b2 headers --prefix=${boost_DIR}
+        BUILD_COMMAND ./b2 headers define=_HAS_AUTO_PTR_ETC --prefix=${boost_DIR}
         BUILD_IN_SOURCE 1
         INSTALL_COMMAND ""
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ else()
             libs/lexical_cast libs/container libs/move libs/smart_ptr libs/multi_array
             libs/functional libs/function libs/type_index libs/container_hash libs/bind
         CONFIGURE_COMMAND ./bootstrap.sh --prefix=<PREFIX>
-        BUILD_COMMAND ./b2 headers define=_HAS_AUTO_PTR_ETC --prefix=${boost_DIR}
+        BUILD_COMMAND ./b2 headers define=_HAS_AUTO_PTR_ETC=1 --prefix=${boost_DIR}
         BUILD_IN_SOURCE 1
         INSTALL_COMMAND ""
     )
@@ -124,7 +124,7 @@ pybind11_add_module(${PROJECT_NAME}
 
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED ON)
 
 target_include_directories(${PROJECT_NAME} PRIVATE "thirdparty/xtensor/include" "thirdparty/xtensor-python/include" "thirdparty/xsimd/include" "thirdparty/xtl/include" "thirdparty/eigen" ${Python_NumPy_INCLUDE_DIRS} "src/simsoptpp/")
@@ -143,7 +143,7 @@ endif()
 add_executable(profiling EXCLUDE_FROM_ALL src/profiling/profiling.cpp src/simsoptpp/biot_savart_c.cpp src/simsoptpp/biot_savart_vjp_c.cpp src/simsoptpp/regular_grid_interpolant_3d_c.cpp)
 set_target_properties(profiling
     PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED ON)
 target_include_directories(profiling PRIVATE  "thirdparty/xtensor/include" "thirdparty/xsimd/include" "thirdparty/xtl/include" "thirdparty/eigen" "src/simsoptpp/")
 target_link_libraries(profiling PRIVATE fmt::fmt-header-only)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(DEFINED ENV{CONDA_PREFIX})
 endif()
 
 find_package(OpenMP)
-find_package(Boost 1.60.0)
+find_package(Boost 1.76.0)
 if(Boost_FOUND)
     message(STATUS "Boost version is ${Boost_VERSION_STRING}")
     message(STATUS "Boost include dirs are ${Boost_INCLUDE_DIRS}")
@@ -83,7 +83,7 @@ else()
         ${boost_target}
         PREFIX ${boost_DIR}
         GIT_REPOSITORY https://github.com/boostorg/boost.git
-        GIT_TAG boost-1.76.0
+        GIT_TAG boost-1.82.0
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
         GIT_SUBMODULES tools/build tools/boost_install libs/config libs/numeric

--- a/conda.recipe/conda_build_config.yaml
+++ b/conda.recipe/conda_build_config.yaml
@@ -1,11 +1,12 @@
 numpy:
-  - 1.19
-  - 1.20
   - 1.21
   - 1.22
+  - 1.23
+  - 1.24
 python:
   - 3.8
   - 3.9
+  - 3.10
 
 pin_run_as_build:
   numpy: x.x

--- a/config.h.in
+++ b/config.h.in
@@ -1,1 +1,2 @@
 #cmakedefine NO_XSIMD
+#cmakedefine _HAS_AUTO_PTR_ETC 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ keywords =
 
 [options]
 install_requires = 
-    numpy >= 1.19.4
+    numpy >= 1.21
     jax >= 0.2.5
     jaxlib >= 0.1.56
     scipy >= 1.5.4


### PR DESCRIPTION
This PR fixes two issues with conda build.

1. conda build on Mac is failing due to boost using some classes deprecated in C++17. Some compilers removed those features, but some didn't. So the build is working only on Linux. This PR fixes the C++17 incompatibility with boost.  
2. Adds simsopt conda packages for python v3.10. Had to bump minimal numpy version to 1.21 which is the first numpy version to support python 3.10.