### PR TITLE
Fix error with netcdf scalars in scipy v1.12

### DIFF
--- a/src/simsopt/field/mgrid.py
+++ b/src/simsopt/field/mgrid.py
@@ -151,16 +151,16 @@ class MGrid():
             var_raw_coil_cur = ds.createVariable('raw_coil_cur', 'f8', ('external_coils',))
 
             # assign values
-            var_ir.assignValue(self.nr)
-            var_jz.assignValue(self.nz)
-            var_kp.assignValue(self.nphi)
-            var_nfp.assignValue(self.nfp)
-            var_nextcur.assignValue(self.n_ext_cur)
+            var_ir.data[()] = self.nr
+            var_jz.data[()] = self.nz
+            var_kp.data[()] = self.nphi
+            var_nfp.data[()] = self.nfp
+            var_nextcur.data[()] = self.n_ext_cur
 
-            var_rmin.assignValue(self.rmin)
-            var_zmin.assignValue(self.zmin)
-            var_rmax.assignValue(self.rmax)
-            var_zmax.assignValue(self.zmax)
+            var_rmin.data[()] = self.rmin
+            var_zmin.data[()] = self.zmin
+            var_rmax.data[()] = self.rmax
+            var_zmax.data[()] = self.zmax
 
             var_mgrid_mode[:] = 'N'  # R - Raw, S - scaled, N - none (old version)
             var_raw_coil_cur[:] = np.ones(self.n_ext_cur)

--- a/src/simsopt/mhd/virtual_casing.py
+++ b/src/simsopt/mhd/virtual_casing.py
@@ -300,27 +300,27 @@ class VirtualCasing:
             f.createDimension('xyz', 3)
 
             src_ntheta = f.createVariable('src_ntheta', 'i', tuple())
-            src_ntheta.assignValue(self.src_ntheta)
+            src_ntheta.data[()] = self.src_ntheta
             src_ntheta.description = 'Number of grid points in the poloidal angle theta for source B field and surface shape'
             src_ntheta.units = 'Dimensionless'
 
             trgt_ntheta = f.createVariable('trgt_ntheta', 'i', tuple())
-            trgt_ntheta.assignValue(self.trgt_ntheta)
+            trgt_ntheta.data[()] = self.trgt_ntheta
             trgt_ntheta.description = 'Number of grid points in the poloidal angle theta for resulting B_external'
             trgt_ntheta.units = 'Dimensionless'
 
             src_nphi = f.createVariable('src_nphi', 'i', tuple())
-            src_nphi.assignValue(self.src_nphi)
+            src_nphi.data[()] = self.src_nphi
             src_nphi.description = 'Number of grid points in the toroidal angle phi for source B field and surface shape'
             src_nphi.units = 'Dimensionless'
 
             trgt_nphi = f.createVariable('trgt_nphi', 'i', tuple())
-            trgt_nphi.assignValue(self.trgt_nphi)
+            trgt_nphi.data[()] = self.trgt_nphi
             trgt_nphi.description = 'Number of grid points in the toroidal angle phi for resulting B_external'
             trgt_nphi.units = 'Dimensionless'
 
             nfp = f.createVariable('nfp', 'i', tuple())
-            nfp.assignValue(self.nfp)
+            nfp.data[()] = self.nfp
             nfp.description = 'Periodicity in toroidal direction'
             nfp.units = 'Dimensionless'
 


### PR DESCRIPTION
[This change to scipy's netcdf module](https://github.com/scipy/scipy/commit/1bd1607fdbb5d762a7ff7bc851074cb38f829d1c) in scipy v1.12 causes simsopt's netcdf-writing functions to fail when setting scalar (i.e. 0D) values. I'm not sure why that change was made to scipy because `numpy.ndarray.itemset` does not appear to be deprecated. Anyhow, this pull request makes simsopt's netcdf routines work with scipy 1.12, while also working with earlier scipy versions. No changes to the required versions of numpy or scipy for simsopt are needed.