### PR TITLE
Flip orientation in create_equally_spaced_curves() to fix free-boundary

### DIFF
--- a/src/simsopt/geo/curve.py
+++ b/src/simsopt/geo/curve.py
@@ -875,7 +875,10 @@ def create_equally_spaced_curves(ncurves, nfp, stellsym, R0=1.0, R1=0.5, order=6
         curve.set("xc(1)", cos(angle)*R1)
         curve.set("yc(0)", sin(angle)*R0)
         curve.set("yc(1)", sin(angle)*R1)
-        curve.set("zs(1)", R1)
+        # The the next line, the minus sign is for consistency with
+        # Vmec.external_current(), so the coils create a toroidal field of the
+        # proper sign and free-boundary equilibrium works following stage-2 optimization.
+        curve.set("zs(1)", -R1)
         curve.x = curve.x  # need to do this to transfer data to C++
         curves.append(curve)
     return curves

--- a/src/simsopt/mhd/vmec.py
+++ b/src/simsopt/mhd/vmec.py
@@ -574,7 +574,7 @@ class Vmec(Optimizable):
             nml += f"MGRID_FILE = '{vi.mgrid_file.decode('utf-8')}'\n"
             nml += 'EXTCUR = ' + array_to_namelist(vi.extcur)
             nml += '\n'
-        
+
         nml += '\n! ---- Resolution parameters ----\n'
         nml += f'MPOL = {vi.mpol}\n'
         nml += f'NTOR = {vi.ntor}\n'


### PR DESCRIPTION
This PR addresses an issue we noticed when doing free-boundary vmec calculations following stage-2 coil optimization. The function `create_equally_spaced_curves()` has a sign convention associated with which way the curve parameter increases. In other words, does a positive current correspond to current going up or down through the plasma's donut hole? We need to be particularly careful about this sign in finite-beta stage-2 optimizations (see `examples/2_Intermediate/stage_two_optimization_finite_beta.py`), where the sign of the coil currents is set by `Vmec.external_current()`, and Bnormal from virtual casing must have the proper sign relation to B from the coils. In the master branch, the signs are not correct, such that when you run free-boundary vmec from the optimized coils, there are two symptoms. First, VMEC complains that B_toroidal has the wrong direction:
~~~~
  R * BTOR(vac) =  -8.14E+01 R * BTOR(plasma) =   8.14E+01

 PHIEDGE HAS WRONG SIGN IN VACUUM SUBROUTINE
~~~~
Second, if you try to fix this problem by flipping the sign of the `EXTCUR` values or `PHIEDGE` and `CURTOR`, the free-boundary equilibrium either doesn't converge or doesn't match the target. Here's an example for the W7-X finite-beta case in `stage_two_optimization_finite_beta.py`:
<img width="980" alt="image" src="https://github.com/hiddenSymmetries/simsopt/assets/5229699/d58c27f3-2b2e-41a3-b983-88c710c4582b">
(red = fixed-boundary target, green = free-boundary solution). The mismatch arises because the relative sign of Bcoils and Bplasma was not correct during the coil optimization, so it can't be fixed by sign flips afterwards. After the sign flip in this PR, the free-boundary solution matches the target:
<img width="975" alt="image" src="https://github.com/hiddenSymmetries/simsopt/assets/5229699/9b32b8c9-40f0-4f39-96fd-050cbdceb64b">
Differences are even more pronounced for QH/QA cases since they have more plasma current.

I thought Florian and I had sorted out these signs back around April 2022 (I have some notes dated 20220417-03 discussing the signs), but it appears the fix never made it into master? Perhaps someone else remembers what happened better than I. Anyhow, with this sign flip in this PR, things work as of today.

This PR includes a new test to cover this issue.

This sign flip in `create_equally_spaced_curves()` will reverse the direction of B in many scripts, so there may be side-effects of this change in your applications. If you have any concerns, please comment.

