### PR TITLE
CurveXYZFourierSymmetries

### DIFF
--- a/docs/source/simsopt.geo.rst
+++ b/docs/source/simsopt.geo.rst
@@ -76,10 +76,10 @@ simsopt.geo.curvexyzfourier module
    :undoc-members:
    :show-inheritance:
 
-simsopt.geo.curvexyzhelical module
-----------------------------------
+simsopt.geo.curvexyzfouriersymmetries module
+--------------------------------------------
 
-.. automodule:: simsopt.geo.curvexyzhelical
+.. automodule:: simsopt.geo.curvexyzfouriersymmetries
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/simsopt.geo.rst
+++ b/docs/source/simsopt.geo.rst
@@ -76,6 +76,14 @@ simsopt.geo.curvexyzfourier module
    :undoc-members:
    :show-inheritance:
 
+simsopt.geo.curvexyzhelical module
+----------------------------------
+
+.. automodule:: simsopt.geo.curvexyzhelical
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 simsopt.geo.finitebuild module
 ------------------------------
 

--- a/src/simsopt/geo/__init__.py
+++ b/src/simsopt/geo/__init__.py
@@ -6,6 +6,7 @@ from .curve import *
 from .curvehelical import *
 from .curverzfourier import *
 from .curvexyzfourier import *
+from .curvexyzhelical import *
 from .curveperturbed import *
 from .curveobjectives import *
 from .curveplanarfourier import *
@@ -28,6 +29,7 @@ from .permanent_magnet_grid import *
 
 __all__ = (curve.__all__ + curvehelical.__all__ +
            curverzfourier.__all__ + curvexyzfourier.__all__ +
+           curvexyzhelical.__all__ +
            curveperturbed.__all__ + curveobjectives.__all__ +
            curveplanarfourier.__all__ +
            finitebuild.__all__ + plotting.__all__ +

--- a/src/simsopt/geo/__init__.py
+++ b/src/simsopt/geo/__init__.py
@@ -6,7 +6,7 @@ from .curve import *
 from .curvehelical import *
 from .curverzfourier import *
 from .curvexyzfourier import *
-from .curvexyzhelical import *
+from .curvexyzfouriersymmetries import *
 from .curveperturbed import *
 from .curveobjectives import *
 from .curveplanarfourier import *
@@ -29,7 +29,7 @@ from .permanent_magnet_grid import *
 
 __all__ = (curve.__all__ + curvehelical.__all__ +
            curverzfourier.__all__ + curvexyzfourier.__all__ +
-           curvexyzhelical.__all__ +
+           curvexyzfouriersymmetries.__all__ +
            curveperturbed.__all__ + curveobjectives.__all__ +
            curveplanarfourier.__all__ +
            finitebuild.__all__ + plotting.__all__ +

--- a/src/simsopt/geo/curvexyzfouriersymmetries.py
+++ b/src/simsopt/geo/curvexyzfouriersymmetries.py
@@ -82,8 +82,7 @@ class CurveXYZFourierSymmetries(JaxCurve):
         pure = lambda dofs, points: jaxXYZFourierSymmetriescurve_pure(
             dofs, points, order, nfp, stellsym, ntor)
         
-        nfp_true = nfp // gcd(nfp, ntor) 
-        if nfp != nfp_true:
+        if gcd(ntor, nfp) != 1:
             raise Exception('nfp and ntor must be coprime')
 
         self.order = order

--- a/src/simsopt/geo/curvexyzfouriersymmetries.py
+++ b/src/simsopt/geo/curvexyzfouriersymmetries.py
@@ -3,10 +3,10 @@ import numpy as np
 from .curve import JaxCurve
 from math import gcd
 
-__all__ = ['CurveXYZHelical']
+__all__ = ['CurveXYZFourierSymmetries']
 
 
-def jaxXYZHelicalFouriercurve_pure(dofs, quadpoints, order, nfp, stellsym, ntor):
+def jaxXYZFourierSymmetriescurve_pure(dofs, quadpoints, order, nfp, stellsym, ntor):
     
     theta, m = jnp.meshgrid(quadpoints, jnp.arange(order + 1), indexing='ij')
 
@@ -43,9 +43,9 @@ def jaxXYZHelicalFouriercurve_pure(dofs, quadpoints, order, nfp, stellsym, ntor)
     return gamma
 
 
-class CurveXYZHelical(JaxCurve):
-    r'''A curve representation for a helical coil that does not lie on a torus.
-     The coordinates of the curve are given by:
+class CurveXYZFourierSymmetries(JaxCurve):
+    r'''A curve representation that allows for stellarator and discrete rotational symmetries.  This class can be used to
+    represent a helical coil that does not lie on a torus.  The coordinates of the curve are given by:
 
         .. math::
             \hat x(\theta) &= x_{c, 0} + \sum_{m=1}^{\text{order}} x_{c,m} \cos(2 \pi n_{\text{fp}} m \theta)\\
@@ -79,7 +79,7 @@ class CurveXYZHelical(JaxCurve):
     def __init__(self, quadpoints, order, nfp, stellsym, ntor=1, **kwargs):
         if isinstance(quadpoints, int):
             quadpoints = np.linspace(0, 1, quadpoints, endpoint=False)
-        pure = lambda dofs, points: jaxXYZHelicalFouriercurve_pure(
+        pure = lambda dofs, points: jaxXYZFourierSymmetriescurve_pure(
             dofs, points, order, nfp, stellsym, ntor)
         
         nfp_true = nfp // gcd(nfp, ntor) 

--- a/src/simsopt/geo/curvexyzfouriersymmetries.py
+++ b/src/simsopt/geo/curvexyzfouriersymmetries.py
@@ -73,7 +73,7 @@ class CurveXYZFourierSymmetries(JaxCurve):
                   it is assumed that nfp and ntor are coprime.  If they are not coprime,
                   then then the curve actually has nfp_new:=nfp // gcd(nfp, ntor),
                   and ntor_new:=ntor // gcd(nfp, ntor).  To avoid confusion,
-                  we assert that ntor and nfp are coprime at instatiation.
+                  we assert that ntor and nfp are coprime at instantiation.
         '''
 
     def __init__(self, quadpoints, order, nfp, stellsym, ntor=1, **kwargs):

--- a/src/simsopt/geo/curvexyzfouriersymmetries.py
+++ b/src/simsopt/geo/curvexyzfouriersymmetries.py
@@ -46,35 +46,44 @@ def jaxXYZFourierSymmetriescurve_pure(dofs, quadpoints, order, nfp, stellsym, nt
 class CurveXYZFourierSymmetries(JaxCurve):
     r'''A curve representation that allows for stellarator and discrete rotational symmetries.  This class can be used to
     represent a helical coil that does not lie on a torus.  The coordinates of the curve are given by:
+    
+    .. math::
+        x(\theta) &= \hat x(\theta)  \cos(2 \pi \theta n_{\text{tor}}) - \hat y(\theta)  \sin(2 \pi \theta n_{\text{tor}})\\
+        y(\theta) &= \hat x(\theta)  \sin(2 \pi \theta n_{\text{tor}}) + \hat y(\theta)  \cos(2 \pi \theta n_{\text{tor}})\\
+        z(\theta) &= \sum_{m=1}^{\text{order}} z_{s,m} \sin(2 \pi n_{\text{fp}} m \theta)
 
-        .. math::
-            \hat x(\theta) &= x_{c, 0} + \sum_{m=1}^{\text{order}} x_{c,m} \cos(2 \pi n_{\text{fp}} m \theta)\\
-            \hat y(\theta) &=            \sum_{m=1}^{\text{order}} y_{s,m} \sin(2 \pi n_{\text{fp}} m \theta)\\
-            x(\theta) &= \hat x(\theta)  \cos(2 \pi \theta n_{\text{tor}}) - \hat y(\theta)  \sin(2 \pi \theta n_{\text{tor}})\\
-            y(\theta) &= \hat x(\theta)  \sin(2 \pi \theta n_{\text{tor}}) + \hat y(\theta)  \cos(2 \pi \theta n_{\text{tor}})\\
-            z(\theta) &= \sum_{m=1}^{\text{order}} z_{s,m} \sin(2 \pi n_{\text{fp}} m \theta)
+    where
 
-        if the coil is stellarator symmetric.  When the coil is not stellarator symmetric, the formulas above
-        become
+    .. math::
+        \hat x(\theta) &= x_{c, 0} + \sum_{m=1}^{\text{order}} x_{c,m} \cos(2 \pi n_{\text{fp}} m \theta)\\
+        \hat y(\theta) &=            \sum_{m=1}^{\text{order}} y_{s,m} \sin(2 \pi n_{\text{fp}} m \theta)\\
 
-        .. math::
-            \hat x(\theta) &= x_{c, 0} + \sum_{m=1}^{\text{order}} \left[ x_{c, m} \cos(2 \pi n_{\text{fp}} m \theta) +  x_{s, m} \sin(2 \pi n_{\text{fp}} m \theta) \right] \\
-            \hat y(\theta) &= y_{c, 0} + \sum_{m=1}^{\text{order}} \left[ y_{c, m} \cos(2 \pi n_{\text{fp}} m \theta) +  y_{s, m} \sin(2 \pi n_{\text{fp}} m \theta) \right] \\
-            x(\theta) &= \hat x(\theta)  \cos(2 \pi \theta n_{\text{tor}}) - \hat y(\theta)  \sin(2 \pi \theta n_{\text{tor}})\\
-            y(\theta) &= \hat x(\theta)  \sin(2 \pi \theta n_{\text{tor}}) + \hat y(\theta)  \cos(2 \pi \theta n_{\text{tor}})\\
-            z(\theta) &= z_{c, 0} + \sum_{m=1}^{\text{order}} \left[ z_{c, m} \cos(2 \pi n_{\text{fp}} m \theta) + z_{s, m} \sin(2 \pi n_{\text{fp}} m \theta) \right]
 
-        Args:
-            quadpoints: number of grid points/resolution along the curve,
-            order:  how many Fourier harmonics to include in the Fourier representation,
-            nfp: discrete rotational symmetry number, 
-            stellsym: stellaratory symmetry if True, not stellarator symmetric otherwise,
-            ntor: the number of times the curve wraps toroidally before biting its tail. Note,
-                  it is assumed that nfp and ntor are coprime.  If they are not coprime,
-                  then then the curve actually has nfp_new:=nfp // gcd(nfp, ntor),
-                  and ntor_new:=ntor // gcd(nfp, ntor).  To avoid confusion,
-                  we assert that ntor and nfp are coprime at instantiation.
-        '''
+    if the coil is stellarator symmetric.  When the coil is not stellarator symmetric, the formulas above
+    become
+
+    .. math::
+        x(\theta) &= \hat x(\theta)  \cos(2 \pi \theta n_{\text{tor}}) - \hat y(\theta)  \sin(2 \pi \theta n_{\text{tor}})\\
+        y(\theta) &= \hat x(\theta)  \sin(2 \pi \theta n_{\text{tor}}) + \hat y(\theta)  \cos(2 \pi \theta n_{\text{tor}})\\
+        z(\theta) &= z_{c, 0} + \sum_{m=1}^{\text{order}} \left[ z_{c, m} \cos(2 \pi n_{\text{fp}} m \theta) + z_{s, m} \sin(2 \pi n_{\text{fp}} m \theta) \right]
+
+    where
+    
+    .. math::
+        \hat x(\theta) &= x_{c, 0} + \sum_{m=1}^{\text{order}} \left[ x_{c, m} \cos(2 \pi n_{\text{fp}} m \theta) +  x_{s, m} \sin(2 \pi n_{\text{fp}} m \theta) \right] \\
+        \hat y(\theta) &= y_{c, 0} + \sum_{m=1}^{\text{order}} \left[ y_{c, m} \cos(2 \pi n_{\text{fp}} m \theta) +  y_{s, m} \sin(2 \pi n_{\text{fp}} m \theta) \right] \\
+
+    Args:
+        quadpoints: number of grid points/resolution along the curve,
+        order:  how many Fourier harmonics to include in the Fourier representation,
+        nfp: discrete rotational symmetry number, 
+        stellsym: stellaratory symmetry if True, not stellarator symmetric otherwise,
+        ntor: the number of times the curve wraps toroidally before biting its tail. Note,
+              it is assumed that nfp and ntor are coprime.  If they are not coprime,
+              then then the curve actually has nfp_new:=nfp // gcd(nfp, ntor),
+              and ntor_new:=ntor // gcd(nfp, ntor).  The operator `//` is integer division.
+              To avoid confusion, we assert that ntor and nfp are coprime at instantiation.
+    '''
 
     def __init__(self, quadpoints, order, nfp, stellsym, ntor=1, **kwargs):
         if isinstance(quadpoints, int):

--- a/src/simsopt/geo/curvexyzhelical.py
+++ b/src/simsopt/geo/curvexyzhelical.py
@@ -1,0 +1,120 @@
+import jax.numpy as jnp
+from math import pi
+import numpy as np
+from .curve import JaxCurve
+
+__all__ = ['CurveXYZHelical']
+
+
+def jaxXYZHelicalFouriercurve_pure(dofs, quadpoints, order, nfp, stellsym):
+    
+    if stellsym:
+        xc = dofs[:order+1]
+        ys = dofs[order+1:2*order+1]
+        zs = dofs[2*order+1:]
+        
+        theta, m = jnp.meshgrid(quadpoints, jnp.arange(order+1), indexing='ij')
+        xhat = np.sum(xc[None, :] * jnp.cos(2 * jnp.pi * nfp*m*theta), axis=1)
+        yhat = np.sum(ys[None, :] * jnp.sin(2 * jnp.pi * nfp*m[:, 1:]*theta[:, 1:]), axis=1)
+        
+        x = jnp.cos(2*jnp.pi*quadpoints) * xhat - jnp.sin(2*jnp.pi*quadpoints) * yhat
+        y = jnp.sin(2*jnp.pi*quadpoints) * xhat + jnp.cos(2*jnp.pi*quadpoints) * yhat
+        z = jnp.sum(zs[None, :] * jnp.sin(2*jnp.pi*nfp * m[:, 1:]*theta[:, 1:]), axis=1)
+    else:
+        xc = dofs[0        :   order+1]
+        xs = dofs[order+1  : 2*order+1]
+        yc = dofs[2*order+1: 3*order+2]
+        ys = dofs[3*order+2: 4*order+2]
+        zc = dofs[4*order+2: 5*order+3]
+        zs = dofs[5*order+3:          ]
+        
+        theta, m = jnp.meshgrid(quadpoints, jnp.arange(order+1), indexing='ij')
+        xhat = np.sum(xc[None, :] * jnp.cos(2*jnp.pi*nfp*m*theta), axis=1) + np.sum(xs[None, :] * jnp.sin(2*jnp.pi*nfp*m[:, 1:]*theta[:, 1:]), axis=1)
+        yhat = np.sum(yc[None, :] * jnp.cos(2*jnp.pi*nfp*m*theta), axis=1) + np.sum(ys[None, :] * jnp.sin(2*jnp.pi*nfp*m[:, 1:]*theta[:, 1:]), axis=1)
+        
+        x = jnp.cos(2*jnp.pi*quadpoints) * xhat - jnp.sin(2*jnp.pi*quadpoints) * yhat
+        y = jnp.sin(2*jnp.pi*quadpoints) * xhat + jnp.cos(2*jnp.pi*quadpoints) * yhat
+        z = np.sum(zc[None, :] * jnp.cos(2*jnp.pi*nfp*m*theta), axis=1) + np.sum(zs[None, :] * jnp.sin(2*jnp.pi*nfp*m[:, 1:]*theta[:, 1:]), axis=1)
+
+    gamma = jnp.zeros((len(quadpoints),3))
+    gamma = gamma.at[:, 0].add(x)
+    gamma = gamma.at[:, 1].add(y)
+    gamma = gamma.at[:, 2].add(z)
+    return gamma
+
+
+class CurveXYZHelical(JaxCurve):
+    r'''A curve representation for a helical coil that does not lie on a torus.  The coordinates of the curve are given by:
+        .. math::
+            \hat x(\theta) &= x_{c, 0} + \sum_{m=1}^{\text{order}} x_{c,m} cos(2pi n_{\text{fp}} m \theta)\\
+            \hat y(\theta) &= \sum_{m=1}^{\text{order}} y_{s,m} sin(2pi n_{\text{fp}} m \theta)\\
+            x(\theta) &= \hat x(\theta)  \cos(2pi \theta) - \hat y(\theta)  \sin(2pi \theta)\\
+            y(\theta) &= \hat x(\theta)  \sin(2pi \theta) + \hat y(\theta)  \cos(2pi \theta)\\
+            z(\theta) &= \sum_{i=0}^{\text{order}} z_{s,m} sin(2pi n_{\text{fp}} \theta)
+        if the coil is stellarator symmetric.  When the coil is not stellarator symmetric, the formulas above
+        become
+        .. math::
+            \hat x(\theta) &= x_{c, 0} + \sum_{m=1}^{\text{order}} x_{c, m} cos(2pi m \theta) +  x_{s, m} sin(2pi m \theta)\\
+            \hat y(\theta) &= y_{c, 0} + \sum_{m=1}^{\text{order}} y_{c, m} cos(2pi m \theta) +  y_{s, m} sin(2pi m \theta)\\
+            x(\theta) &= \hat x(\theta)  \cos(2pi \theta) - \hat y(\theta)  \sin(2pi \theta)\\
+            y(\theta) &= \hat x(\theta)  \sin(2pi \theta) + \hat y(\theta)  \cos(2pi \theta)\\
+            z(\theta) &= z_{c, 0} + \sum_{m=1}^{\text{order}} z_{c, m} cos(2pi \theta) + z_{s, m} sin(2pi \theta)
+        
+        Args:
+            quadpoints: number of grid points/resolution along the curve,
+            order:  how many Fourier harmonics to include in the Fourier representation,
+            nfp: discrete rotational symmetry number, 
+            stellsym: stellaratory symmetry if True, not stellarator symmetric otherwise.
+        '''
+
+    def __init__(self, quadpoints, order, nfp, stellsym, **kwargs):
+        if isinstance(quadpoints, int):
+            quadpoints = np.linspace(0, 1, quadpoints, endpoint=False)
+        pure = lambda dofs, points: jaxXYZHelicalFouriercurve_pure(
+            dofs, points, order, nfp, stellsym)
+        
+        self.order = order
+        self.nfp = nfp
+        self.stellsym = stellsym
+        self.coefficients = np.zeros(self.num_dofs())
+        if "dofs" not in kwargs:
+            if "x0" not in kwargs:
+                kwargs["x0"] = self.coefficients
+            else:
+                self.set_dofs_impl(kwargs["x0"])
+
+        super().__init__(quadpoints, pure, names=self._make_names(order), **kwargs)
+
+    def _make_names(self, order):
+        if self.stellsym:
+            x_cos_names = [f'xc({i})' for i in range(0, order + 1)]
+            x_names = x_cos_names
+            y_sin_names = [f'ys({i})' for i in range(1, order + 1)]
+            y_names = y_sin_names
+            z_sin_names = [f'zs({i})' for i in range(1, order + 1)]
+            z_names = z_sin_names
+        else:
+            x_names = ['xc(0)']
+            x_cos_names = [f'xc({i})' for i in range(1, order + 1)]
+            x_sin_names = [f'xs({i})' for i in range(1, order + 1)]
+            x_names += x_cos_names + x_sin_names
+            y_names = ['yc(0)']
+            y_cos_names = [f'yc({i})' for i in range(1, order + 1)]
+            y_sin_names = [f'ys({i})' for i in range(1, order + 1)]
+            y_names += y_cos_names + y_sin_names
+            z_names = ['zc(0)']
+            z_cos_names = [f'zc({i})' for i in range(1, order + 1)]
+            z_sin_names = [f'zs({i})' for i in range(1, order + 1)]
+            z_names += z_cos_names + z_sin_names
+
+        return x_names + y_names + z_names
+
+    def num_dofs(self):
+        return (self.order+1) + self.order + self.order if self.stellsym else 3*(2*self.order+1)
+
+    def get_dofs(self):
+        return self.coefficients
+
+    def set_dofs_impl(self, dofs):
+        self.coefficients[:] = dofs[:]
+

--- a/src/simsopt/geo/curvexyzhelical.py
+++ b/src/simsopt/geo/curvexyzhelical.py
@@ -43,21 +43,25 @@ def jaxXYZHelicalFouriercurve_pure(dofs, quadpoints, order, nfp, stellsym):
 
 
 class CurveXYZHelical(JaxCurve):
-    r'''A curve representation for a helical coil that does not lie on a torus.  The coordinates of the curve are given by:
+    r'''A curve representation for a helical coil that does not lie on a torus.
+     The coordinates of the curve are given by:
+
         .. math::
-            \hat x(\theta) &= x_{c, 0} + \sum_{m=1}^{\text{order}} x_{c,m} cos(2pi n_{\text{fp}} m \theta)\\
-            \hat y(\theta) &=            \sum_{m=1}^{\text{order}} y_{s,m} sin(2pi n_{\text{fp}} m \theta)\\
-            x(\theta) &= \hat x(\theta)  \cos(2pi \theta) - \hat y(\theta)  \sin(2pi \theta)\\
-            y(\theta) &= \hat x(\theta)  \sin(2pi \theta) + \hat y(\theta)  \cos(2pi \theta)\\
-            z(\theta) &= \sum_{i=1}^{\text{order}} z_{s,m} sin(2pi n_{\text{fp}} \theta)
+            \hat x(\theta) &= x_{c, 0} + \sum_{m=1}^{\text{order}} x_{c,m} \cos(2 \pi n_{\text{fp}} m \theta)\\
+            \hat y(\theta) &=            \sum_{m=1}^{\text{order}} y_{s,m} \sin(2 \pi n_{\text{fp}} m \theta)\\
+            x(\theta) &= \hat x(\theta)  \cos(2 \pi \theta) - \hat y(\theta)  \sin(2 \pi \theta)\\
+            y(\theta) &= \hat x(\theta)  \sin(2 \pi \theta) + \hat y(\theta)  \cos(2 \pi \theta)\\
+            z(\theta) &= \sum_{m=1}^{\text{order}} z_{s,m} \sin(2 \pi n_{\text{fp}} m \theta)
+
         if the coil is stellarator symmetric.  When the coil is not stellarator symmetric, the formulas above
         become
+
         .. math::
-            \hat x(\theta) &= x_{c, 0} + \sum_{m=1}^{\text{order}} x_{c, m} cos(2pi m \theta) +  x_{s, m} sin(2pi m \theta)\\
-            \hat y(\theta) &= y_{c, 0} + \sum_{m=1}^{\text{order}} y_{c, m} cos(2pi m \theta) +  y_{s, m} sin(2pi m \theta)\\
-            x(\theta) &= \hat x(\theta)  \cos(2pi \theta) - \hat y(\theta)  \sin(2pi \theta)\\
-            y(\theta) &= \hat x(\theta)  \sin(2pi \theta) + \hat y(\theta)  \cos(2pi \theta)\\
-            z(\theta) &= z_{c, 0} + \sum_{m=1}^{\text{order}} z_{c, m} cos(2pi \theta) + z_{s, m} sin(2pi \theta)
+            \hat x(\theta) &= x_{c, 0} + \sum_{m=1}^{\text{order}} \left[ x_{c, m} \cos(2 \pi n_{\text{fp}} m \theta) +  x_{s, m} \sin(2 \pi n_{\text{fp}} m \theta) \right] \\
+            \hat y(\theta) &= y_{c, 0} + \sum_{m=1}^{\text{order}} \left[ y_{c, m} \cos(2 \pi n_{\text{fp}} m \theta) +  y_{s, m} \sin(2 \pi n_{\text{fp}} m \theta) \right] \\
+            x(\theta) &= \hat x(\theta)  \cos(2 \pi \theta) - \hat y(\theta)  \sin(2 \pi \theta)\\
+            y(\theta) &= \hat x(\theta)  \sin(2 \pi \theta) + \hat y(\theta)  \cos(2 \pi \theta)\\
+            z(\theta) &= z_{c, 0} + \sum_{m=1}^{\text{order}} \left[ z_{c, m} \cos(2 \pi n_{\text{fp}} m \theta) + z_{s, m} \sin(2 \pi n_{\text{fp}} m \theta) \right]
         
         Args:
             quadpoints: number of grid points/resolution along the curve,

--- a/src/simsopt/geo/curvexyzhelical.py
+++ b/src/simsopt/geo/curvexyzhelical.py
@@ -49,7 +49,7 @@ class CurveXYZHelical(JaxCurve):
             \hat y(\theta) &=            \sum_{m=1}^{\text{order}} y_{s,m} sin(2pi n_{\text{fp}} m \theta)\\
             x(\theta) &= \hat x(\theta)  \cos(2pi \theta) - \hat y(\theta)  \sin(2pi \theta)\\
             y(\theta) &= \hat x(\theta)  \sin(2pi \theta) + \hat y(\theta)  \cos(2pi \theta)\\
-            z(\theta) &= \sum_{i=0}^{\text{order}} z_{s,m} sin(2pi n_{\text{fp}} \theta)
+            z(\theta) &= \sum_{i=1}^{\text{order}} z_{s,m} sin(2pi n_{\text{fp}} \theta)
         if the coil is stellarator symmetric.  When the coil is not stellarator symmetric, the formulas above
         become
         .. math::

--- a/src/simsopt/geo/curvexyzhelical.py
+++ b/src/simsopt/geo/curvexyzhelical.py
@@ -1,5 +1,4 @@
 import jax.numpy as jnp
-from math import pi
 import numpy as np
 from .curve import JaxCurve
 

--- a/src/simsopt/geo/curvexyzhelical.py
+++ b/src/simsopt/geo/curvexyzhelical.py
@@ -46,7 +46,7 @@ class CurveXYZHelical(JaxCurve):
     r'''A curve representation for a helical coil that does not lie on a torus.  The coordinates of the curve are given by:
         .. math::
             \hat x(\theta) &= x_{c, 0} + \sum_{m=1}^{\text{order}} x_{c,m} cos(2pi n_{\text{fp}} m \theta)\\
-            \hat y(\theta) &= \sum_{m=1}^{\text{order}} y_{s,m} sin(2pi n_{\text{fp}} m \theta)\\
+            \hat y(\theta) &=            \sum_{m=1}^{\text{order}} y_{s,m} sin(2pi n_{\text{fp}} m \theta)\\
             x(\theta) &= \hat x(\theta)  \cos(2pi \theta) - \hat y(\theta)  \sin(2pi \theta)\\
             y(\theta) &= \hat x(\theta)  \sin(2pi \theta) + \hat y(\theta)  \cos(2pi \theta)\\
             z(\theta) &= \sum_{i=0}^{\text{order}} z_{s,m} sin(2pi n_{\text{fp}} \theta)

--- a/src/simsopt/geo/curvexyzhelical.py
+++ b/src/simsopt/geo/curvexyzhelical.py
@@ -7,17 +7,16 @@ __all__ = ['CurveXYZHelical']
 
 def jaxXYZHelicalFouriercurve_pure(dofs, quadpoints, order, nfp, stellsym):
     
+    theta, m = jnp.meshgrid(quadpoints, jnp.arange(order + 1), indexing='ij')
+
     if stellsym:
         xc = dofs[:order+1]
         ys = dofs[order+1:2*order+1]
         zs = dofs[2*order+1:]
         
-        theta, m = jnp.meshgrid(quadpoints, jnp.arange(order+1), indexing='ij')
         xhat = np.sum(xc[None, :] * jnp.cos(2 * jnp.pi * nfp*m*theta), axis=1)
         yhat = np.sum(ys[None, :] * jnp.sin(2 * jnp.pi * nfp*m[:, 1:]*theta[:, 1:]), axis=1)
         
-        x = jnp.cos(2*jnp.pi*quadpoints) * xhat - jnp.sin(2*jnp.pi*quadpoints) * yhat
-        y = jnp.sin(2*jnp.pi*quadpoints) * xhat + jnp.cos(2*jnp.pi*quadpoints) * yhat
         z = jnp.sum(zs[None, :] * jnp.sin(2*jnp.pi*nfp * m[:, 1:]*theta[:, 1:]), axis=1)
     else:
         xc = dofs[0        :   order+1]
@@ -27,13 +26,14 @@ def jaxXYZHelicalFouriercurve_pure(dofs, quadpoints, order, nfp, stellsym):
         zc = dofs[4*order+2: 5*order+3]
         zs = dofs[5*order+3:          ]
         
-        theta, m = jnp.meshgrid(quadpoints, jnp.arange(order+1), indexing='ij')
         xhat = np.sum(xc[None, :] * jnp.cos(2*jnp.pi*nfp*m*theta), axis=1) + np.sum(xs[None, :] * jnp.sin(2*jnp.pi*nfp*m[:, 1:]*theta[:, 1:]), axis=1)
         yhat = np.sum(yc[None, :] * jnp.cos(2*jnp.pi*nfp*m*theta), axis=1) + np.sum(ys[None, :] * jnp.sin(2*jnp.pi*nfp*m[:, 1:]*theta[:, 1:]), axis=1)
         
-        x = jnp.cos(2*jnp.pi*quadpoints) * xhat - jnp.sin(2*jnp.pi*quadpoints) * yhat
-        y = jnp.sin(2*jnp.pi*quadpoints) * xhat + jnp.cos(2*jnp.pi*quadpoints) * yhat
         z = np.sum(zc[None, :] * jnp.cos(2*jnp.pi*nfp*m*theta), axis=1) + np.sum(zs[None, :] * jnp.sin(2*jnp.pi*nfp*m[:, 1:]*theta[:, 1:]), axis=1)
+
+    angle = 2 * jnp.pi * quadpoints
+    x = jnp.cos(angle) * xhat - jnp.sin(angle) * yhat
+    y = jnp.sin(angle) * xhat + jnp.cos(angle) * yhat
 
     gamma = jnp.zeros((len(quadpoints),3))
     gamma = gamma.at[:, 0].add(x)

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -276,13 +276,14 @@ class Testing(unittest.TestCase):
                     self.subtest_xyzhelical_symmetries(nfp, ntor)
     
     def subtest_xyzhelical_symmetries(self, nfp, ntor):
-        nfp_true = nfp // gcd(ntor, nfp)
-        if nfp_true != nfp:
+        if gcd(nfp, ntor) != 1 :
             return
 
         # does the stellarator symmetric curve have rotational symmetry?
         curve = self.get_curvexyzfouriersymmetries(stellsym=True, nfp=nfp, x=np.array([0.123, 0.123+1/nfp]), ntor=ntor)
         out = curve.gamma()
+        
+        # NOTE: the point at angle t+1/nfp is the point at angle t, but rotated by 2pi *(ntor/nfp) radians.
         alpha = 2*np.pi*ntor/nfp
         R = np.array([
             [np.cos(alpha), -np.sin(alpha), 0], 
@@ -327,6 +328,7 @@ class Testing(unittest.TestCase):
         np.testing.assert_allclose(B[0, 2], B[1, 2], atol=1e-14)
         
         # does the non-stellarator symmetric curve have rotational symmetry still?
+        # NOTE: the point at angle t+1/nfp is the point at angle t, but rotated by 2pi *(ntor/nfp) radians.
         curve = self.get_curvexyzfouriersymmetries(stellsym=False, nfp=nfp, x = np.array([0.123, 0.123+1./nfp]), ntor=ntor)
         out = curve.gamma()
         alpha = 2*np.pi*ntor/nfp

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -128,7 +128,6 @@ class Testing(unittest.TestCase):
     
     def test_curve_xyzhelical_xyzfourier(self):
         # this test checks that both helical coil representations can produce the same helical curve on a torus
-        
         order = 1
         nfp = 2
         x = np.linspace(0, 1, 100, endpoint=False)

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -166,6 +166,8 @@ class Testing(unittest.TestCase):
         np.testing.assert_allclose(curve1.gamma(), curve2.gamma(), atol=1e-14)
     
     def test_nonstellsym(self):
+        # this test checks that you can obtain a stellarator symmetric magnetic field from two non-stellarator symmetric
+        # CurveXYZHelical curves.
         for nfp in [1, 2, 3, 4, 5, 6]:
             for ntor in [1, 2, 3, 4, 5, 6]:
                 with self.subTest(nfp=nfp, ntor=ntor):
@@ -188,16 +190,14 @@ class Testing(unittest.TestCase):
         np.testing.assert_allclose(B[0, 1], B[1, 1], atol=1e-14)
         np.testing.assert_allclose(B[0, 2], B[1, 2], atol=1e-14)
     
-    def test_ntor(self):
-        # this test checks that you can obtain a stellarator symmetric magnetic field from two non-stellarator symmetric
-        # CurveXYZHelical curves.
+    def test_xyzhelical_symmetries(self):
+        # checking various symmetries of the CurveXYZHelical representation
         for nfp in [1, 2, 3, 4, 5, 6]:
             for ntor in [1, 2, 3, 4, 5, 6]:
                 with self.subTest(nfp=nfp, ntor=ntor):
                     self.subtest_xyzhelical_symmetries(nfp, ntor)
     
     def subtest_xyzhelical_symmetries(self, nfp, ntor):
-        
         nfp_true = nfp // gcd(ntor, nfp)
         if nfp_true != nfp:
             return

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -163,7 +163,7 @@ class Testing(unittest.TestCase):
         curve1.set('xc(1)', r)
         curve1.set('zs(1)', -r)
         curve2 = CurveHelical(x, order, nfp, 1, R, r, x0=np.zeros((2*order,)))
-        assert np.mean(np.linalg.norm(curve1.gamma()-curve2.gamma(), axis=-1)) == 0 
+        np.testing.assert_allclose(curve1.gamma(), curve2.gamma(), atol=1e-14)
 
     def test_nonstellsym(self):
         # this test checks that you can obtain a stellarator symmetric magnetic field from two non-stellarator symmetric
@@ -175,18 +175,9 @@ class Testing(unittest.TestCase):
         bs = BiotSavart(coils)
         bs.set_points([[1, 1, 1], [1, -1, -1]])
         B=bs.B_cyl()
-        assert np.abs(B[0, 0]+B[1, 0]) <1e-15
-        assert np.abs(B[0, 1]-B[1, 1]) <1e-15
-        assert np.abs(B[0, 2]-B[1, 2]) <1e-15
-
-        # sanity check that a nonstellarator symmetric CurveXYZHelical produces a non-stellsym magnetic field
-        bs = BiotSavart([Coil(curve, Current(1e5))])
-        bs.set_points([[1, 1, 1], [1, -1, -1]])
-        B=bs.B_cyl()
-        assert not np.abs(B[0, 0]+B[1, 0]) <1e-15
-        assert not np.abs(B[0, 1]-B[1, 1]) <1e-15
-        assert not np.abs(B[0, 2]-B[1, 2]) <1e-15
-
+        np.testing.assert_allclose(B[0, 0], -B[1, 0], atol=1e-14)
+        np.testing.assert_allclose(B[0, 1], B[1, 1], atol=1e-14)
+        np.testing.assert_allclose(B[0, 2], B[1, 2], atol=1e-14)
 
     def test_xyzhelical_symmetries(self):
 
@@ -197,29 +188,29 @@ class Testing(unittest.TestCase):
         alpha = -2*np.pi/nfp
         R = np.array([[np.cos(alpha), np.sin(alpha), 0], [-np.sin(alpha), np.cos(alpha), 0], [0, 0, 1]])
         print(R@out[0], out[1])
-        assert np.linalg.norm(out[1]-R@out[0])<1e-15
+        np.testing.assert_allclose(out[1], R@out[0], atol=1e-14)
 
         # does the stellarator symmetric curve indeed pass through (x0, 0, 0)?
         curve = self.get_curvexyzhelical(stellsym=True, nfp=nfp, x = np.array([0]))
         out = curve.gamma()
-        assert out[0, 0] !=0
-        assert out[0, 1] == 0
-        assert out[0, 2] == 0
+        assert np.abs(out[0, 0]) > 1e-3
+        np.testing.assert_allclose(out[0, 1], 0, atol=1e-14)
+        np.testing.assert_allclose(out[0, 2], 0, atol=1e-14)
 
 
         # does the non-stellarator symmetric curve not pass through (x0, 0, 0)?
         curve = self.get_curvexyzhelical(stellsym=False, nfp=nfp, x = np.array([0]))
         out = curve.gamma()
-        assert out[0, 0] !=0
-        assert out[0, 1] != 0
-        assert out[0, 2] != 0
+        assert np.abs(out[0, 0]) > 1e-3
+        assert np.abs(out[0, 1]) > 1e-3
+        assert np.abs(out[0, 2]) > 1e-3
 
         # is the stellarator symmetric curve actually stellarator symmetric?
         curve = self.get_curvexyzhelical(stellsym=True, nfp=nfp, x = np.array([0.123, -0.123]))
         pts = curve.gamma()
-        assert np.abs(pts[0, 0]-pts[1, 0]) <1e-15
-        assert np.abs(pts[0, 1]+pts[1, 1]) <1e-15
-        assert np.abs(pts[0, 2]+pts[1, 2]) <1e-15
+        np.testing.assert_allclose(pts[0, 0], pts[1, 0], atol=1e-14)
+        np.testing.assert_allclose(pts[0, 1], -pts[1, 1], atol= 1e-14)
+        np.testing.assert_allclose(pts[0, 2], -pts[1, 2], atol= 1e-14)
 
         # is the field from the stellarator symmetric curve actually stellarator symmetric?
         curve = self.get_curvexyzhelical(stellsym=True, nfp=nfp, x=np.linspace(0, 1, 200, endpoint=False))
@@ -228,9 +219,9 @@ class Testing(unittest.TestCase):
         bs = BiotSavart([coil])
         bs.set_points([[1, 1, 1], [1, -1, -1]])
         B=bs.B_cyl()
-        assert np.abs(B[0, 0]+B[1, 0]) <1e-15
-        assert np.abs(B[0, 1]-B[1, 1]) <1e-15
-        assert np.abs(B[0, 2]-B[1, 2]) <1e-15
+        np.testing.assert_allclose(B[0, 0],-B[1, 0], atol=1e-14)
+        np.testing.assert_allclose(B[0, 1], B[1, 1], atol=1e-14)
+        np.testing.assert_allclose(B[0, 2], B[1, 2], atol=1e-14)
         
         # does the non-stellarator symmetric curve have rotational symmetry still?
         curve = self.get_curvexyzhelical(stellsym=False, nfp=nfp, x = np.array([0.123, 0.123+1/nfp]))
@@ -238,7 +229,7 @@ class Testing(unittest.TestCase):
         alpha = -2*np.pi/nfp
         R = np.array([[np.cos(alpha), np.sin(alpha), 0], [-np.sin(alpha), np.cos(alpha), 0], [0, 0, 1]])
         print(R@out[0], out[1])
-        assert np.linalg.norm(out[1]-R@out[0])<1e-15
+        np.testing.assert_allclose(out[1], R@out[0], atol=1e-14)
 
     def test_curve_helical_xyzfourier(self):
         x = np.asarray([0.6])

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -15,6 +15,7 @@ from simsopt.geo.curvexyzhelical import CurveXYZHelical
 from simsopt.geo.curve import RotatedCurve, curves_to_vtk
 from simsopt.geo import parameters
 from simsopt.configs.zoo import get_ncsx_data, get_w7x_data  
+from simsopt.field import BiotSavart, Current, coils_via_symmetries, Coil
 from simsopt.field.coil import coils_to_makegrid
 from simsopt.geo import CurveLength, CurveCurveDistance
 
@@ -59,7 +60,6 @@ def taylor_test(f, df, x, epsilons=None, direction=None):
     print("################################################################################")
 
 
-#def get_curve(curvetype, rotated, x=np.linspace(0, 1, 100, endpoint=False)):
 def get_curve(curvetype, rotated, x=np.asarray([0.5])):
     np.random.seed(2)
     rand_scale = 0.01
@@ -170,7 +170,6 @@ class Testing(unittest.TestCase):
         # CurveXYZHelical curves.
         nfp = 3
         curve = self.get_curvexyzhelical(stellsym=False, nfp=nfp)
-        from simsopt.field import BiotSavart, Current, coils_via_symmetries, Coil
         current = Current(1e5)
         coils = coils_via_symmetries([curve], [current], 1, True)
         bs = BiotSavart(coils)
@@ -223,7 +222,6 @@ class Testing(unittest.TestCase):
         assert np.abs(pts[0, 2]+pts[1, 2]) <1e-15
 
         # is the field from the stellarator symmetric curve actually stellarator symmetric?
-        from simsopt.field import BiotSavart, Current, Coil
         curve = self.get_curvexyzhelical(stellsym=True, nfp=nfp, x=np.linspace(0, 1, 200, endpoint=False))
         current = Current(1e5)
         coil = Coil(curve, current)

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -81,6 +81,8 @@ def get_curve(curvetype, rotated, x=np.asarray([0.5])):
         curve = CurveXYZFourierSymmetries(x, order, 2, True)
     elif curvetype == "CurveXYZFourierSymmetries2":
         curve = CurveXYZFourierSymmetries(x, order, 2, False)
+    elif curvetype == "CurveXYZFourierSymmetries3":
+        curve = CurveXYZFourierSymmetries(x, order, 2, False, ntor=3)
     else:
         assert False
     
@@ -112,6 +114,16 @@ def get_curve(curvetype, rotated, x=np.asarray([0.5])):
         curve.set('zc(0)', 1)
         curve.set('zs(1)', r)
         dofs = curve.get_dofs()
+    elif curvetype == "CurveXYZFourierSymmetries3":
+        R = 1
+        r = 0.5
+        curve.set('xc(0)', R)
+        curve.set('xs(1)', -0.1*r)
+        curve.set('xc(1)', -r)
+        curve.set('zs(1)', -r)
+        curve.set('zc(0)', 1)
+        curve.set('zs(1)', r)
+        dofs = curve.get_dofs()
     else:
         assert False
 
@@ -124,7 +136,7 @@ def get_curve(curvetype, rotated, x=np.asarray([0.5])):
 
 class Testing(unittest.TestCase):
 
-    curvetypes = ["CurveXYZFourier", "JaxCurveXYZFourier", "CurveRZFourier", "CurvePlanarFourier", "CurveHelical", "CurveXYZFourierSymmetries1","CurveXYZFourierSymmetries2", "CurveHelicalInitx0"]
+    curvetypes = ["CurveXYZFourier", "JaxCurveXYZFourier", "CurveRZFourier", "CurvePlanarFourier", "CurveHelical", "CurveXYZFourierSymmetries1","CurveXYZFourierSymmetries2", "CurveXYZFourierSymmetries3", "CurveHelicalInitx0"]
     
     def get_curvexyzfouriersymmetries(self, stellsym=True, x=None, nfp=None, ntor=1):
         # returns a CurveXYZFourierSymmetries that is randomly perturbed
@@ -169,21 +181,21 @@ class Testing(unittest.TestCase):
         r''' This test checks that a CurveXYZFourierSymmetries can represent a non-stellarator symmetric
         trefoil knot.  A parametric representation of a trefoil knot is given by:
         
-        .. math::
-            x(t) &= sin(t) + 2sin(t) \\
-            y(t) &= cos(t) - 2cos(t) \\
-            z(t) &= -sin(3t)
+            x(t) = sin(t) + 2sin(t)
+            y(t) = cos(t) - 2cos(t)
+            z(t) = -sin(3t)
         
         The above can be rewritten the CurveXYZFourierSymmetries representation, with
         order = 1, nfp = 3, and ntor = 2:
         
-        .. math::
-            xhat(t) &= sin(nfp*t) \\
-            yhat(t) &= -2 + cos(nfp*t), \\ 
-            x(t) &= xhat(t) * cos(ntor*t) - yhat(t) * sin(ntor*t), \\
-            y(t) &= xhat(t) * sin(ntor*t) + yhat(t) * cos(ntor*t), \\
-            z(t) &= -sin(nfp*t),
+            x(t) = xhat(t) * cos(ntor*t) - yhat(t) * sin(ntor*t),
+            y(t) = xhat(t) * sin(ntor*t) + yhat(t) * cos(ntor*t),
+            z(t) = -sin(nfp*t),
         
+        where
+            xhat(t) &= sin(nfp*t),
+            yhat(t) &= -2 + cos(nfp*t),
+
         i.e., The dofs are xs(1)=1, yc(0)=-2, yc(1)=1, zs(1)=-1, and zero otherwise.
         '''
 
@@ -208,21 +220,22 @@ class Testing(unittest.TestCase):
         r''' This test checks that a CurveXYZFourierSymmetries can represent a stellarator symmetric
         trefoil knot.  A parametric representation of a trefoil knot is given by:
         
-        .. math::
-            x(t) &= cos(t) - 2cos(t) \\
-            y(t) &=-sin(t) - 2sin(t) \\
-            z(t) &= -sin(3t)
+            x(t) = cos(t) - 2cos(t),
+            y(t) =-sin(t) - 2sin(t),
+            z(t) = -sin(3t).
         
         The above can be rewritten the CurveXYZFourierSymmetries representation, with
         order = 1, nfp = 3, and ntor = 2:
         
-        .. math::
-            xhat(t) &= -2 + cos(t)\\
-            yhat(t) &= -sin(t)\\ 
-            x(t) &= xhat(t) * cos(ntor*t) - yhat(t) * sin(ntor*t), \\
-            y(t) &= xhat(t) * sin(ntor*t) + yhat(t) * cos(ntor*t), \\
-            z(t) &= -sin(nfp*t),
+            x(t) = xhat(t) * cos(ntor*t) - yhat(t) * sin(ntor*t),
+            y(t) = xhat(t) * sin(ntor*t) + yhat(t) * cos(ntor*t),
+            z(t) = -sin(nfp*t),
         
+        where
+
+            xhat(t) = -2 + cos(nfp*t)
+            yhat(t) = -sin(nfp*t)
+
         i.e., xc(0)=-2, xc(1)=1, ys(1)=-1, zs(1)=-1.
         '''
 

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -213,8 +213,7 @@ class Testing(unittest.TestCase):
                     self.subtest_nonstellsym(nfp, ntor)
 
     def subtest_nonstellsym(self, nfp, ntor):
-        nfp_true = nfp // gcd(ntor, nfp)
-        if nfp_true != nfp:
+        if gcd(ntor, nfp) != 1:
             return
 
         # this test checks that you can obtain a stellarator symmetric magnetic field from two non-stellarator symmetric

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -200,13 +200,27 @@ class Testing(unittest.TestCase):
         print(R@out[0], out[1])
         assert np.linalg.norm(out[1]-R@out[0])<1e-15
 
+        # does the stellarator symmetric curve indeed pass through (x0, 0, 0)?
+        curve = self.get_curvexyzhelical(stellsym=True, nfp=nfp, x = np.array([0]))
+        out = curve.gamma()
+        assert out[0, 0] !=0
+        assert out[0, 1] == 0
+        assert out[0, 2] == 0
+
+
+        # does the non-stellarator symmetric curve not pass through (x0, 0, 0)?
+        curve = self.get_curvexyzhelical(stellsym=False, nfp=nfp, x = np.array([0]))
+        out = curve.gamma()
+        assert out[0, 0] !=0
+        assert out[0, 1] != 0
+        assert out[0, 2] != 0
+
         # is the stellarator symmetric curve actually stellarator symmetric?
         curve = self.get_curvexyzhelical(stellsym=True, nfp=nfp, x = np.array([0.123, -0.123]))
         pts = curve.gamma()
         assert np.abs(pts[0, 0]-pts[1, 0]) <1e-15
         assert np.abs(pts[0, 1]+pts[1, 1]) <1e-15
         assert np.abs(pts[0, 2]+pts[1, 2]) <1e-15
-
 
         # is the field from the stellarator symmetric curve actually stellarator symmetric?
         from simsopt.field import BiotSavart, Current, Coil

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -172,15 +172,16 @@ class Testing(unittest.TestCase):
         ntor = 2
         # nfp = 1 and ntor = 2 here, so it should work
         curve = CurveXYZFourierSymmetries(100, order, nfp, True, ntor=ntor, x0=np.ones(3*order+1))
-        
+        print(curve.x)
+
         with self.assertRaises(Exception):
             order = 1
             nfp = 2
             ntor = 2
             # nfp = 2 and ntor = 2 here, so an exception should be raised
-            curve = CurveXYZFourierSymmetries(100, order, nfp, True, ntor=ntor, x0=np.ones(3*order+1))
-    
-    def test_curvexyzsymmetries_is_curvexyzfouriersymmetries(self):
+            _ = CurveXYZFourierSymmetries(100, order, nfp, True, ntor=ntor, x0=np.ones(3*order+1))
+
+    def test_curvehelical_is_curvexyzfouriersymmetries(self):
         # this test checks that both helical coil representations can produce the same helical curve on a torus
         order = 1
         nfp = 2

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -165,9 +165,9 @@ class Testing(unittest.TestCase):
         curve2 = CurveHelical(x, order, nfp, 1, R, r, x0=np.zeros((2*order,)))
         np.testing.assert_allclose(curve1.gamma(), curve2.gamma(), atol=1e-14)
     
-    def test_trefoil(self):
-        r''' This test checks that a CurveXYZFourierSymmetries can represent a trefoil knot.
-        A parametric representation of a trefoil knot is given by:
+    def test_trefoil_nonstellsym(self):
+        r''' This test checks that a CurveXYZFourierSymmetries can represent a non-stellarator symmetric
+        trefoil knot.  A parametric representation of a trefoil knot is given by:
         
         .. math::
             x(t) &= sin(t) + 2sin(t) \\
@@ -184,7 +184,7 @@ class Testing(unittest.TestCase):
             y(t) &= xhat(t) * sin(ntor*t) + yhat(t) * cos(ntor*t), \\
             z(t) &= -sin(nfp*t),
         
-        i.e., xs(1)=1, yc(0)=-2, yc(1)=1, zs(1)=-1.
+        i.e., The dofs are xs(1)=1, yc(0)=-2, yc(1)=1, zs(1)=-1, and zero otherwise.
         '''
 
         order = 1
@@ -203,6 +203,46 @@ class Testing(unittest.TestCase):
         curve.set('yc(1)', 1.)
         curve.set('zs(1)', -1.)
         np.testing.assert_allclose(curve.gamma(), XYZ, atol=1e-14)
+
+    def test_trefoil_stellsym(self):
+        r''' This test checks that a CurveXYZFourierSymmetries can represent a stellarator symmetric
+        trefoil knot.  A parametric representation of a trefoil knot is given by:
+        
+        .. math::
+            x(t) &= cos(t) - 2cos(t) \\
+            y(t) &=-sin(t) - 2sin(t) \\
+            z(t) &= -sin(3t)
+        
+        The above can be rewritten the CurveXYZFourierSymmetries representation, with
+        order = 1, nfp = 3, and ntor = 2:
+        
+        .. math::
+            xhat(t) &= -2 + cos(t)\\
+            yhat(t) &= -sin(t)\\ 
+            x(t) &= xhat(t) * cos(ntor*t) - yhat(t) * sin(ntor*t), \\
+            y(t) &= xhat(t) * sin(ntor*t) + yhat(t) * cos(ntor*t), \\
+            z(t) &= -sin(nfp*t),
+        
+        i.e., xc(0)=-2, xc(1)=1, ys(1)=-1, zs(1)=-1.
+        '''
+
+        order = 1
+        nfp = 3
+        ntor = 2
+        x = np.linspace(0, 1, 500, endpoint=False)
+        curve = CurveXYZFourierSymmetries(x, order, nfp, True, ntor=ntor)
+        
+        X = np.cos(2*np.pi * x) - 2 * np.cos(2*2*np.pi * x)
+        Y =-np.sin(2*np.pi * x) - 2 * np.sin(2*2*np.pi * x)
+        Z = -np.sin(3*2*np.pi*x)
+        XYZ = np.concatenate([X[:, None], Y[:, None], Z[:, None]], axis=1)
+        
+        curve.set('xc(0)', -2)
+        curve.set('xc(1)', 1)
+        curve.set('ys(1)', -1)
+        curve.set('zs(1)', -1)
+        np.testing.assert_allclose(curve.gamma(), XYZ, atol=1e-14)
+
 
     def test_nonstellsym(self):
         # this test checks that you can obtain a stellarator symmetric magnetic field from two non-stellarator symmetric

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -163,18 +163,34 @@ class Testing(unittest.TestCase):
 
         return curve
 
-    def test_curvehelical_is_curvexyzfouriersymmetries(self):
+    def test_curvexyzsymmetries_raisesexception(self):
+        # test ensures that an exception is raised when you try and create a curvexyzfouriersymmetries
+        # where gcd(ntor, nfp) != 1.
+        
+        order = 1
+        nfp = 1
+        ntor = 2
+        # nfp = 1 and ntor = 2 here, so it should work
+        curve = CurveXYZFourierSymmetries(100, order, nfp, True, ntor=ntor, x0=np.ones(3*order+1))
+        
+        with self.assertRaises(Exception):
+            order = 1
+            nfp = 2
+            ntor = 2
+            # nfp = 2 and ntor = 2 here, so an exception should be raised
+            curve = CurveXYZFourierSymmetries(100, order, nfp, True, ntor=ntor, x0=np.ones(3*order+1))
+    
+    def test_curvexyzsymmetries_is_curvexyzfouriersymmetries(self):
         # this test checks that both helical coil representations can produce the same helical curve on a torus
         order = 1
         nfp = 2
-        x = np.linspace(0, 1, 100, endpoint=False)
-        curve1 = CurveXYZFourierSymmetries(x, order, nfp, True)
+        curve1 = CurveXYZFourierSymmetries(100, order, nfp, True)
         R = 1
         r = 0.5
         curve1.set('xc(0)', R)
         curve1.set('xc(1)', r)
         curve1.set('zs(1)', -r)
-        curve2 = CurveHelical(x, order, nfp, 1, R, r, x0=np.zeros((2*order,)))
+        curve2 = CurveHelical(np.linspace(0, 1, 100, endpoint=False), order, nfp, 1, R, r, x0=np.zeros((2*order,)))
         np.testing.assert_allclose(curve1.gamma(), curve2.gamma(), atol=1e-14)
     
     def test_trefoil_nonstellsym(self):

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -128,7 +128,7 @@ class Testing(unittest.TestCase):
     
     def test_curve_xyzhelical_xyzfourier(self):
         # this test checks that both helical coil representations can produce the same helical curve on a torus
-
+        
         order = 1
         nfp = 2
         x = np.linspace(0, 1, 100, endpoint=False)
@@ -138,7 +138,6 @@ class Testing(unittest.TestCase):
         curve1.set('xc(0)', R)
         curve1.set('xc(1)', r)
         curve1.set('zs(1)', -r)
-        dofs = curve1.get_dofs()
         curve2 = CurveHelical(x, order, nfp, 1, R, r, x0=np.zeros((2*order,)))
         assert np.mean(np.linalg.norm(curve1.gamma()-curve2.gamma(), axis=-1)) == 0 
 

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -168,18 +168,21 @@ class Testing(unittest.TestCase):
     def test_trefoil(self):
         r''' This test checks that a CurveXYZFourierSymmetries can represent a trefoil knot.
         A parametric representation of a trefoil knot is given by:
-        x(t) = sin(t) + 2sin(t)
-        y(t) = cos(t) - 2cos(t)
-        z(t) = -sin(3t)
+        
+        .. math::
+            x(t) &= sin(t) + 2sin(t) \\
+            y(t) &= cos(t) - 2cos(t) \\
+            z(t) &= -sin(3t)
         
         The above can be rewritten the CurveXYZFourierSymmetries representation, with
         order = 1, nfp = 3, and ntor = 2:
         
-        xhat(t) = sin(nfp*t)
-        yhat(t) = -2 + cos(nfp*t),
-        x(t) = xhat(t) * cos(ntor*t) - yhat(t) * sin(ntor*t),
-        y(t) = xhat(t) * sin(ntor*t) + yhat(t) * cos(ntor*t),
-        z(t) = -sin(nfp*t),
+        .. math::
+            xhat(t) &= sin(nfp*t) \\
+            yhat(t) &= -2 + cos(nfp*t), \\ 
+            x(t) &= xhat(t) * cos(ntor*t) - yhat(t) * sin(ntor*t), \\
+            y(t) &= xhat(t) * sin(ntor*t) + yhat(t) * cos(ntor*t), \\
+            z(t) &= -sin(nfp*t),
         
         i.e., xs(1)=1, yc(0)=-2, yc(1)=1, zs(1)=-1.
         '''
@@ -191,7 +194,7 @@ class Testing(unittest.TestCase):
         curve = CurveXYZFourierSymmetries(x, order, nfp, False, ntor=ntor)
         
         X = np.sin(2*np.pi * x) + 2 * np.sin(2*2*np.pi * x)
-        Y = np.cos(2*np.pi * x) - 2 * np.cos(2*2*np.pi*x)
+        Y = np.cos(2*np.pi * x) - 2 * np.cos(2*2*np.pi * x)
         Z = -np.sin(3*2*np.pi*x)
         XYZ = np.concatenate([X[:, None], Y[:, None], Z[:, None]], axis=1)
         
@@ -239,20 +242,17 @@ class Testing(unittest.TestCase):
             return
 
         # does the stellarator symmetric curve have rotational symmetry?
-        curve = self.get_curvexyzfouriersymmetries(stellsym=True, nfp=nfp, x=np.array([0.123, 0.123+ntor/nfp]), ntor=ntor)
+        curve = self.get_curvexyzfouriersymmetries(stellsym=True, nfp=nfp, x=np.array([0.123, 0.123+1/nfp]), ntor=ntor)
         out = curve.gamma()
-        alpha = -2*np.pi/nfp
+        alpha = 2*np.pi*ntor/nfp
         R = np.array([
-            [np.cos(alpha), np.sin(alpha), 0], 
-            [-np.sin(alpha), np.cos(alpha), 0], 
+            [np.cos(alpha), -np.sin(alpha), 0], 
+            [np.sin(alpha), np.cos(alpha), 0], 
             [0, 0, 1]
             ])
         
         print(R@out[0], out[1])
-        try:
-            np.testing.assert_allclose(out[1], R@out[0], atol=1e-14)
-        except:
-            np.testing.assert_allclose(out[1], np.linalg.inv(R)@out[0], atol=1e-14)
+        np.testing.assert_allclose(out[1], R@out[0], atol=1e-14)
 
         # does the stellarator symmetric curve indeed pass through (x0, 0, 0)?
         curve = self.get_curvexyzfouriersymmetries(stellsym=True, nfp=nfp, x = np.array([0]), ntor=ntor)
@@ -288,15 +288,16 @@ class Testing(unittest.TestCase):
         np.testing.assert_allclose(B[0, 2], B[1, 2], atol=1e-14)
         
         # does the non-stellarator symmetric curve have rotational symmetry still?
-        curve = self.get_curvexyzfouriersymmetries(stellsym=False, nfp=nfp, x = np.array([0.123, 0.123+ntor/nfp]), ntor=ntor)
+        curve = self.get_curvexyzfouriersymmetries(stellsym=False, nfp=nfp, x = np.array([0.123, 0.123+1./nfp]), ntor=ntor)
         out = curve.gamma()
-        alpha = -2*np.pi/nfp
-        R = np.array([[np.cos(alpha), np.sin(alpha), 0], [-np.sin(alpha), np.cos(alpha), 0], [0, 0, 1]])
+        alpha = 2*np.pi*ntor/nfp
+        R = np.array([
+            [np.cos(alpha), -np.sin(alpha), 0], 
+            [np.sin(alpha), np.cos(alpha), 0], 
+            [0, 0, 1]
+            ])
         print(R@out[0], out[1])
-        try:
-            np.testing.assert_allclose(out[1], R@out[0], atol=1e-14)
-        except:
-            np.testing.assert_allclose(out[1], np.linalg.inv(R)@out[0], atol=1e-14)
+        np.testing.assert_allclose(out[1], R@out[0], atol=1e-14)
 
     def test_curve_helical_xyzfourier(self):
         x = np.asarray([0.6])

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -193,8 +193,8 @@ class Testing(unittest.TestCase):
             z(t) = -sin(nfp*t),
         
         where
-            xhat(t) &= sin(nfp*t),
-            yhat(t) &= -2 + cos(nfp*t),
+            xhat(t) = sin(nfp*t),
+            yhat(t) = -2 + cos(nfp*t),
 
         i.e., The dofs are xs(1)=1, yc(0)=-2, yc(1)=1, zs(1)=-1, and zero otherwise.
         '''


### PR DESCRIPTION
This pull request introduces a new helical curve representation called `CurveXYZHelical`.  This curve is different from `CurveXYZFourier` because it can have discrete rotational symmetry.  It can also be stellarator symmetric, or not.

We currently support a helical curve representation `CurveHelical`, but this curve is restricted to lie on a torus.  The new  `CurveXYZHelical` is not restricted to lie on a torus, and can represent curves like the one below.  Viewing from above, the  `CurveXYZHelical` appears to lie on a torus
![helical_top](https://github.com/hiddenSymmetries/simsopt/assets/51761749/dd7524a8-7473-40f7-8679-89976ea5db3b)

but profile view reveals that it clearly does not:
![helical_side](https://github.com/hiddenSymmetries/simsopt/assets/51761749/ace19c13-414f-4e26-afbb-5e2633ef0a6f)

When `CurveXYZHelical` is stellarator symmetric, then necessarily the curve must pass through the point `(x0, 0, 0)`.  If you do not want this, then the user can apply stellarator symmetry to a non-stellarator symmetric `CurveXYZHelical` curve and obtain a stellsym magnetic field from those two curves.