### PR TITLE
Yet another single-stage refactor

### DIFF
--- a/examples/3_Advanced/single_stage_optimization_finite_beta.py
+++ b/examples/3_Advanced/single_stage_optimization_finite_beta.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from scipy.optimize import minimize
 from simsopt.util import MpiPartition
 from simsopt._core.util import ObjectiveFailure
-from simsopt._core.optimizable import make_optimizable
+from simsopt import make_optimizable
 from simsopt._core.finite_difference import MPIFiniteDifference
 from simsopt.field import BiotSavart, Current, coils_via_symmetries
 from simsopt.mhd import Vmec, QuasisymmetryRatioResidual, VirtualCasing
@@ -126,11 +126,13 @@ J_MSC = MSC_WEIGHT * sum(QuadraticPenalty(J, MSC_THRESHOLD) for i, J in enumerat
 J_ALS = ARCLENGTH_WEIGHT * sum(Jals)
 J_LENGTH_PENALTY = LENGTH_CON_WEIGHT * sum([QuadraticPenalty(Jls[i], LENGTH_THRESHOLD) for i in range(len(base_curves))])
 JF = Jf + J_CC + J_LENGTH + J_LENGTH_PENALTY + J_CURVATURE + J_MSC
+
 ##########################################################################################
 pprint(f'  Starting optimization')
 ##########################################################################################
 # Initial stage 2 optimization
 ##########################################################################################
+
 ## The function fun_coils defined below is used to only optimize the coils at the beginning
 ## and then optimize the coils and the surface together. This makes the overall optimization
 ## more efficient as the number of iterations needed to achieve a good solution is reduced.
@@ -155,62 +157,59 @@ def fun_coils(dofss, info):
         outstr += f" lengths=sum([{cl_string}])={sum(j.J() for j in Jls):.1f}, curv=[{kap_string}],msc=[{msc_string}]"
         print(outstr)
     return J, grad
+
 ##########################################################################################
 ##########################################################################################
+
 ## The function fun_J defined below is used to calculate the objective function value
 ## from the coils and the surface using the virtual casing principle. As this function
 ## is used also to calculate the derivatives using finite difference, it was separated
 ## from the function fun below.
 
 
-def fun_J(*all_dofs):
-    if len(all_dofs) == 1:
-        all_dofs = all_dofs[0]
-    number_vmec_dofs = len(prob.x)
-    dofs_vmec = all_dofs[:number_vmec_dofs]
-    dofs_coils = all_dofs[number_vmec_dofs:]
-    run_vcasing = False
-    if np.sum(prob.x != dofs_vmec) > 0:
-        prob.x = dofs_vmec
-        run_vcasing = True
+def fun_J(prob, coils_prob):
+    global previous_surf_dofs
     J_stage_1 = prob.objective()
-    dofs_coils = np.ravel(dofs_coils)
-    if np.sum(JF.x != dofs_coils) > 0:
-        JF.x = dofs_coils
-    if run_vcasing:
+    if np.any(previous_surf_dofs != prob.x):  # Only run virtual casing if surface dofs have changed
+        previous_surf_dofs = prob.x
         try:
             vc = VirtualCasing.from_vmec(vmec, src_nphi=vc_src_nphi, trgt_nphi=nphi_VMEC, trgt_ntheta=ntheta_VMEC, filename=None)
             Jf.target = vc.B_external_normal
-            if np.sum(Jf.x != dofs_coils) > 0: Jf.x = dofs_coils
         except ObjectiveFailure as e:
             pass
+
     bs.set_points(surf.gamma().reshape((-1, 3)))
     J_stage_2 = coils_objective_weight * JF.J()
     J = J_stage_1 + J_stage_2
     return J
+
 ##########################################################################################
 ##########################################################################################
 ## The function fun defined below is used to optimize the coils and the surface together.
 
 
-def fun(dofss, prob_jacobian=None, info={'Nfeval': 0}):
+def fun(dofss, prob_jacobian, info={'Nfeval': 0}):
     info['Nfeval'] += 1
     os.chdir(vmec_results_path)
-    dofs_vmec = dofss[-number_vmec_dofs:]
-    dofs_coils = dofss[:-number_vmec_dofs]
-    all_dofs = np.concatenate((dofs_vmec, dofs_coils))
-    J = fun_J(all_dofs)
+    prob.x = dofss[-number_vmec_dofs:]
+    coil_dofs = dofss[:-number_vmec_dofs]
+    # Un-fix the desired coil dofs so they can be updated:
+    JF.full_unfix(free_coil_dofs)
+    JF.x = coil_dofs
+    J = fun_J(prob, JF)
     if J > JACOBIAN_THRESHOLD or isnan(J):
         pprint(f"fun#{info['Nfeval']}: Exception caught during function evaluation with J={J}. Returning J={JACOBIAN_THRESHOLD}")
         J = JACOBIAN_THRESHOLD
         grad_with_respect_to_surface = [0] * number_vmec_dofs
-        grad_with_respect_to_coils = [0] * len(dofs_coils)
+        grad_with_respect_to_coils = [0] * len(coil_dofs)
     else:
         pprint(f"fun#{info['Nfeval']}: Objective function = {J:.4f}")
         coils_dJ = JF.dJ()
         grad_with_respect_to_coils = coils_objective_weight * coils_dJ
-        grad_with_respect_to_surface = prob_jacobian.jac(dofs_vmec, dofs_coils)[0]
-        fun_J(all_dofs)
+        JF.fix_all()  # Must re-fix the coil dofs before beginning the finite differencing.
+        grad_with_respect_to_surface = prob_jacobian.jac(prob.x)[0]
+
+    JF.fix_all()
     grad = np.concatenate((grad_with_respect_to_coils, grad_with_respect_to_surface))
 
     return J, grad
@@ -228,6 +227,7 @@ number_vmec_dofs = int(len(surf.x))
 qs = QuasisymmetryRatioResidual(vmec, quasisymmetry_target_surfaces, helicity_m=1, helicity_n=-1)
 objective_tuple = [(vmec.aspect, aspect_ratio_target, aspect_ratio_weight), (qs.residuals, 0, 1)]
 prob = LeastSquaresProblem.from_tuples(objective_tuple)
+previous_surf_dofs = prob.x
 dofs = np.concatenate((JF.x, vmec.x))
 bs.set_points(surf.gamma().reshape((-1, 3)))
 vc = VirtualCasing.from_vmec(vmec, src_nphi=vc_src_nphi, trgt_nphi=nphi_VMEC, trgt_ntheta=ntheta_VMEC, filename=None)
@@ -250,13 +250,20 @@ pprint(f'  Performing single stage optimization with ~{MAXITER_single_stage} ite
 dofs[:-number_vmec_dofs] = res.x
 JF.x = dofs[:-number_vmec_dofs]
 mpi.comm_world.Bcast(dofs, root=0)
-dof_indicators = np.concatenate((["dof"]*len(dofs[-number_vmec_dofs:]), ["non-dof"]*len(dofs[:-number_vmec_dofs])))
-all_dofs = np.concatenate((dofs[-number_vmec_dofs:], dofs[:-number_vmec_dofs]))
-opt = make_optimizable(fun_J, all_dofs, dof_indicators=dof_indicators)
-with MPIFiniteDifference(opt.J, mpi, diff_method=diff_method, abs_step=finite_difference_abs_step, rel_step=finite_difference_rel_step) as prob_jacobian:
+opt = make_optimizable(fun_J, prob, JF)
+free_coil_dofs = JF.dofs_free_status
+JF.fix_all()
+
+with MPIFiniteDifference(
+    opt.J, 
+    mpi, 
+    diff_method=diff_method, 
+    abs_step=finite_difference_abs_step, 
+    rel_step=finite_difference_rel_step,
+) as prob_jacobian:
     if mpi.proc0_world:
         res = minimize(fun, dofs, args=(prob_jacobian, {'Nfeval': 0}), jac=True, method='BFGS', options={'maxiter': MAXITER_single_stage}, tol=1e-9)
-        dofs = res.x
+
 Bbs = bs.B().reshape((nphi_VMEC, ntheta_VMEC, 3))
 BdotN_surf = np.sum(Bbs * surf.unitnormal(), axis=2) - vc.B_external_normal
 if comm.rank == 0:
@@ -270,6 +277,7 @@ pprint(f"Mean iota after optimization: {vmec.mean_iota()}")
 pprint(f"Quasisymmetry objective after optimization: {qs.total()}")
 pprint(f"Magnetic well after optimization: {vmec.vacuum_well()}")
 pprint(f"Squared flux after optimization: {Jf.J()}")
+JF.full_unfix(free_coil_dofs)  # Needed to evaluate JF.dJ
 BdotN_surf = np.sum(Bbs * surf.unitnormal(), axis=2)
 BdotN = np.mean(np.abs(BdotN_surf))
 BdotNmax = np.max(np.abs(BdotN_surf))

--- a/src/simsopt/_core/finite_difference.py
+++ b/src/simsopt/_core/finite_difference.py
@@ -298,14 +298,14 @@ class MPIFiniteDifference:
         logger.debug('mpi leaders task')
 
         # x is a buffer for receiving the state vector:
-        x = np.empty(self.opt.dof_size, dtype='d')
+        full_x = np.empty(self.opt.full_dof_size, dtype='d')
         # If we make it here, we must be doing a fd_jac_par
         # calculation, so receive the state vector: mpi4py has
         # separate bcast and Bcast functions!!  comm.Bcast(x,
         # root=0)
-        x = self.mpi.comm_leaders.bcast(x, root=0)
-        logger.debug(f'mpi leaders loop x={x}')
-        self.opt.x = x
+        full_x = self.mpi.comm_leaders.bcast(full_x, root=0)
+        logger.debug(f'mpi leaders loop full_x={full_x}')
+        self.opt.full_x = full_x
         self._jac()
 
     def mpi_workers_task(self, *args):
@@ -358,7 +358,9 @@ class MPIFiniteDifference:
                                      dtype=np.int32)
 
         self.mpi.mobilize_leaders(ARB_VAL)  # Any value not equal to STOP
-        self.mpi.comm_leaders.bcast(x, root=0)
+        full_x = self.opt.full_x
+        self.mpi.comm_leaders.bcast(full_x, root=0)
+        self.opt.full_x = full_x
 
         jac, xs, evals = self._jac(x)
         logger.debug(f'jac is {jac}')

--- a/src/simsopt/_core/optimizable.py
+++ b/src/simsopt/_core/optimizable.py
@@ -1055,6 +1055,16 @@ class Optimizable(ABC_Callable, Hashable, GSONable, metaclass=OptimizableMeta):
         return np.concatenate([opt._dofs.full_x for
                                opt in self._unique_dof_opts])
 
+    @full_x.setter
+    def full_x(self, x: RealArray) -> None:
+        lengths = [len(opt._dofs.full_x) for opt in self._unique_dof_opts]
+        if sum(lengths) != len(x):
+            raise ValueError
+        index = 0
+        for length, opt in zip(lengths, self._unique_dof_opts):
+            opt._dofs.full_x = x[index:index + length]
+            index += length
+
     @property
     def local_x(self) -> RealArray:
         """

--- a/src/simsopt/_core/optimizable.py
+++ b/src/simsopt/_core/optimizable.py
@@ -1639,7 +1639,6 @@ def make_optimizable(func, *args, dof_indicators=None, **kwargs):
         def __init__(self, func, *args, dof_indicators=None, **kwargs):
 
             self.func = func
-            args = np.ravel(args)  # The user may pass a tuple or list
             self.arg_len = len(args)
             self.kwarg_len = len(kwargs)
             self.kwarg_keys = []

--- a/src/simsopt/_core/optimizable.py
+++ b/src/simsopt/_core/optimizable.py
@@ -966,6 +966,7 @@ class Optimizable(ABC_Callable, Hashable, GSONable, metaclass=OptimizableMeta):
         # TODO: Develop a faster scheme.
         # TODO: Alternatively ask the user to call this manually from the end
         # TODO: node after fixing/unfixing any DOF
+        dof_indices = [0]
         full_dof_size = 0
         dof_objs = set()
         self.ancestors = self._get_ancestors()
@@ -974,8 +975,12 @@ class Optimizable(ABC_Callable, Hashable, GSONable, metaclass=OptimizableMeta):
             if opt.dofs not in dof_objs:
                 dof_objs.add(opt.dofs)
                 full_dof_size += opt.local_full_dof_size
+                dof_indices.append(full_dof_size)
                 self._unique_dof_opts.append(opt)
+
         self._full_dof_size = full_dof_size
+        self._full_dof_indices = dict(zip(self._unique_dof_opts,
+                                          zip(dof_indices[:-1], dof_indices[1:])))
 
         # Update the full dof length of children
         for weakref_child in self._children:
@@ -1057,13 +1062,11 @@ class Optimizable(ABC_Callable, Hashable, GSONable, metaclass=OptimizableMeta):
 
     @full_x.setter
     def full_x(self, x: RealArray) -> None:
-        lengths = [len(opt._dofs.full_x) for opt in self._unique_dof_opts]
-        if sum(lengths) != len(x):
-            raise ValueError
-        index = 0
-        for length, opt in zip(lengths, self._unique_dof_opts):
-            opt._dofs.full_x = x[index:index + length]
-            index += length
+        """
+        Setter used to set all the global DOF values
+        """
+        for opt, indices in self._full_dof_indices.items():
+            opt.local_full_x = x[indices[0]:indices[1]]
 
     @property
     def local_x(self) -> RealArray:
@@ -1437,6 +1440,34 @@ class Optimizable(ABC_Callable, Hashable, GSONable, metaclass=OptimizableMeta):
         """
         self._dofs.unfix(key)
         self.update_free_dof_size_indices()
+
+    def full_fix(self, arr: Key) -> None:
+        """
+        Set the fixed/free attribute for all dofs on which this Optimizable object
+        depends. 
+
+        Args:
+            arr: List or array of the same length as ``full_x``, containing
+                booleans. For each array entry that is ``True``, the corresponding dof will be set
+                to fixed.
+        """
+        for opt, indices in self._full_dof_indices.items():
+            opt._dofs._free[:] = np.logical_not(arr[indices[0]:indices[1]])
+            opt._dofs._update_opt_indices()
+
+    def full_unfix(self, arr: Key) -> None:
+        """
+        Set the fixed/free attribute for all dofs on which this Optimizable object
+        depends. 
+
+        Args:
+            arr: List or array of the same length as ``full_x``, containing
+                booleans. For each array entry that is ``True``, the corresponding dof will be set
+                to free.
+        """
+        for opt, indices in self._full_dof_indices.items():
+            opt._dofs._free[:] = arr[indices[0]:indices[1]]
+            opt._dofs._update_opt_indices()
 
     def local_fix_all(self) -> None:
         """

--- a/tests/core/test_finite_difference.py
+++ b/tests/core/test_finite_difference.py
@@ -262,13 +262,14 @@ class MPIFiniteDifferenceTests(unittest.TestCase):
             logger.info(f"nprocs={mpi.nprocs_world} ngroups={ngroups}")
             optimizable = TestFunction1()
             initial_x = optimizable.x
-            print(optimizable.dof_names)
             optimizable.fix_all()
             optimizable.unfix('x0')
             arr_to_bcast = np.arange(3) * 0.25 + ngroups + 7  # Arbitrary values
             if mpi.proc0_world:
                 # Only proc0_world has the data:
                 optimizable.full_x = arr_to_bcast
+            if not mpi.proc0_world:
+                self.assertGreater(np.sum(np.abs(optimizable.full_x - arr_to_bcast)), 20)
 
             with MPIFiniteDifference(optimizable.J, mpi) as fd:
                 # bcast the array within the MPIFiniteDifference context:

--- a/tests/core/test_finite_difference.py
+++ b/tests/core/test_finite_difference.py
@@ -253,3 +253,28 @@ class MPIFiniteDifferenceTests(unittest.TestCase):
             mpi.together()
             if mpi.proc0_world:
                 fd.log_file.close()
+
+    def test_bcast_fixed_dofs(self):
+        """Test that MPIFiniteDifference also MPI-broadcasts the fixed dofs."""
+
+        for ngroups in range(1, 4):
+            mpi = MpiPartition(ngroups=ngroups)
+            logger.info(f"nprocs={mpi.nprocs_world} ngroups={ngroups}")
+            optimizable = TestFunction1()
+            initial_x = optimizable.x
+            print(optimizable.dof_names)
+            optimizable.fix_all()
+            optimizable.unfix('x0')
+            arr_to_bcast = np.arange(3) * 0.25 + ngroups + 7  # Arbitrary values
+            if mpi.proc0_world:
+                # Only proc0_world has the data:
+                optimizable.full_x = arr_to_bcast
+
+            with MPIFiniteDifference(optimizable.J, mpi) as fd:
+                # bcast the array within the MPIFiniteDifference context:
+                if mpi.proc0_world:
+                    fd.jac()
+
+            # The data should now reside with all group leaders:
+            if mpi.proc0_groups:
+                np.testing.assert_allclose(optimizable.full_x, arr_to_bcast)

--- a/tests/core/test_optimizable.py
+++ b/tests/core/test_optimizable.py
@@ -626,6 +626,15 @@ class OptimizableTests(unittest.TestCase):
         full_x = test_obj1.full_x
         self.assertTrue(np.allclose(full_x, np.array([4, 5, 6, 10, 25])))
 
+        new_vals = np.arange(5) - 10
+        with self.assertRaises(ValueError):
+            test_obj1.full_x = np.arange(6)
+        with self.assertRaises(ValueError):
+            test_obj1.full_x = np.arange(4)
+        test_obj1.full_x = new_vals
+        full_x = test_obj1.full_x
+        self.assertTrue(np.allclose(full_x, new_vals))
+
     def test_local_full_x(self):
         # Check with leaf type Optimizable objects
         # Check with Optimizable objects containing parents
@@ -1357,6 +1366,14 @@ class TestOptimizableSharedDOFs(unittest.TestCase):
         adder_shared_dofs.x = [0, 1]
         self.assertEqual(adder_orig.J(), adder_shared_dofs.J())
         adder_orig.set("x", 20)
+        self.assertEqual(adder_orig.J(), adder_shared_dofs.J())
+        with self.assertRaises(ValueError):
+            adder_orig.full_x = np.arange(6)
+        adder_orig.full_x = np.arange(3) - 10
+        self.assertEqual(adder_orig.J(), adder_shared_dofs.J())
+        with self.assertRaises(ValueError):
+            adder_shared_dofs.full_x = np.arange(6)
+        adder_shared_dofs.full_x = np.arange(3) - 100
         self.assertEqual(adder_orig.J(), adder_shared_dofs.J())
 
     def test_adder_dofs_shared_fix_unfix(self):

--- a/tests/core/test_optimizable.py
+++ b/tests/core/test_optimizable.py
@@ -627,13 +627,26 @@ class OptimizableTests(unittest.TestCase):
         self.assertTrue(np.allclose(full_x, np.array([4, 5, 6, 10, 25])))
 
         new_vals = np.arange(5) - 10
-        with self.assertRaises(ValueError):
-            test_obj1.full_x = np.arange(6)
-        with self.assertRaises(ValueError):
-            test_obj1.full_x = np.arange(4)
         test_obj1.full_x = new_vals
         full_x = test_obj1.full_x
         self.assertTrue(np.allclose(full_x, new_vals))
+
+    def test_full_fix(self):
+        adder = Adder(n=3, x0=[1, 2, 3], names=['x', 'y', 'z'])
+        iden = Identity(x=10, dof_fixed=True)
+        test_obj = OptClassWithParents(20, depends_on=[iden, adder])
+        full_x = test_obj.full_x
+        # Loop over all possible True/False arrays:
+        for binary_arr in range(32):
+            free_arr = np.array([(binary_arr >> j) & 1 for j in range(5)], dtype=bool)
+            fixed_arr = np.logical_not(free_arr)
+            test_obj.full_fix(fixed_arr)
+            np.testing.assert_equal(test_obj.dofs_free_status, free_arr)
+            np.testing.assert_allclose(test_obj.x, full_x[free_arr])
+
+            test_obj.full_unfix(free_arr)
+            np.testing.assert_equal(test_obj.dofs_free_status, free_arr)
+            np.testing.assert_allclose(test_obj.x, full_x[free_arr])
 
     def test_local_full_x(self):
         # Check with leaf type Optimizable objects
@@ -1367,12 +1380,8 @@ class TestOptimizableSharedDOFs(unittest.TestCase):
         self.assertEqual(adder_orig.J(), adder_shared_dofs.J())
         adder_orig.set("x", 20)
         self.assertEqual(adder_orig.J(), adder_shared_dofs.J())
-        with self.assertRaises(ValueError):
-            adder_orig.full_x = np.arange(6)
         adder_orig.full_x = np.arange(3) - 10
         self.assertEqual(adder_orig.J(), adder_shared_dofs.J())
-        with self.assertRaises(ValueError):
-            adder_shared_dofs.full_x = np.arange(6)
         adder_shared_dofs.full_x = np.arange(3) - 100
         self.assertEqual(adder_orig.J(), adder_shared_dofs.J())
 


### PR DESCRIPTION
This is yet another possible refactoring of the single-stage example in #301 suggested by @mbkumar, as an alternative to #317. In this approach, `MPIFiniteDifference` broadcasts `full_x` instead of just the free `x`, so there is no extra data that needs to be broadcast. The coil dofs are fixed during the finite-differencing, then un-fixed to update the coil dofs and compute their gradient analytically, then fixed again for the next finite-differencing, etc. Even though the coil dofs are fixed during the finite differencing, they are still part of `full_x`, so they get broadcast.

To get this working, a few functions were added to `Optimizable`: a setter for `full_x` (copied from @mbkumar 's commit to #317), and `full_fix()` and `full_unfix()` to set the free/fixed property for the full dofs on which an object depends. Corresponding tests have been added. A few changes from #301 to `finite_difference.py` and `optimizable.py` have been reverted, as in #317.

For `single_stage_optimization_finite_beta.py`, this branch gives identical values for all quantities at the end of the optimization and uses fewer calls to `VirtualCasing.from_vmec()` compared to https://github.com/hiddenSymmetries/simsopt/pull/301.

I don't have a super strong preference between this approach and #317, but perhaps slightly prefer this one, since it makes sense that `full_x` should be synched by `MPIFiniteDifference` anyway. What do you think?