### PR TITLE
PR: Added Interface term to single stage finitebeta

### DIFF
--- a/examples/3_Advanced/single_stage_optimization_finite_beta.py
+++ b/examples/3_Advanced/single_stage_optimization_finite_beta.py
@@ -175,10 +175,10 @@ def fun_J(prob, coils_prob):
 
     bs.set_points(vc.trgt_surf.gamma().reshape((-1, 3)))
     Bvmec = np.transpose(np.array(B_cartesian(vmec, quadpoints_phi=vc.trgt_surf.quadpoints_phi,
-                                            quadpoints_theta=vc.trgt_surf.quadpoints_theta)),(1,2,0))
+                                              quadpoints_theta=vc.trgt_surf.quadpoints_theta)), (1, 2, 0))
     Bvirtualcasing = vc.B_external
     Bcoil = bs.B().reshape(Bvirtualcasing.shape)
-    Bsquared_interface = np.sum((Bcoil - Bvirtualcasing)*(Bcoil - Bvirtualcasing + 2*Bvmec),axis=-1)
+    Bsquared_interface = np.sum((Bcoil - Bvirtualcasing)*(Bcoil - Bvirtualcasing + 2*Bvmec), axis=-1)
     sum_Bsquared_interface = np.sum(Bsquared_interface**2)
 
     bs.set_points(surf.gamma().reshape((-1, 3)))

--- a/src/simsopt/mhd/virtual_casing.py
+++ b/src/simsopt/mhd/virtual_casing.py
@@ -188,6 +188,7 @@ class VirtualCasing:
             surf.set_rc(int(vmec.wout.xm[jmn]), int(vmec.wout.xn[jmn] / nfp), vmec.wout.rmnc[jmn, -1])
             surf.set_zs(int(vmec.wout.xm[jmn]), int(vmec.wout.xn[jmn] / nfp), vmec.wout.zmns[jmn, -1])
         Bxyz = B_cartesian(vmec, nphi=src_nphi, ntheta=src_ntheta, range=ran)
+        cls.Bxyz = Bxyz
         gamma = surf.gamma()
         logger.debug(f'gamma.shape: {gamma.shape}')
         logger.debug(f'Bxyz[0].shape: {Bxyz[0].shape}')

--- a/src/simsopt/mhd/virtual_casing.py
+++ b/src/simsopt/mhd/virtual_casing.py
@@ -200,6 +200,7 @@ class VirtualCasing:
         trgt_surf = SurfaceRZFourier.from_nphi_ntheta(mpol=vmec.wout.mpol, ntor=vmec.wout.ntor, nfp=nfp,
                                                       nphi=trgt_nphi, ntheta=trgt_ntheta, range=ran)
         trgt_surf.x = surf.x
+        cls.trgt_surf = trgt_surf
 
         unit_normal = trgt_surf.unitnormal()
         logger.debug(f'unit_normal.shape: {unit_normal.shape}')


### PR DESCRIPTION
The single stage optimization, up to now, has minimized the squared flux corrected for the target magnetic field.
According to texts on free boundary [add reference], an extra term is needed that minimizes the squared of the magnetic field just outside the plasma boundary and the square of magnetic field just inside the boundary.
Added that term here to the optimization.