### PR TITLE
Mbk/docker

### DIFF
--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -31,10 +31,8 @@ RUN \
     mkdir scalapack/build && \
     cd scalapack/build && \
     CC=mpicc F77=mpif77 FC=mpif90 CXX=mpicxx cmake -DBUILD_SHARED_LIBS=ON -GNinja .. && \
-    cmake --build .  && \
-    cmake --install . && \
-    cd ../..  && \
-    rm -rf scalapack
+    cmake --build .  2>&1 | tee scalapack_build.log && \
+    cmake --install . 2>&1 | tee scalapack_install.log
      
 RUN /sbin/ldconfig
 
@@ -48,15 +46,12 @@ ENV PATH="/venv/bin:${PATH}"
 
 RUN git clone --depth 1 https://github.com/PrincetonUniversity/SPEC.git /src/SPEC && \
     cd /src/SPEC   &&  \
-    /venv/bin/pip install -v . && \
-    # /venv/bin/pip install -v dist/*.whl && \
-    cd .. && rm -rf SPEC
+    /venv/bin/pip install -v . 2>&1 | tee spec_build.log
     
 RUN git clone --depth 1 https://github.com/hiddenSymmetries/VMEC2000.git /src/VMEC && \
     cd /src/VMEC && \
     cp cmake/machines/ubuntu.json cmake_config_file.json && \
-    /venv/bin/pip install -v . && \
-    cd .. && rm -rf VMEC
+    /venv/bin/pip install -v . 2>&1 | tee vmec_build.log
 
 RUN /venv/bin/pip install h5py pyoculus py_spec
 RUN /venv/bin/pip install vtk==9.2.6 pyqt5 matplotlib pyevtk plotly
@@ -70,8 +65,10 @@ RUN git clone --recurse-submodules https://github.com/hiddenSymmetries/simsopt.g
     git fetch --tags --all && \
     /venv/bin/pip install  -v .
 
-# Get the failure logs
-# ====================
+# Get the failure logs by uncommenting the two lines following # === and running
+# DOCKER_BUILDKIT=1 docker build -t test -f Dockerfile.ubuntu . --target=fail-logs --output type=local,dest=./output/
+# For Mac, don't forget sudo before docker command
+# ========================================
 #FROM scratch AS fail-logs
 #COPY --from=intermediate /src /output
 


### PR DESCRIPTION
Updating the base image to Ubuntu 22.04 LTS from Ubuntu 20.04 LTS. The new base image uses GCC 11.3 and Python 3.10. Ubuntu 20.04 uses GCC 9.4 and Python 3.8. Changes include bumping the mpich2 version from 3.3 to 4.0. 

Based on the EOL of various packages, we are set for the next 3 years.
