### PR TITLE
Tweak for compatibility with jax 0.4.25

### DIFF
--- a/src/simsopt/geo/__init__.py
+++ b/src/simsopt/geo/__init__.py
@@ -1,5 +1,5 @@
-from jax.config import config
-config.update("jax_enable_x64", True)
+import jax
+jax.config.update("jax_enable_x64", True)
 from .config import *
 
 from .curve import *


### PR DESCRIPTION
In jax 0.4.25, released last month, `jax.config.config` was [deprecated](https://github.com/google/jax/blob/main/CHANGELOG.md#jax-0425-feb-26-2024), which causes simsopt to break with this jax version. In particular the CI is failing. This PR is a fix. The change works with older jax versions too - simsopt was already using the new syntax `import jax; jax.config.update(...)` in another location (`geo/jit.py`.)