### PR TITLE
Removing python 3.7 in CI due to its EOL in a week

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,6 @@ source = simsopt
 
 [paths]
 sources = 
-    /opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages
-    /opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages
-    /opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages
+    /opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages
+    /opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages
+    /opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8.15] # To sync with coveragerc use 3 level
+        python-version: [3.8.17] # To sync with coveragerc use 3 level
         test-type: [unit, integrated]
 
     steps:

--- a/.github/workflows/extensive_ci.yml
+++ b/.github/workflows/extensive_ci.yml
@@ -29,12 +29,12 @@ jobs:
       matrix:
         test-type: [unit, integrated]
         packages: [all, vmec, spec, none]
-        python-version: [3.7.15, 3.8.15, 3.9.16] # , 3.10.0] # To sync with coveragerc use 3 levels with python version
+        python-version: [3.8.17, 3.9.17, 3.10.12] # To sync with coveragerc use 3 levels with python version
         include:
-            - python-version: 3.9.16
+            - python-version: 3.9.17
               test-type: unit
               packages: none
-            - python-version: 3.9.16
+            - python-version: 3.9.17
               test-type: integrated
               packages: none
 
@@ -247,7 +247,7 @@ jobs:
     - name: Set up Python 
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8.15
+        python-version: 3.8.17
 
     - name: Install coverage
       run: pip install coverage

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -20,12 +20,12 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.4
         # To supply options, put them in 'env'
         env:
-          # Only build for python 3.{7,8,9,10}
-          CIBW_BUILD : cp37-* cp38-* cp39-* cp310-*
+          # Only build for python 3.{8,9,10}
+          CIBW_BUILD : cp38-* cp39-* cp310-*
           # Supports only x86_64 arch for linux
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_MACOS: "x86_64 arm64"
-          CIBW_SKIP: cp27-* cp36-*
+          CIBW_SKIP: cp27-* cp36-* cp37-*
           CIBW_DEPENDENCY_VERSIONS: latest
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Python 3.7 is reaching its end of life in ten days.  I am removing 3.7 and adding 3.10 to the extensive CI. 

