### PR TITLE
fix for issue #405

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 SPEC = ["py_spec>=3.0.1", "pyoculus>=0.1.1", "h5py>=3.1.0"]
 MPI = ["mpi4py>=3.0.3"]
-VIS = ["vtk >= 8.1.2", "PyQt5", "mayavi", "plotly", "networkx"]
+VIS = ["vtk >= 8.1.2", "PyQt5", "plotly", "networkx"]
 DOCS = ["sphinx", "sphinx-rtd-theme"]
 
 [project.urls]


### PR DESCRIPTION
This PR attempts to fix the problem described in issue #405, where `mayavi` is not being installed correctly during `test.yml`.   It seems like the installation problem has been documented here:

https://github.com/enthought/mayavi/issues/1219
where the upshot is to install from source.

In branch `ag/fix_issue_405`, I install `mayavi` from source on the runner without issues:
https://github.com/hiddenSymmetries/simsopt/compare/master...ag/fix_issue_405

but runtime errors associated to `mayavi` appear now instead (rather than compile time errors as previously)
https://github.com/hiddenSymmetries/simsopt/actions/runs/8793008167/job/24130188871
and I have not yet been able to resolve the runtime errors.

I think the easiest path forward is to remove mayavi from the optional-dependencies in `pyproject.toml`.  The mayavi portions of the plotting subroutines were not being reached by the unit tests anyways prior to these `mayavi` installation issues appearing.
https://app.codecov.io/gh/hiddenSymmetries/simsopt/commit/38a20cb8a0bcb6aab6d7250e595fd47b5f720ecf/blob/src/simsopt/geo/curve.py#L127
https://app.codecov.io/gh/hiddenSymmetries/simsopt/commit/38a20cb8a0bcb6aab6d7250e595fd47b5f720ecf/blob/src/simsopt/geo/surface.py#L246