### PR TITLE
Refactor single stage

### DIFF
--- a/examples/3_Advanced/single_stage_optimization_finite_beta.py
+++ b/examples/3_Advanced/single_stage_optimization_finite_beta.py
@@ -126,15 +126,16 @@ J_MSC = MSC_WEIGHT * sum(QuadraticPenalty(J, MSC_THRESHOLD) for i, J in enumerat
 J_ALS = ARCLENGTH_WEIGHT * sum(Jals)
 J_LENGTH_PENALTY = LENGTH_CON_WEIGHT * sum([QuadraticPenalty(Jls[i], LENGTH_THRESHOLD) for i in range(len(base_curves))])
 JF = Jf + J_CC + J_LENGTH + J_LENGTH_PENALTY + J_CURVATURE + J_MSC
+coil_dofs_buffer = JF.x  # This array is used for broadcasting the coil dofs from proc0 to other procs.
 ##########################################################################################
 pprint(f'  Starting optimization')
 ##########################################################################################
 # Initial stage 2 optimization
 ##########################################################################################
+
 ## The function fun_coils defined below is used to only optimize the coils at the beginning
 ## and then optimize the coils and the surface together. This makes the overall optimization
 ## more efficient as the number of iterations needed to achieve a good solution is reduced.
-
 
 def fun_coils(dofss, info):
     info['Nfeval'] += 1
@@ -155,15 +156,19 @@ def fun_coils(dofss, info):
         outstr += f" lengths=sum([{cl_string}])={sum(j.J() for j in Jls):.1f}, curv=[{kap_string}],msc=[{msc_string}]"
         print(outstr)
     return J, grad
+
 ##########################################################################################
 ##########################################################################################
+
 ## The function fun_J defined below is used to calculate the objective function value
 ## from the coils and the surface using the virtual casing principle. As this function
 ## is used also to calculate the derivatives using finite difference, it was separated
 ## from the function fun below.
 
-
-def fun_J(*all_dofs):
+n_virtual_casing_runs = 0
+def fun_J():
+    global n_virtual_casing_runs
+    """
     if len(all_dofs) == 1:
         all_dofs = all_dofs[0]
     number_vmec_dofs = len(prob.x)
@@ -173,44 +178,54 @@ def fun_J(*all_dofs):
     if np.sum(prob.x != dofs_vmec) > 0:
         prob.x = dofs_vmec
         run_vcasing = True
+    """
+    run_vcasing = True
     J_stage_1 = prob.objective()
-    dofs_coils = np.ravel(dofs_coils)
-    if np.sum(JF.x != dofs_coils) > 0:
-        JF.x = dofs_coils
+    #dofs_coils = np.ravel(dofs_coils)
+    if np.sum(JF.x != coil_dofs_buffer) > 0:
+        JF.x = coil_dofs_buffer
     if run_vcasing:
         try:
+            n_virtual_casing_runs += 1
+            print(f"[{mpi.comm_world.rank}] Running virtual casing #{n_virtual_casing_runs}")
             vc = VirtualCasing.from_vmec(vmec, src_nphi=vc_src_nphi, trgt_nphi=nphi_VMEC, trgt_ntheta=ntheta_VMEC, filename=None)
             Jf.target = vc.B_external_normal
-            if np.sum(Jf.x != dofs_coils) > 0: Jf.x = dofs_coils
+            # Next line seemed unnecessary
+            #if np.sum(Jf.x != coil_dofs_buffer) > 0: Jf.x = coil_dofs_buffer
         except ObjectiveFailure as e:
             pass
     bs.set_points(surf.gamma().reshape((-1, 3)))
     J_stage_2 = coils_objective_weight * JF.J()
     J = J_stage_1 + J_stage_2
     return J
+
 ##########################################################################################
 ##########################################################################################
 ## The function fun defined below is used to optimize the coils and the surface together.
 
 
-def fun(dofss, prob_jacobian=None, info={'Nfeval': 0}):
+def fun(dofss, prob_jacobian, info={'Nfeval': 0}):
     info['Nfeval'] += 1
     os.chdir(vmec_results_path)
     dofs_vmec = dofss[-number_vmec_dofs:]
-    dofs_coils = dofss[:-number_vmec_dofs]
-    all_dofs = np.concatenate((dofs_vmec, dofs_coils))
-    J = fun_J(all_dofs)
+    #dofs_coils = dofss[:-number_vmec_dofs]
+    coil_dofs_buffer[:] = dofss[:-number_vmec_dofs]
+    #all_dofs = np.concatenate((dofs_vmec, dofs_coils))
+    #J = fun_J(all_dofs)
+    prob.x = dofs_vmec
+    J = fun_J()
     if J > JACOBIAN_THRESHOLD or isnan(J):
         pprint(f"fun#{info['Nfeval']}: Exception caught during function evaluation with J={J}. Returning J={JACOBIAN_THRESHOLD}")
         J = JACOBIAN_THRESHOLD
         grad_with_respect_to_surface = [0] * number_vmec_dofs
-        grad_with_respect_to_coils = [0] * len(dofs_coils)
+        grad_with_respect_to_coils = [0] * len(coil_dofs_buffer)
     else:
         pprint(f"fun#{info['Nfeval']}: Objective function = {J:.4f}")
         coils_dJ = JF.dJ()
         grad_with_respect_to_coils = coils_objective_weight * coils_dJ
-        grad_with_respect_to_surface = prob_jacobian.jac(dofs_vmec, dofs_coils)[0]
-        fun_J(all_dofs)
+        grad_with_respect_to_surface = prob_jacobian.jac(dofs_vmec)[0]
+        # I'm not sure what this next line was for
+        #fun_J(dofs_vmec)
     grad = np.concatenate((grad_with_respect_to_coils, grad_with_respect_to_surface))
 
     return J, grad
@@ -250,13 +265,24 @@ pprint(f'  Performing single stage optimization with ~{MAXITER_single_stage} ite
 dofs[:-number_vmec_dofs] = res.x
 JF.x = dofs[:-number_vmec_dofs]
 mpi.comm_world.Bcast(dofs, root=0)
-dof_indicators = np.concatenate((["dof"]*len(dofs[-number_vmec_dofs:]), ["non-dof"]*len(dofs[:-number_vmec_dofs])))
-all_dofs = np.concatenate((dofs[-number_vmec_dofs:], dofs[:-number_vmec_dofs]))
-opt = make_optimizable(fun_J, all_dofs, dof_indicators=dof_indicators)
-with MPIFiniteDifference(opt.J, mpi, diff_method=diff_method, abs_step=finite_difference_abs_step, rel_step=finite_difference_rel_step) as prob_jacobian:
+#dof_indicators = np.concatenate((["dof"]*len(dofs[-number_vmec_dofs:]), ["non-dof"]*len(dofs[:-number_vmec_dofs])))
+#all_dofs = np.concatenate((dofs[-number_vmec_dofs:], dofs[:-number_vmec_dofs]))
+#opt = make_optimizable(fun_J, all_dofs, dof_indicators=dof_indicators)
+opt = make_optimizable(fun_J)
+opt.append_parent(prob)
+np.testing.assert_allclose(opt.x, prob.x)
+with MPIFiniteDifference(
+    opt.J, 
+    mpi, 
+    diff_method=diff_method, 
+    abs_step=finite_difference_abs_step, 
+    rel_step=finite_difference_rel_step,
+    data=coil_dofs_buffer,
+    ) as prob_jacobian:
     if mpi.proc0_world:
         res = minimize(fun, dofs, args=(prob_jacobian, {'Nfeval': 0}), jac=True, method='BFGS', options={'maxiter': MAXITER_single_stage}, tol=1e-9)
         dofs = res.x
+
 Bbs = bs.B().reshape((nphi_VMEC, ntheta_VMEC, 3))
 BdotN_surf = np.sum(Bbs * surf.unitnormal(), axis=2) - vc.B_external_normal
 if comm.rank == 0:

--- a/src/simsopt/_core/finite_difference.py
+++ b/src/simsopt/_core/finite_difference.py
@@ -207,9 +207,7 @@ class MPIFiniteDifference:
             self.log_file.close()
 
     # Called by MPI leaders
-    def _jac(self, x: RealArray = None, *args):
-        # *args are considered non_dofs that should also
-        # be broadcast when performing parallel computations
+    def _jac(self, x: RealArray = None):
         # Use shortcuts for class variables
         opt = self.opt
         mpi = self.mpi
@@ -227,8 +225,6 @@ class MPIFiniteDifference:
         nparams = opt.dof_size
         # Make sure all leaders have the same x0.
         mpi.comm_leaders.Bcast(x0)
-        non_dofs = np.array(args).flatten() if args else None
-        non_dofs = mpi.comm_leaders.bcast(non_dofs, root=0)
         logger.info(f'nparams: {nparams}')
         logger.info(f'x0:  {x0}')
 
@@ -273,7 +269,6 @@ class MPIFiniteDifference:
                 x = xs[:, j]
                 mpi.comm_groups.bcast(x, root=0)
                 opt.x = x
-                self.opt.non_dofs = non_dofs
                 out = np.asarray(self.fn())
 
                 if evals is None and mpi.proc0_world:
@@ -384,7 +379,7 @@ class MPIFiniteDifference:
         self.mpi.comm_leaders.bcast(x, root=0)
         self.mpi.comm_leaders.Bcast(self.data_to_broadcast)
 
-        jac, xs, evals = self._jac(x, args)
+        jac, xs, evals = self._jac(x)
         logger.debug(f'jac is {jac}')
 
         # Write to the log file:

--- a/src/simsopt/_core/optimizable.py
+++ b/src/simsopt/_core/optimizable.py
@@ -1639,7 +1639,6 @@ def make_optimizable(func, *args, dof_indicators=None, **kwargs):
         def __init__(self, func, *args, dof_indicators=None, **kwargs):
 
             self.func = func
-            args = np.ravel(args)  # The user may pass a tuple or list
             self.arg_len = len(args)
             self.kwarg_len = len(kwargs)
             self.kwarg_keys = []

--- a/src/simsopt/_core/optimizable.py
+++ b/src/simsopt/_core/optimizable.py
@@ -978,7 +978,7 @@ class Optimizable(ABC_Callable, Hashable, GSONable, metaclass=OptimizableMeta):
 
         self._full_dof_size = full_dof_size
         self._full_dof_indices = dict(zip(self._unique_dof_opts,
-                                    zip(dof_indices[:-1], dof_indices[1:])))
+                                          zip(dof_indices[:-1], dof_indices[1:])))
 
         # Update the full dof length of children
         for weakref_child in self._children:

--- a/tests/core/test_finite_difference.py
+++ b/tests/core/test_finite_difference.py
@@ -18,6 +18,7 @@ if MPI is not None:
 
 logger = logging.getLogger(__name__)
 
+
 class TestFunction1(Optimizable):
     def __init__(self):
         x = np.array([1.2, 0.9, -0.4])

--- a/tests/core/test_optimizable.py
+++ b/tests/core/test_optimizable.py
@@ -626,6 +626,10 @@ class OptimizableTests(unittest.TestCase):
         full_x = test_obj1.full_x
         self.assertTrue(np.allclose(full_x, np.array([4, 5, 6, 10, 25])))
 
+        full_x[0] = 8
+        test_obj1.full_x = full_x
+        self.assertTrue(np.allclose(test_obj1.full_x, np.array([8, 5, 6, 10, 25])))
+
     def test_local_full_x(self):
         # Check with leaf type Optimizable objects
         # Check with Optimizable objects containing parents


### PR DESCRIPTION
In #301, we've discussed how it is awkward that `finite_difference.py` had to be modified to manipulate the `non_dofs` attribute, which most Optimizable objects do not have. This PR shows one way things could be refactored to avoid this, so `non_dofs` is never mentioned. Here the changes to `finite_difference.py` and `optimizable.py` in #301 are reverted to master, and instead the `MPIFiniteDifference` class is extended to allow extra data besides `.x` to be broadcast among the worker groups. The example `single_stage_optimization_finite_beta.py` is refactored correspondingly. This example gives identical values for all quantities at the end of the optimization and uses fewer calls to `VirtualCasing.from_vmec()` in this branch compared to #301.

I'm not wedded to the approach here, but wanted to put it on the table. @rogeriojorge @mbkumar what do you think?