### PR TITLE
Cylindrical magnets grid fix

### DIFF
--- a/src/simsopt/mhd/vmec.py
+++ b/src/simsopt/mhd/vmec.py
@@ -574,7 +574,7 @@ class Vmec(Optimizable):
             nml += f"MGRID_FILE = '{vi.mgrid_file.decode('utf-8')}'\n"
             nml += 'EXTCUR = ' + array_to_namelist(vi.extcur)
             nml += '\n'
-        
+
         nml += '\n! ---- Resolution parameters ----\n'
         nml += f'MPOL = {vi.mpol}\n'
         nml += f'NTOR = {vi.ntor}\n'

--- a/src/simsoptpp/dipole_field.cpp
+++ b/src/simsoptpp/dipole_field.cpp
@@ -845,7 +845,7 @@ Array define_a_uniform_cartesian_grid_between_two_toroidal_surfaces(Array& norma
 // and creates a final set of points which lie between the
 // inner and outer toroidal surfaces corresponding to the permanent
 // magnet surface. 
-std::tuple<Array, Array> define_a_uniform_cylindrical_grid_between_two_toroidal_surfaces(Array& phi, Array& normal_inner, Array& normal_outer, Array& dipole_grid_rz, Array& r_inner, Array& r_outer, Array& z_inner, Array& z_outer)
+Array define_a_uniform_cylindrical_grid_between_two_toroidal_surfaces(Array& normal_inner, Array& normal_outer, Array& dipole_grid_rz,  Array& rphiz_inner, Array& rphiz_outer)
 {
     // For each toroidal cross-section:
     // For each dipole location:
@@ -860,103 +860,94 @@ std::tuple<Array, Array> define_a_uniform_cylindrical_grid_between_two_toroidal_
     //           start of the ray, conclude point is outside the outer surface. 
     //     8. If Step 4 was True but Step 5 was False, add the point to the final grid.
    	
-    int ntheta = normal_inner.shape(1);
-    int num_inner = r_inner.shape(1);
-    int num_outer = r_outer.shape(1);
-    int rz_max = dipole_grid_rz.shape(0);
-    int nphi = phi.shape(0);
+    int num_inner = rphiz_inner.shape(0);
+    int num_outer = rphiz_outer.shape(0);
+    int ngrid = dipole_grid_rz.shape(0);
     int num_ray = 2000;
-    Array inds = xt::zeros<int>({nphi});
+    double tol = 1e-5;
 
     // initialize new_grids with size of the full uniform grid,
     // and then chop later in the python part of the code
-    Array new_grids = xt::zeros<double>({rz_max * nphi, 3});
+    Array final_grid = xt::zeros<double>({ngrid, 3});
 
-    // Loop through phi locations
-    #pragma omp parallel for schedule(static)
-    for (int i = 0; i < nphi; i++) {
-        int ind_count = 0;
-        double phi_i = phi(i);
-        double rot_matrix[3] = {cos(phi_i), sin(phi_i), 0};
 
-        // Loop through every dipole at fixed phi_i
-        for (int j = 0; j < rz_max; j++) {
-            // Get (R, Z) locations of the points with respect to the magnetic axis
-            double Rpoint = dipole_grid_rz(j, i, 0);
-            double Zpoint = dipole_grid_rz(j, i, 2);
-           
-            // find nearest point on inner/outer toroidal surface
-            double min_dist_inner = 1e5;
-            double min_dist_outer = 1e5;
-            int inner_loc = 0;
-            int outer_loc = 0;
-            for (int k = 0; k < num_inner; k++) {
-                double dist_inner = (r_inner(i, k) - Rpoint) * (r_inner(i, k) - Rpoint) + (z_inner(i, k) - Zpoint) * (z_inner(i, k) - Zpoint);
-                double dist_outer = (r_outer(i, k) - Rpoint) * (r_outer(i, k) - Rpoint) + (z_outer(i, k) - Zpoint) * (z_outer(i, k) - Zpoint);
-                if (dist_inner < min_dist_inner) {
-                    min_dist_inner = dist_inner;
-                    inner_loc = k;
-                }
-                if (dist_outer < min_dist_outer) {
-                    min_dist_outer = dist_outer;
-                    outer_loc = k;
-                }
-	        }
+#pragma omp parallel for schedule(static)
+    for (int j = 0; j < ngrid; j++) {
+        // Get (R, Z) locations of the points with respect to the magnetic axis
+        double Rpoint = dipole_grid_rz(j, 0);
+        double Phipoint = dipole_grid_rz(j, 1);
+        double rot_matrix[3] = {cos(Phipoint), sin(Phipoint), 0};
+        double Zpoint = dipole_grid_rz(j, 2);
+       
+        // find nearest point on inner/outer toroidal surface
+        double min_dist_inner = 1e5;
+        double min_dist_outer = 1e5;
+        int inner_loc = 0;
+        int outer_loc = 0;
+        for (int k = 0; k < num_inner; k++) {
+            double dist_inner = (rphiz_inner(k, 0) - Rpoint) * (rphiz_inner(k, 0) - Rpoint) + (rphiz_inner(k, 2) - Zpoint) * (rphiz_inner(k, 2) - Zpoint);
+            double dist_outer = (rphiz_outer(k, 0) - Rpoint) * (rphiz_outer(k, 0) - Rpoint) + (rphiz_outer(k, 2) - Zpoint) * (rphiz_outer(k, 2) - Zpoint);
+            if ((dist_inner < min_dist_inner) && (std::abs(rphiz_inner(k, 1) - Phipoint) < tol)) {
+                min_dist_inner = dist_inner;
+                inner_loc = k;
+            }
+            if ((dist_outer < min_dist_outer) && (std::abs(rphiz_outer(k, 1) - Phipoint) < tol)) {
+                min_dist_outer = dist_outer;
+                outer_loc = k;
+            }
+	    }
 	    
 	        // rotate normal vectors in (r, phi, z) coordinates and set phi component to zero
-            // so that we keep everything in the same phi = constant cross-section
-            double normal_vec_r = 0.0;
-            double normal_vec_z = 0.0;
-            if (min_dist_inner < min_dist_outer) {
-                normal_vec_r = rot_matrix[0] * normal_inner(i, inner_loc, 0) + rot_matrix[1] * normal_inner(i, inner_loc, 1);
-                normal_vec_z = normal_inner(i, inner_loc, 2);
+        // so that we keep everything in the same phi = constant cross-section
+        double normal_vec_r = 0.0;
+        double normal_vec_z = 0.0;
+        if (min_dist_inner < min_dist_outer) {
+            normal_vec_r = rot_matrix[0] * normal_inner(inner_loc, 0) + rot_matrix[1] * normal_inner(inner_loc, 1);
+            normal_vec_z = normal_inner(inner_loc, 2);
+        }
+        else {
+            normal_vec_r = rot_matrix[0] * normal_outer(outer_loc, 0) + rot_matrix[1] * normal_outer(outer_loc, 1);
+            normal_vec_z = normal_outer(outer_loc, 2);
+        }
+        // normalize the rotated unit vectors
+        double norm_vec = sqrt(normal_vec_r * normal_vec_r + normal_vec_z * normal_vec_z);
+        double ray_dir_r = normal_vec_r / norm_vec;
+        double ray_dir_z = normal_vec_z / norm_vec;
+       
+        // Compute all the rays and find the location of minimum ray-surface distance
+        double dist_inner_ray = 0.0;
+        double dist_outer_ray = 0.0;
+        double min_dist_inner_ray = 1e5;
+        double min_dist_outer_ray = 1e5;
+        int nearest_loc_inner = 0;
+        int nearest_loc_outer = 0;
+        double ray_equation_r = 0.0;
+        double ray_equation_z = 0.0;
+        for (int k = 0; k < num_ray; k++) {
+            ray_equation_r = Rpoint + ray_dir_r * (4.0 / ((double) num_ray)) * k;
+            ray_equation_z = Zpoint + ray_dir_z * (4.0 / ((double) num_ray)) * k;
+            dist_inner_ray = (rphiz_inner(inner_loc, 0) - ray_equation_r) * (rphiz_inner(inner_loc, 0) - ray_equation_r) + (rphiz_inner(inner_loc, 2) - ray_equation_z) * (rphiz_inner(inner_loc, 2) - ray_equation_z);
+            dist_outer_ray = (rphiz_outer(outer_loc, 0) - ray_equation_r) * (rphiz_outer(outer_loc, 0) - ray_equation_r) + (rphiz_outer(outer_loc, 2) - ray_equation_z) * (rphiz_outer(outer_loc, 2) - ray_equation_z);
+            if (dist_inner_ray < min_dist_inner_ray) {
+                min_dist_inner_ray = dist_inner_ray;
+                nearest_loc_inner = k;
             }
-            else {
-                normal_vec_r = rot_matrix[0] * normal_outer(i, outer_loc, 0) + rot_matrix[1] * normal_outer(i, outer_loc, 1);
-                normal_vec_z = normal_outer(i, outer_loc, 2);
+            if (dist_outer_ray < min_dist_outer_ray) {
+                min_dist_outer_ray = dist_outer_ray;
+                nearest_loc_outer = k;
             }
-            // normalize the rotated unit vectors
-            double norm_vec = sqrt(normal_vec_r * normal_vec_r + normal_vec_z * normal_vec_z);
-            double ray_dir_r = normal_vec_r / norm_vec;
-            double ray_dir_z = normal_vec_z / norm_vec;
-           
-            // Compute all the rays and find the location of minimum ray-surface distance
-            double dist_inner_ray = 0.0;
-            double dist_outer_ray = 0.0;
-            double min_dist_inner_ray = 1e5;
-            double min_dist_outer_ray = 1e5;
-            int nearest_loc_inner = 0;
-            int nearest_loc_outer = 0;
-            double ray_equation_r = 0.0;
-            double ray_equation_z = 0.0;
-            for (int k = 0; k < num_ray; k++) {
-                ray_equation_r = Rpoint + ray_dir_r * (4.0 / ((double) num_ray)) * k;
-                ray_equation_z = Zpoint + ray_dir_z * (4.0 / ((double) num_ray)) * k;
-                dist_inner_ray = (r_inner(i, inner_loc) - ray_equation_r) * (r_inner(i, inner_loc) - ray_equation_r) + (z_inner(i, inner_loc) - ray_equation_z) * (z_inner(i, inner_loc) - ray_equation_z);
-                dist_outer_ray = (r_outer(i, outer_loc) - ray_equation_r) * (r_outer(i, outer_loc) - ray_equation_r) + (z_outer(i, outer_loc) - ray_equation_z) * (z_outer(i, outer_loc) - ray_equation_z);
-                if (dist_inner_ray < min_dist_inner_ray) {
-                    min_dist_inner_ray = dist_inner_ray;
-                    nearest_loc_inner = k;
-                }
-                if (dist_outer_ray < min_dist_outer_ray) {
-                    min_dist_outer_ray = dist_outer_ray;
-                    nearest_loc_outer = k;
-                }
-            }
-            
-            // nearest distance from the inner surface to the ray should be just the original point
-            if (nearest_loc_inner > 0)
-                continue;
-            
-            // nearest distance from the outer surface to the ray should NOT be the original point
-            if (nearest_loc_outer > 0) {
-                new_grids(ind_count + i * rz_max, 0) = Rpoint;
-                new_grids(ind_count + i * rz_max, 1) = phi_i; 
-                new_grids(ind_count + i * rz_max, 2) = Zpoint;
-                ind_count += 1;
-            }
-	}
-	inds(i) = ind_count;
+        }
+        
+        // nearest distance from the inner surface to the ray should be just the original point
+        if (nearest_loc_inner > 0)
+            continue;
+        
+        // nearest distance from the outer surface to the ray should NOT be the original point
+        if (nearest_loc_outer > 0) {
+            final_grid(j, 0) = Rpoint;
+            final_grid(j, 1) = Phipoint; 
+            final_grid(j, 2) = Zpoint;
+        }
     }
-    return std::make_tuple(new_grids, inds);
+    return final_grid;
 }

--- a/src/simsoptpp/dipole_field.cpp
+++ b/src/simsoptpp/dipole_field.cpp
@@ -749,6 +749,7 @@ Array define_a_uniform_cartesian_grid_between_two_toroidal_surfaces(Array& norma
     //     8. If Step 4 was True but Step 5 was False, add the point to the final grid.
 
     int num_inner = xyz_inner.shape(0);
+    int num_outer = xyz_outer.shape(0);
     int ngrid = xyz_uniform.shape(0);
     int num_ray = 2000;
     Array final_grid = xt::zeros<double>({ngrid, 3});
@@ -769,15 +770,17 @@ Array define_a_uniform_cartesian_grid_between_two_toroidal_surfaces(Array& norma
             double x_inner = xyz_inner(k, 0);
             double y_inner = xyz_inner(k, 1);
             double z_inner = xyz_inner(k, 2);
-            double x_outer = xyz_outer(k, 0);
-            double y_outer = xyz_outer(k, 1);
-            double z_outer = xyz_outer(k, 2);
             double dist_inner = (x_inner - X) * (x_inner - X) + (y_inner - Y) * (y_inner - Y) + (z_inner - Z) * (z_inner - Z);
-            double dist_outer = (x_outer - X) * (x_outer - X) + (y_outer - Y) * (y_outer - Y) + (z_outer - Z) * (z_outer - Z);
             if (dist_inner < min_dist_inner) {
                 min_dist_inner = dist_inner;
                 inner_loc = k;
             }
+	    }
+        for (int k = 0; k < num_outer; k++) {
+            double x_outer = xyz_outer(k, 0);
+            double y_outer = xyz_outer(k, 1);
+            double z_outer = xyz_outer(k, 2);
+            double dist_outer = (x_outer - X) * (x_outer - X) + (y_outer - Y) * (y_outer - Y) + (z_outer - Z) * (z_outer - Z);
             if (dist_outer < min_dist_outer) {
                 min_dist_outer = dist_outer;
                 outer_loc = k;
@@ -836,117 +839,6 @@ Array define_a_uniform_cartesian_grid_between_two_toroidal_surfaces(Array& norma
             final_grid(i, 0) = X;
             final_grid(i, 1) = Y;
             final_grid(i, 2) = Z;
-        }
-    }
-    return final_grid;
-}
-
-// Takes a uniform grid of dipoles, and loops through
-// and creates a final set of points which lie between the
-// inner and outer toroidal surfaces corresponding to the permanent
-// magnet surface. 
-Array define_a_uniform_cylindrical_grid_between_two_toroidal_surfaces(Array& normal_inner, Array& normal_outer, Array& dipole_grid_rz,  Array& rphiz_inner, Array& rphiz_outer)
-{
-    // For each toroidal cross-section:
-    // For each dipole location:
-    //     1. Find nearest point from dipole to the inner surface
-    //     2. Find nearest point from dipole to the outer surface
-    //     3. Select nearest point that is closest to the dipole
-    //     4. Get normal vector of this inner/outer surface point
-    //     5. Draw ray from dipole location in the direction of this normal vector
-    //     6. If closest point between inner surface and the ray is the 
-    //           start of the ray, conclude point is outside the inner surface. 
-    //     7. If closest point between outer surface and the ray is the
-    //           start of the ray, conclude point is outside the outer surface. 
-    //     8. If Step 4 was True but Step 5 was False, add the point to the final grid.
-   	
-    int num_inner = rphiz_inner.shape(0);
-    int num_outer = rphiz_outer.shape(0);
-    int ngrid = dipole_grid_rz.shape(0);
-    int num_ray = 2000;
-    double tol = 1e-5;
-
-    // initialize new_grids with size of the full uniform grid,
-    // and then chop later in the python part of the code
-    Array final_grid = xt::zeros<double>({ngrid, 3});
-
-
-#pragma omp parallel for schedule(static)
-    for (int j = 0; j < ngrid; j++) {
-        // Get (R, Z) locations of the points with respect to the magnetic axis
-        double Rpoint = dipole_grid_rz(j, 0);
-        double Phipoint = dipole_grid_rz(j, 1);
-        double rot_matrix[3] = {cos(Phipoint), sin(Phipoint), 0};
-        double Zpoint = dipole_grid_rz(j, 2);
-       
-        // find nearest point on inner/outer toroidal surface
-        double min_dist_inner = 1e5;
-        double min_dist_outer = 1e5;
-        int inner_loc = 0;
-        int outer_loc = 0;
-        for (int k = 0; k < num_inner; k++) {
-            double dist_inner = (rphiz_inner(k, 0) - Rpoint) * (rphiz_inner(k, 0) - Rpoint) + (rphiz_inner(k, 2) - Zpoint) * (rphiz_inner(k, 2) - Zpoint);
-            double dist_outer = (rphiz_outer(k, 0) - Rpoint) * (rphiz_outer(k, 0) - Rpoint) + (rphiz_outer(k, 2) - Zpoint) * (rphiz_outer(k, 2) - Zpoint);
-            if ((dist_inner < min_dist_inner) && (std::abs(rphiz_inner(k, 1) - Phipoint) < tol)) {
-                min_dist_inner = dist_inner;
-                inner_loc = k;
-            }
-            if ((dist_outer < min_dist_outer) && (std::abs(rphiz_outer(k, 1) - Phipoint) < tol)) {
-                min_dist_outer = dist_outer;
-                outer_loc = k;
-            }
-	    }
-	    
-	        // rotate normal vectors in (r, phi, z) coordinates and set phi component to zero
-        // so that we keep everything in the same phi = constant cross-section
-        double normal_vec_r = 0.0;
-        double normal_vec_z = 0.0;
-        if (min_dist_inner < min_dist_outer) {
-            normal_vec_r = rot_matrix[0] * normal_inner(inner_loc, 0) + rot_matrix[1] * normal_inner(inner_loc, 1);
-            normal_vec_z = normal_inner(inner_loc, 2);
-        }
-        else {
-            normal_vec_r = rot_matrix[0] * normal_outer(outer_loc, 0) + rot_matrix[1] * normal_outer(outer_loc, 1);
-            normal_vec_z = normal_outer(outer_loc, 2);
-        }
-        // normalize the rotated unit vectors
-        double norm_vec = sqrt(normal_vec_r * normal_vec_r + normal_vec_z * normal_vec_z);
-        double ray_dir_r = normal_vec_r / norm_vec;
-        double ray_dir_z = normal_vec_z / norm_vec;
-       
-        // Compute all the rays and find the location of minimum ray-surface distance
-        double dist_inner_ray = 0.0;
-        double dist_outer_ray = 0.0;
-        double min_dist_inner_ray = 1e5;
-        double min_dist_outer_ray = 1e5;
-        int nearest_loc_inner = 0;
-        int nearest_loc_outer = 0;
-        double ray_equation_r = 0.0;
-        double ray_equation_z = 0.0;
-        for (int k = 0; k < num_ray; k++) {
-            ray_equation_r = Rpoint + ray_dir_r * (4.0 / ((double) num_ray)) * k;
-            ray_equation_z = Zpoint + ray_dir_z * (4.0 / ((double) num_ray)) * k;
-            dist_inner_ray = (rphiz_inner(inner_loc, 0) - ray_equation_r) * (rphiz_inner(inner_loc, 0) - ray_equation_r) + (rphiz_inner(inner_loc, 2) - ray_equation_z) * (rphiz_inner(inner_loc, 2) - ray_equation_z);
-            dist_outer_ray = (rphiz_outer(outer_loc, 0) - ray_equation_r) * (rphiz_outer(outer_loc, 0) - ray_equation_r) + (rphiz_outer(outer_loc, 2) - ray_equation_z) * (rphiz_outer(outer_loc, 2) - ray_equation_z);
-            if (dist_inner_ray < min_dist_inner_ray) {
-                min_dist_inner_ray = dist_inner_ray;
-                nearest_loc_inner = k;
-            }
-            if (dist_outer_ray < min_dist_outer_ray) {
-                min_dist_outer_ray = dist_outer_ray;
-                nearest_loc_outer = k;
-            }
-        }
-        
-        // nearest distance from the inner surface to the ray should be just the original point
-        if (nearest_loc_inner > 0)
-            continue;
-        
-        // nearest distance from the outer surface to the ray should NOT be the original point
-        if (nearest_loc_outer > 0) {
-            final_grid(j, 0) = Rpoint;
-            final_grid(j, 1) = Phipoint; 
-            final_grid(j, 2) = Zpoint;
         }
     }
     return final_grid;

--- a/src/simsoptpp/dipole_field.h
+++ b/src/simsoptpp/dipole_field.h
@@ -17,6 +17,4 @@ Array dipole_field_dA(Array& points, Array& m_points, Array& m);
 
 Array dipole_field_Bn(Array& points, Array& m_points, Array& unitnormal, int nfp, int stellsym, Array& b, std::string coordinate_flag="cartesian", double R0=0.0);
 
-Array define_a_uniform_cylindrical_grid_between_two_toroidal_surfaces(Array& normal_inner, Array& normal_outer, Array& dipole_grid_rz, Array& rphiz_inner, Array& rphiz_outer);
-
 Array define_a_uniform_cartesian_grid_between_two_toroidal_surfaces(Array& normal_inner, Array& normal_outer, Array& xyz_uniform, Array& xyz_inner, Array& xyz_outer);

--- a/src/simsoptpp/dipole_field.h
+++ b/src/simsoptpp/dipole_field.h
@@ -17,6 +17,6 @@ Array dipole_field_dA(Array& points, Array& m_points, Array& m);
 
 Array dipole_field_Bn(Array& points, Array& m_points, Array& unitnormal, int nfp, int stellsym, Array& b, std::string coordinate_flag="cartesian", double R0=0.0);
 
-std::tuple<Array, Array> define_a_uniform_cylindrical_grid_between_two_toroidal_surfaces(Array& phi, Array& normal_inner, Array& normal_outer, Array& dipole_grid_rz, Array& r_inner, Array& r_outer, Array& z_inner, Array& z_outer);
+Array define_a_uniform_cylindrical_grid_between_two_toroidal_surfaces(Array& normal_inner, Array& normal_outer, Array& dipole_grid_rz, Array& rphiz_inner, Array& rphiz_outer);
 
 Array define_a_uniform_cartesian_grid_between_two_toroidal_surfaces(Array& normal_inner, Array& normal_outer, Array& xyz_uniform, Array& xyz_inner, Array& xyz_outer);

--- a/src/simsoptpp/python.cpp
+++ b/src/simsoptpp/python.cpp
@@ -64,7 +64,6 @@ PYBIND11_MODULE(simsoptpp, m) {
     m.def("dipole_field_dB", &dipole_field_dB);
     m.def("dipole_field_dA" , &dipole_field_dA);
     m.def("dipole_field_Bn" , &dipole_field_Bn, py::arg("points"), py::arg("m_points"), py::arg("unitnormal"), py::arg("nfp"), py::arg("stellsym"), py::arg("b"), py::arg("coordinate_flag") = "cartesian", py::arg("R0") = 0.0);
-    m.def("define_a_uniform_cylindrical_grid_between_two_toroidal_surfaces" , &define_a_uniform_cylindrical_grid_between_two_toroidal_surfaces);
     m.def("define_a_uniform_cartesian_grid_between_two_toroidal_surfaces" , &define_a_uniform_cartesian_grid_between_two_toroidal_surfaces);
 
     // Permanent magnet optimization algorithms have many default arguments


### PR DESCRIPTION
This branch fixes an issue with the grid generation for permanent magnets, particularly for uniform cylindrical grids, pointed out by @MigMadeira. Basically, the magnets are initialized on a uniform grid (cartesian, cylindrical, or simple toroidal), and then magnets that do not lie between an inner and outer toroidal surface are eliminated by a ray-tracing routine. Some of the magnets near pi and 2pi  were incorrectly eliminated or incorrectly kept around. I think this is because of not being careful that the inner, outer, and plasma surfaces all had the same toroidal angle range between [0, 2pi], and that the ray tracing knew that 0 and 360 were the same angle. 

Part of this issue is that, for historical reasons (bad coding), I had a separate ray tracing routine for both the cartesian and cylindrical scenarios. Now, the code is reduced to a single ray tracing routine for all the coordinate systems, the unit tests for this method are improved, and the bug eliminated. The code is also now compatible with scenarios in which the resolution of the inner and outer toroidal surfaces is different than the plasma surface. 