### PR TITLE
New magnetic field class - mirror machine

### DIFF
--- a/docs/source/fields.rst
+++ b/docs/source/fields.rst
@@ -170,6 +170,32 @@ Physics Communications 43 (1986) 157—167
 It is an analytical magnetic field representation that allows the
 explicit calculation of the width of the magnetic field islands.
 
+MirrorModel
+~~~~~~~~~~~
+
+The :obj:`simsopt.field.MirrorModel` provides the
+vacuum magnetic field employed in https://arxiv.org/abs/2305.06372 to study
+the magnetic mirror experiment WHAM. It is composed of an analytical flux
+function whose gradients yield the magnetic field vector. Namely, the
+magnetic field is given by B=B_R e_R + B_Z e_Z, where e_R and e_Z are
+the cylindrical radial and vertical unit vectors, respectively, and
+B_R and B_Z are given by
+
+.. math::
+
+    B_R = -{\partial\psi}/{\partial Z}/R, B_Z = {\partial\psi}/{\partial R}/R
+
+In this model, the magnetic flux function psi is written as a double
+Lorentzian distribution
+
+.. math::
+
+    \psi = \frac{R^2 B}{2 \pi \gamma}\left(\left[1+\left(\frac{Z-Z_m}{\gamma}\right)^2\right]^{-1}+\left[1+\left(\frac{Z+Z_m}{\gamma}\right)^2\right]^{-1}\right)
+
+The input parameters are B, gamma and Z_m with the standard values the
+ones used in https://arxiv.org/abs/2305.06372, that is, B0=6.51292,
+gamma = 0.124904 and Z_m = 0.98.
+
 InterpolatedField
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/source/fields.rst
+++ b/docs/source/fields.rst
@@ -173,28 +173,10 @@ explicit calculation of the width of the magnetic field islands.
 MirrorModel
 ~~~~~~~~~~~
 
-The :obj:`simsopt.field.MirrorModel` provides the
-vacuum magnetic field employed in https://arxiv.org/abs/2305.06372 to study
-the magnetic mirror experiment WHAM. It is composed of an analytical flux
-function whose gradients yield the magnetic field vector. Namely, the
-magnetic field is given by B=B_R e_R + B_Z e_Z, where e_R and e_Z are
-the cylindrical radial and vertical unit vectors, respectively, and
-B_R and B_Z are given by
-
-.. math::
-
-    B_R = -{\partial\psi}/{\partial Z}/R, B_Z = {\partial\psi}/{\partial R}/R
-
-In this model, the magnetic flux function psi is written as a double
-Lorentzian distribution
-
-.. math::
-
-    \psi = \frac{R^2 B}{2 \pi \gamma}\left(\left[1+\left(\frac{Z-Z_m}{\gamma}\right)^2\right]^{-1}+\left[1+\left(\frac{Z+Z_m}{\gamma}\right)^2\right]^{-1}\right)
-
-The input parameters are B, gamma and Z_m with the standard values the
-ones used in https://arxiv.org/abs/2305.06372, that is, B0=6.51292,
-gamma = 0.124904 and Z_m = 0.98.
+The class :obj:`simsopt.field.MirrorModel` provides an analytic model field for
+magnetic mirrors, used in https://arxiv.org/abs/2305.06372 to study
+the experiment WHAM. See the documentation of :obj:`~simsopt.field.MirrorModel`
+for more details.
 
 InterpolatedField
 ~~~~~~~~~~~~~~~~~

--- a/src/simsopt/field/magneticfieldclasses.py
+++ b/src/simsopt/field/magneticfieldclasses.py
@@ -17,7 +17,8 @@ from .._core.json import GSONable, GSONDecoder
 logger = logging.getLogger(__name__)
 
 __all__ = ['ToroidalField', 'PoloidalField', 'ScalarPotentialRZMagneticField',
-           'CircularCoil', 'Dommaschk', 'Reiman', 'InterpolatedField', 'DipoleField']
+           'CircularCoil', 'Dommaschk', 'Reiman', 'InterpolatedField', 'DipoleField',
+           'MirrorModel']
 
 
 class ToroidalField(MagneticField):

--- a/src/simsopt/field/magneticfieldclasses.py
+++ b/src/simsopt/field/magneticfieldclasses.py
@@ -851,3 +851,112 @@ class InterpolatedField(sopp.InterpolatedField, MagneticField):
             rmin=self.r_range[0], rmax=self.r_range[1],
             zmin=self.z_range[0], zmax=self.z_range[1]
         )
+
+
+class MirrorModel(MagneticField):
+    """
+    Vacuum magnetic field employed in https://arxiv.org/abs/2305.06372 to study
+    the magnetic mirror experiment WHAM. It is composed of an analytical flux
+    function whose gradients yield the magnetic field vector. Namely, the
+    magnetic field is given by B=B_R e_R + B_Z e_Z, where e_R and e_Z are
+    the cylindrical radial and vertical unit vectors, respectively, and
+    B_R and B_Z are given by
+
+    .. math::
+
+        B_R = -{\partial\psi}/{\partial Z}/R, B_Z = {\partial\psi}/{\partial R}/R
+    
+    In this model, the magnetic flux function psi is written as a double
+    Lorentzian distribution
+
+    .. math::
+
+        \psi = \frac{R^2 B}{2 \pi \gamma}\left(\left[1+\left(\frac{Z-Z_m}{\gamma}\right)^2\right]^{-1}+\left[1+\left(\frac{Z+Z_m}{\gamma}\right)^2\right]^{-1}\right)
+    
+    The input parameters are B, gamma and Z_m with the standard values the
+    ones used in https://arxiv.org/abs/2305.06372, that is, B0=6.51292,
+    gamma = 0.124904 and Z_m = 0.98.
+
+    Args:
+        B0:  parameter \mathcal{B} of the flux surface function
+        gamma:  parameter \gamma of the flux surface function
+        Z_m:  parameter Z_m of the flux surface function
+    """
+
+    def __init__(self, B0=6.51292, gamma = 0.124904, Z_m = 0.98):
+        MagneticField.__init__(self)
+        self.B0 = B0
+        self.gamma = gamma
+        self.Z_m = Z_m
+    
+    def _psi(self, R, Z):
+        factor1 = 1+((Z-self.Z_m)/(self.gamma))**2
+        factor2 = 1+((Z+self.Z_m)/(self.gamma))**2
+        psi = (R*R*self.B0/(2*np.pi*self.gamma))*(1/factor1+1/factor2)
+        return psi
+
+    def _B_impl(self, B):
+        points = self.get_points_cart_ref()
+        r = np.sqrt(np.square(points[:, 0]) + np.square(points[:, 1]))
+        z = points[:, 2]
+        phi = np.arctan2(points[:, 1], points[:, 0])
+        # BR = -(1/R)dpsi/dZ, BZ=(1/R)dpsi/dR
+        factor1 = (1+((z-self.Z_m)/(self.gamma))**2)**2
+        factor2 = (1+((z+self.Z_m)/(self.gamma))**2)**2
+        Br = (r*self.B0/(np.pi*self.gamma**3))*((z-self.Z_m)/factor1+(z+self.Z_m)/factor2)
+        Bz = self._psi(r,z)*2/r/r
+        B[:, 0] = Br * np.cos(phi)
+        B[:, 1] = Br * np.sin(phi)
+        B[:, 2] = Bz
+
+    def _dB_by_dX_impl(self, dB):
+        points = self.get_points_cart_ref()
+        r = np.sqrt(np.square(points[:, 0]) + np.square(points[:, 1]))
+        z = points[:, 2]
+        phi = np.arctan2(points[:, 1], points[:, 0])
+        
+        factor1 = (1+((z-self.Z_m)/(self.gamma))**2)**2
+        factor2 = (1+((z+self.Z_m)/(self.gamma))**2)**2
+        Br = (r*self.B0/(np.pi*self.gamma**3))*((z-self.Z_m)/factor1+(z+self.Z_m)/factor2)
+        # Bz = self._psi(r,z)*2/r/r
+        dBrdr = (self.B0/(np.pi*self.gamma**3))*((z-self.Z_m)/factor1+(z+self.Z_m)/factor2)
+        dBzdz = -2*dBrdr
+        dBrdz = (self.B0*r/(np.pi*self.gamma**3))*(1/factor1+1/factor2
+                                                   -4*self.gamma**4*((z-self.Z_m)**2/((z-self.Z_m)**2+self.gamma**2)**3+(z+self.Z_m)**2/((z+self.Z_m)**2+self.gamma**2)**3))
+        cosphi = np.cos(phi)
+        sinphi = np.sin(phi)
+        dcosphidx = -points[:, 0]**2/r**3 + 1/r
+        dsinphidx = -points[:, 0]*points[:, 1]/r**3
+        dcosphidy = -points[:, 0]*points[:, 1]/r**3
+        dsinphidy = -points[:, 1]**2/r**3 + 1/r
+        drdx = points[:, 0]/r
+        drdy = points[:, 1]/r
+        dBxdx = dBrdr*drdx*cosphi + Br*dcosphidx
+        dBxdy = dBrdr*drdy*cosphi + Br*dcosphidy
+        dBxdz = dBrdz*cosphi
+        dBydx = dBrdr*drdx*sinphi + Br*dsinphidx
+        dBydy = dBrdr*drdy*sinphi + Br*dsinphidy
+        dBydz = dBrdz*sinphi
+        
+        dB[:, 0, 0] = dBxdx
+        dB[:, 1, 0] = dBxdy
+        dB[:, 2, 0] = dBxdz
+        dB[:, 0, 1] = dBydx
+        dB[:, 1, 1] = dBydy
+        dB[:, 2, 1] = dBydz
+        dB[:, 0, 2] = 0
+        dB[:, 1, 2] = 0
+        dB[:, 2, 2] = dBzdz
+
+    def as_dict(self, serial_objs_dict) -> dict:
+        d = super().as_dict(serial_objs_dict=serial_objs_dict)
+        d["points"] = self.get_points_cart()
+        return d
+
+    @classmethod
+    def from_dict(cls, d, serial_objs_dict, recon_objs):
+        field = cls(d["B0"], d["gamma"], d["Z_m"])
+        decoder = GSONDecoder()
+        xyz = decoder.process_decoded(d["points"], serial_objs_dict, recon_objs)
+        field.set_points_cart(xyz)
+        return field

--- a/src/simsopt/field/magneticfieldclasses.py
+++ b/src/simsopt/field/magneticfieldclasses.py
@@ -865,14 +865,14 @@ class MirrorModel(MagneticField):
     .. math::
 
         B_R = -{\partial\psi}/{\partial Z}/R, B_Z = {\partial\psi}/{\partial R}/R
-    
+
     In this model, the magnetic flux function psi is written as a double
     Lorentzian distribution
 
     .. math::
 
         \psi = \frac{R^2 B}{2 \pi \gamma}\left(\left[1+\left(\frac{Z-Z_m}{\gamma}\right)^2\right]^{-1}+\left[1+\left(\frac{Z+Z_m}{\gamma}\right)^2\right]^{-1}\right)
-    
+
     The input parameters are B, gamma and Z_m with the standard values the
     ones used in https://arxiv.org/abs/2305.06372, that is, B0=6.51292,
     gamma = 0.124904 and Z_m = 0.98.
@@ -883,12 +883,12 @@ class MirrorModel(MagneticField):
         Z_m:  parameter Z_m of the flux surface function
     """
 
-    def __init__(self, B0=6.51292, gamma = 0.124904, Z_m = 0.98):
+    def __init__(self, B0=6.51292, gamma=0.124904, Z_m=0.98):
         MagneticField.__init__(self)
         self.B0 = B0
         self.gamma = gamma
         self.Z_m = Z_m
-    
+
     def _psi(self, R, Z):
         factor1 = 1+((Z-self.Z_m)/(self.gamma))**2
         factor2 = 1+((Z+self.Z_m)/(self.gamma))**2
@@ -904,7 +904,7 @@ class MirrorModel(MagneticField):
         factor1 = (1+((z-self.Z_m)/(self.gamma))**2)**2
         factor2 = (1+((z+self.Z_m)/(self.gamma))**2)**2
         Br = (r*self.B0/(np.pi*self.gamma**3))*((z-self.Z_m)/factor1+(z+self.Z_m)/factor2)
-        Bz = self._psi(r,z)*2/r/r
+        Bz = self._psi(r, z)*2/r/r
         B[:, 0] = Br * np.cos(phi)
         B[:, 1] = Br * np.sin(phi)
         B[:, 2] = Bz
@@ -914,7 +914,7 @@ class MirrorModel(MagneticField):
         r = np.sqrt(np.square(points[:, 0]) + np.square(points[:, 1]))
         z = points[:, 2]
         phi = np.arctan2(points[:, 1], points[:, 0])
-        
+
         factor1 = (1+((z-self.Z_m)/(self.gamma))**2)**2
         factor2 = (1+((z+self.Z_m)/(self.gamma))**2)**2
         Br = (r*self.B0/(np.pi*self.gamma**3))*((z-self.Z_m)/factor1+(z+self.Z_m)/factor2)
@@ -922,7 +922,7 @@ class MirrorModel(MagneticField):
         dBrdr = (self.B0/(np.pi*self.gamma**3))*((z-self.Z_m)/factor1+(z+self.Z_m)/factor2)
         dBzdz = -2*dBrdr
         dBrdz = (self.B0*r/(np.pi*self.gamma**3))*(1/factor1+1/factor2
-                                                   -4*self.gamma**4*((z-self.Z_m)**2/((z-self.Z_m)**2+self.gamma**2)**3+(z+self.Z_m)**2/((z+self.Z_m)**2+self.gamma**2)**3))
+                                                   - 4*self.gamma**4*((z-self.Z_m)**2/((z-self.Z_m)**2+self.gamma**2)**3+(z+self.Z_m)**2/((z+self.Z_m)**2+self.gamma**2)**3))
         cosphi = np.cos(phi)
         sinphi = np.sin(phi)
         dcosphidx = -points[:, 0]**2/r**3 + 1/r
@@ -937,7 +937,7 @@ class MirrorModel(MagneticField):
         dBydx = dBrdr*drdx*sinphi + Br*dsinphidx
         dBydy = dBrdr*drdy*sinphi + Br*dsinphidy
         dBydz = dBrdz*sinphi
-        
+
         dB[:, 0, 0] = dBxdx
         dB[:, 1, 0] = dBxdy
         dB[:, 2, 0] = dBxdz

--- a/src/simsopt/field/magneticfieldclasses.py
+++ b/src/simsopt/field/magneticfieldclasses.py
@@ -855,33 +855,35 @@ class InterpolatedField(sopp.InterpolatedField, MagneticField):
 
 
 class MirrorModel(MagneticField):
-    """
-    Vacuum magnetic field employed in https://arxiv.org/abs/2305.06372 to study
-    the magnetic mirror experiment WHAM. It is composed of an analytical flux
-    function whose gradients yield the magnetic field vector. Namely, the
-    magnetic field is given by B=B_R e_R + B_Z e_Z, where e_R and e_Z are
-    the cylindrical radial and vertical unit vectors, respectively, and
-    B_R and B_Z are given by
+    r"""
+    Model magnetic field employed in https://arxiv.org/abs/2305.06372 to study
+    the magnetic mirror experiment WHAM. The
+    magnetic field is given by :math:`\vec{B}=B_R \vec{e}_R + B_Z \vec{e}_Z`, where 
+    :math:`\vec{e}_R` and :math:`\vec{e}_Z` are
+    the cylindrical radial and axial unit vectors, respectively, and
+    :math:`B_R` and :math:`B_Z` are given by
 
     .. math::
 
-        B_R = -{\partial\psi}/{\partial Z}/R, B_Z = {\partial\psi}/{\partial R}/R
+        B_R = -\frac{1}{R} \frac{\partial\psi}{\partial Z}, \; B_Z = \frac{1}{R}.
+        \frac{\partial\psi}{\partial R}
 
-    In this model, the magnetic flux function psi is written as a double
-    Lorentzian distribution
+    In this model, the magnetic flux function :math:`\psi` is written as a double
+    Lorentzian function
 
     .. math::
 
-        \psi = \frac{R^2 B}{2 \pi \gamma}\left(\left[1+\left(\frac{Z-Z_m}{\gamma}\right)^2\right]^{-1}+\left[1+\left(\frac{Z+Z_m}{\gamma}\right)^2\right]^{-1}\right)
+        \psi = \frac{R^2 \mathcal{B}}{2 \pi \gamma}\left(\left[1+\left(\frac{Z-Z_m}{\gamma}\right)^2\right]^{-1}+\left[1+\left(\frac{Z+Z_m}{\gamma}\right)^2\right]^{-1}\right).
 
-    The input parameters are B, gamma and Z_m with the standard values the
-    ones used in https://arxiv.org/abs/2305.06372, that is, B0=6.51292,
-    gamma = 0.124904 and Z_m = 0.98.
+    Note that this field is neither a vacuum field nor a solution of MHD force balance.
+    The input parameters are ``B0``, ``gamma`` and ``Z_m`` with the standard values the
+    ones used in https://arxiv.org/abs/2305.06372, that is, ``B0 = 6.51292``,
+    ``gamma = 0.124904``, and ``Z_m = 0.98``.
 
     Args:
-        B0:  parameter \mathcal{B} of the flux surface function
-        gamma:  parameter \gamma of the flux surface function
-        Z_m:  parameter Z_m of the flux surface function
+        B0:  parameter :math:`\mathcal{B}` of the flux surface function
+        gamma:  parameter :math:`\gamma` of the flux surface function
+        Z_m:  parameter :math:`Z_m` of the flux surface function
     """
 
     def __init__(self, B0=6.51292, gamma=0.124904, Z_m=0.98):

--- a/tests/field/test_magneticfields.py
+++ b/tests/field/test_magneticfields.py
@@ -523,6 +523,10 @@ class Testing(unittest.TestCase):
         self.assertTrue(np.allclose(Bfield.B(), Bfield_regen.B()))
 
     def test_MirrorModel(self):
+        """
+        For MirrorModel, compare to reference values from Rogerio Jorge's
+        Mathematica notebook.
+        """
         Bfield = MirrorModel(B0=6.51292, gamma=0.124904, Z_m=0.98)
         point = np.asarray([[0.9231, 0.8423, -0.1123]])
         Bfield.set_points(point)
@@ -531,8 +535,6 @@ class Testing(unittest.TestCase):
         # Verify B
         B = Bfield.B()
         assert np.allclose(B, [[0.172472, 0.157375, 0.551171]])
-        # Verify gradB is symmetric and its value
-        # assert np.allclose(gradB, transpGradB)
         assert np.allclose(transpGradB, np.array([[0.18684, 0, -1.66368], [0, 0.18684, -1.51805], [0, 0, -0.373679]]))
         # Verify serialization works
         field_json_str = json.dumps(SIMSON(Bfield), cls=GSONEncoder)

--- a/tests/field/test_magneticfields.py
+++ b/tests/field/test_magneticfields.py
@@ -474,7 +474,7 @@ class Testing(unittest.TestCase):
         field_json_str = json.dumps(SIMSON(Bfield), cls=GSONEncoder)
         Bfield_regen = json.loads(field_json_str, cls=GSONDecoder)
         self.assertTrue(np.allclose(B, Bfield_regen.B()))
-        
+
         #Field configuration from Dommaschk paper equation number (40)
         mn = [[5, 2], [5, 4], [5, 10]]
         coeffs = [[1.4, 1.4], [19.25, 0], [5.10e10, 5.10e10]]

--- a/tests/field/test_magneticfields.py
+++ b/tests/field/test_magneticfields.py
@@ -19,7 +19,7 @@ from simsopt.field import (BiotSavart, CircularCoil, Coil, Current,
                            DipoleField, Dommaschk, InterpolatedField,
                            MagneticFieldSum, PoloidalField, Reiman,
                            ScalarPotentialRZMagneticField, ToroidalField,
-                           coils_via_symmetries)
+                           coils_via_symmetries, MirrorModel)
 from simsopt.objectives import SquaredFlux
 from simsopt.geo import (CurveHelical, CurveRZFourier, CurveXYZFourier,
                          PermanentMagnetGrid, SurfaceRZFourier,
@@ -517,6 +517,27 @@ class Testing(unittest.TestCase):
         assert np.allclose(gradB, np.array([[39.394312086253024, 14.061725133810995, 0.1684479703125076],
                                             [14.061729381899355, -40.23304445668633, -0.40810476986895994],
                                             [0.16844815337021118, -0.4081047568874514, 0.838733]]))                
+        # Verify serialization works
+        field_json_str = json.dumps(SIMSON(Bfield), cls=GSONEncoder)
+        Bfield_regen = json.loads(field_json_str, cls=GSONDecoder)
+        self.assertTrue(np.allclose(Bfield.B(), Bfield_regen.B()))
+
+    def test_MirrorModel(self):
+        Bfield = MirrorModel(B0=6.51292, gamma=0.124904, Z_m=0.98)
+        point = np.asarray([[0.9231, 0.8423, -0.1123]])
+        Bfield.set_points(point)
+        gradB = np.array(Bfield.dB_by_dX())
+        transpGradB = np.array([dBdx.T for dBdx in gradB])
+        # Verify B
+        B = Bfield.B()
+        assert np.allclose(B, [[0.172472, 0.157375, 0.551171]])
+        # Verify gradB is symmetric and its value
+        # assert np.allclose(gradB, transpGradB)
+        assert np.allclose(transpGradB, np.array([[0.18684, 0, -1.66368], [0, 0.18684, -1.51805], [0, 0, -0.373679]]))
+        # Verify serialization works
+        field_json_str = json.dumps(SIMSON(Bfield), cls=GSONEncoder)
+        Bfield_regen = json.loads(field_json_str, cls=GSONDecoder)
+        self.assertTrue(np.allclose(B, Bfield_regen.B()))
 
     def test_DipoleField_single_dipole(self):
         m = np.array([0.5, 0.5, 0.5])


### PR DESCRIPTION
This PR introduces the mirror machine model from https://arxiv.org/abs/2305.06372
It expands the set of magnetic field models available to SIMSOPT to include a magnetic mirror model for fusion applications. The default input parameters follow the ones used to model WHAM (https://wippl.wisc.edu/wisconsin-hts-axisymmetric-mirror/)