### PR TITLE
added use of axis aspect ratio argument when plotting poincare sections

### DIFF
--- a/src/simsopt/field/tracing.py
+++ b/src/simsopt/field/tracing.py
@@ -818,6 +818,8 @@ def plot_poincare_data(fieldlines_phi_hits, phis, filename, mark_lost=False, asp
     nrowcol = ceil(sqrt(len(phis)))
     plt.figure()
     fig, axs = plt.subplots(nrowcol, nrowcol, figsize=(8, 5))
+    for ax in axs.ravel():
+        ax.set_aspect(aspect)
     color = None
     for i in range(len(phis)):
         row = i//nrowcol


### PR DESCRIPTION
The routine plot_poincare_data had as argument 'aspect' (by default set to 'equal') but actually never used it, which meant that the poincare plots were produced without the 'equal aspect ratio'. This is just a quick fix so that the function actually sets the aspect ratio as desired.