### PR TITLE
fix for failing workflows on github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,7 +163,7 @@ jobs:
 
     - name: Install simsopt package
       # run: env CMAKE_BUILD_TYPE=Debug pip install -v .[MPI,SPEC]
-      run: pip install -v ".[MPI,SPEC,VIS]"
+      run: pip install -v ".[MPI,SPEC]"
 
     - name: Verify that importing simsopt does not automatically initialize MPI
       run: ./tests/verify_MPI_not_initialized.py

--- a/tests/mhd/test_spec.py
+++ b/tests/mhd/test_spec.py
@@ -138,29 +138,28 @@ class SpecTests(unittest.TestCase):
 
         filename = os.path.join(TEST_DIR, 'RotatingEllipse_Nvol8.sp')
 
-        with ScratchDir("."):
-            s = Spec(filename)
-            nvol = s.inputlist.nvol
-            mvol = nvol + s.inputlist.lfreebound
+        s = Spec(filename)
+        nvol = s.inputlist.nvol
+        mvol = nvol + s.inputlist.lfreebound
 
-            cumulative = False  # Surfaces currents are non-cumulative quantities in SPEC
-            surface_current = ProfileSpec(np.zeros((mvol,)), cumulative=cumulative)
+        cumulative = False  # Surfaces currents are non-cumulative quantities in SPEC
+        surface_current = ProfileSpec(np.zeros((mvol,)), cumulative=cumulative)
 
-            s.interface_current_profile = surface_current
+        s.interface_current_profile = surface_current
 
-            # Check that all currents are actually zero
-            for lvol in range(1, mvol):
+        # Check that all currents are actually zero
+        for lvol in range(1, mvol):
+            self.assertEqual(s.get_profile('interface_current', lvol), 0)
+
+        # Modify one interface current
+        s.set_profile('interface_current', lvol=3, value=1)
+
+        # Check values
+        for lvol in range(1, mvol):
+            if lvol != 3:
                 self.assertEqual(s.get_profile('interface_current', lvol), 0)
-
-            # Modify one interface current
-            s.set_profile('interface_current', lvol=3, value=1)
-
-            # Check values
-            for lvol in range(1, mvol):
-                if lvol != 3:
-                    self.assertEqual(s.get_profile('interface_current', lvol), 0)
-                else:
-                    self.assertEqual(s.get_profile('interface_current', lvol), 1)
+            else:
+                self.assertEqual(s.get_profile('interface_current', lvol), 1)
 
     def test_set_profile_cumulative(self):
         """
@@ -170,31 +169,30 @@ class SpecTests(unittest.TestCase):
 
         filename = os.path.join(TEST_DIR, 'RotatingEllipse_Nvol8.sp')
 
-        with ScratchDir("."):
-            s = Spec(filename)
-            nvol = s.inputlist.nvol
-            mvol = nvol + s.inputlist.lfreebound
+        s = Spec(filename)
+        nvol = s.inputlist.nvol
+        mvol = nvol + s.inputlist.lfreebound
 
-            cumulative = True  # Surfaces currents are non-cumulative quantities in SPEC
-            volume_current = ProfileSpec(np.zeros((mvol,)), cumulative=cumulative)
+        cumulative = True  # Surfaces currents are non-cumulative quantities in SPEC
+        volume_current = ProfileSpec(np.zeros((mvol,)), cumulative=cumulative)
 
-            s.volume_current_profile = volume_current
+        s.volume_current_profile = volume_current
 
-            # Check that all currents are actually zero
-            for lvol in range(1, mvol):
+        # Check that all currents are actually zero
+        for lvol in range(1, mvol):
+            self.assertEqual(s.get_profile('volume_current', lvol), 0)
+
+        # Modify one interface current
+        s.set_profile('volume_current', lvol=3, value=1)
+
+        print(s.volume_current_profile)
+
+        # Check values
+        for lvol in range(1, mvol):
+            if lvol < 3:
                 self.assertEqual(s.get_profile('volume_current', lvol), 0)
-
-            # Modify one interface current
-            s.set_profile('volume_current', lvol=3, value=1)
-
-            print(s.volume_current_profile)
-
-            # Check values
-            for lvol in range(1, mvol):
-                if lvol < 3:
-                    self.assertEqual(s.get_profile('volume_current', lvol), 0)
-                else:
-                    self.assertEqual(s.get_profile('volume_current', lvol), 1)
+            else:
+                self.assertEqual(s.get_profile('volume_current', lvol), 1)
 
     def test_integrated_stellopt_scenarios_1dof(self):
         """


### PR DESCRIPTION
This PR fixes two issues with github actions that I've noticed:

The first problem is documented in issue #357.  The unit tests now pass if I remove the `with ScratchDir:` from
https://github.com/hiddenSymmetries/simsopt/blob/38a20cb8a0bcb6aab6d7250e595fd47b5f720ecf/tests/mhd/test_spec.py#L141

The second problem is documented in issue #405.  For some reason, mayavi is having issues installing on some of the runners:
https://github.com/hiddenSymmetries/simsopt/actions/runs/8741345143/job/23987152753?pr=404
https://github.com/hiddenSymmetries/simsopt/actions/runs/8754269959/job/24025642995?pr=404



The error goes away by removing VIS from 
https://github.com/hiddenSymmetries/simsopt/blob/38a20cb8a0bcb6aab6d7250e595fd47b5f720ecf/.github/workflows/tests.yml#L166
since mayavi won't be installed.

Let's use this PR to discuss possible solutions, because the failing workflows are quite annoying.  Removing `VIS` from above is not advisable, so we need to find an alternative way to fix the issue.