### PR TITLE
Make residuals file optional

### DIFF
--- a/src/simsopt/solve/mpi.py
+++ b/src/simsopt/solve/mpi.py
@@ -79,6 +79,7 @@ def least_squares_mpi_solve(prob: LeastSquaresProblem,
                             abs_step: float = 1.0e-7,
                             rel_step: float = 0.0,
                             diff_method: str = "forward",
+                            save_residuals: bool = False,
                             **kwargs):
     """
     Solve a nonlinear-least-squares minimization problem using
@@ -101,6 +102,8 @@ def least_squares_mpi_solve(prob: LeastSquaresProblem,
              "forward". If ``centered``, centered finite differences will
              be used. If ``forward``, one-sided finite differences will
              be used. Else, error is raised.
+        save_residuals: Whether to save the residuals at each iteration.
+             This may be useful for debugging, although the file can become large.
         kwargs: Any arguments to pass to
                 `scipy.optimize.least_squares <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.least_squares.html>`_.
                 For instance, you can supply ``max_nfev=100`` to set
@@ -159,20 +162,21 @@ def least_squares_mpi_solve(prob: LeastSquaresProblem,
             objective_file.write(f"Problem type:\nleast_squares\nnparams:\n{prob.dof_size}\n")
             objective_file.write("function_evaluation,seconds")
 
-            residuals_file = open(f"residuals_{datestr}.dat", 'w')
-            residuals_file.write(f"Problem type:\nleast_squares\nnparams:\n{prob.dof_size}\n")
-            residuals_file.write("function_evaluation,seconds")
-
             for j in range(prob.dof_size):
                 objective_file.write(f",x({j})")
             objective_file.write(",objective_function\n")
 
-            for j in range(prob.dof_size):
-                residuals_file.write(f",x({j})")
-            residuals_file.write(",objective_function")
-            for j in range(len(residuals)):
-                residuals_file.write(f",F({j})")
-            residuals_file.write("\n")
+            if save_residuals:
+                residuals_file = open(f"residuals_{datestr}.dat", 'w')
+                residuals_file.write(f"Problem type:\nleast_squares\nnparams:\n{prob.dof_size}\n")
+                residuals_file.write("function_evaluation,seconds")
+
+                for j in range(prob.dof_size):
+                    residuals_file.write(f",x({j})")
+                residuals_file.write(",objective_function")
+                for j in range(len(residuals)):
+                    residuals_file.write(f",F({j})")
+                residuals_file.write("\n")
 
         del_t = time() - start_time
         objective_file.write(f"{nevals:6d},{del_t:12.4e}")
@@ -181,14 +185,16 @@ def least_squares_mpi_solve(prob: LeastSquaresProblem,
         objective_file.write(f",{objective_val:24.16e}\n")
         objective_file.flush()
 
-        residuals_file.write(f"{nevals:6d},{del_t:12.4e}")
-        for xj in x:
-            residuals_file.write(f",{xj:24.16e}")
-        residuals_file.write(f",{objective_val:24.16e}")
-        for fj in unweighted_residuals:
-            residuals_file.write(f",{fj:24.16e}")
-        residuals_file.write("\n")
-        residuals_file.flush()
+        if save_residuals:
+            residuals_file.write(f"{nevals:6d},{del_t:12.4e}")
+            for xj in x:
+                residuals_file.write(f",{xj:24.16e}")
+            residuals_file.write(f",{objective_val:24.16e}")
+            for fj in unweighted_residuals:
+                residuals_file.write(f",{fj:24.16e}")
+            residuals_file.write("\n")
+            residuals_file.flush()
+
         nevals += 1
         logger.debug(f"residuals are {residuals}")
         return residuals
@@ -225,7 +231,8 @@ def least_squares_mpi_solve(prob: LeastSquaresProblem,
         x = result.x
 
         objective_file.close()
-        residuals_file.close()
+        if save_residuals:
+            residuals_file.close()
 
     datalog_started = False
     logger.info("Completed solve.")

--- a/tests/mhd/test_integrated_mpi.py
+++ b/tests/mhd/test_integrated_mpi.py
@@ -190,7 +190,7 @@ class IntegratedTests(unittest.TestCase):
                                                         (residue2.J, 0, 1)])
                
                 # Solve for two nfevs to test if runs
-                least_squares_mpi_solve(prob, mpi=mpi, grad=grad, max_nfev=2)
+                least_squares_mpi_solve(prob, mpi=mpi, grad=grad, save_residuals=True, max_nfev=2)
                 
                 # No assertions, run is too short to complete, just testing if it does run
 

--- a/tests/solve/test_least_squares.py
+++ b/tests/solve/test_least_squares.py
@@ -72,11 +72,12 @@ class LeastSquaresProblemTests(unittest.TestCase):
         """
         with ScratchDir("."):
             for solver in solvers:
-                #for grad in [True, False]:
-                r = Rosenbrock()
-                prob = LeastSquaresProblem(0, 1, depends_on=r)
-                solver(prob)  # , grad=grad)
-                self.assertAlmostEqual(prob.objective(), 0)
+                for save_residuals in [True, False]:
+                    #for grad in [True, False]:
+                    r = Rosenbrock()
+                    prob = LeastSquaresProblem(0, 1, depends_on=r)
+                    solver(prob, save_residuals=save_residuals)  # , grad=grad)
+                    self.assertAlmostEqual(prob.objective(), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When running optimizations for least-squares problems, the vector of residuals is saved at each iteration. For objectives like quasisymmetry with lots of residuals, this file can get quite large. So this PR makes the residuals file optional.