### PR TITLE
adding an assert statement

### DIFF
--- a/src/simsopt/geo/boozersurface.py
+++ b/src/simsopt/geo/boozersurface.py
@@ -85,8 +85,6 @@ class BoozerSurface(Optimizable):
         # set the default options now
         if 'verbose' not in options:
             options['verbose'] = True
-        if 'G' not in options:
-            options['G'] = None
         
         # default solver options for the BoozerExact and BoozerLS solvers
         if self.boozer_type == 'exact':
@@ -120,7 +118,7 @@ class BoozerSurface(Optimizable):
         Args:
             boozer_type: either 'exact' or 'ls', to indicate whether a BoozerExact or a BoozerLS surface is to be computed.
             iota: guess for value of rotational transform on the surface,
-            G: guess for value of G on surface, defaults to None.
+            G: guess for value of G on surface, defaults to None.  Note that if None is used, then the coil currents must be fixed.
             options: dictionary of solver options. If keyword is not specified, then a default 
                     value is used.  Possible keywords are:
                     `verbose`: display convergence information
@@ -134,6 +132,10 @@ class BoozerSurface(Optimizable):
         if not self.need_to_run_code:
             return
         
+        # for coil optimizations, the gradient calculations of the objective assume that the coil currents are fixed when G is None.
+        if G is None:
+            assert np.all([c.current.dofs.all_fixed() for c in self.biotsavart.coils])
+
         # BoozerExact default solver
         if self.boozer_type == 'exact':
             res = self.solve_residual_equation_exactly_newton(iota=iota, G=G, tol=self.options['newton_tol'], maxiter=self.options['newton_maxiter'], verbose=self.options['verbose'])

--- a/tests/geo/surface_test_helpers.py
+++ b/tests/geo/surface_test_helpers.py
@@ -90,6 +90,11 @@ def get_boozer_surface(label="Volume", nphi=None, ntheta=None, boozer_type='exac
     current_sum = sum(abs(c.current.get_value()) for c in coils)
     G0 = 2. * np.pi * current_sum * (4 * np.pi * 10**(-7) / (2 * np.pi)) if optimize_G else None
 
+    # currents need to be fixed if optimize_G is None
+    if optimize_G is False:
+        for c in bs.coils:
+            c.current.fix_all()
+
     ## RESOLUTION DETAILS OF SURFACE ON WHICH WE OPTIMIZE FOR QA
     mpol = 6 if boozer_type == 'exact' else 3
     ntor = 6 if boozer_type == 'exact' else 3

--- a/tests/geo/test_boozersurface.py
+++ b/tests/geo/test_boozersurface.py
@@ -378,6 +378,10 @@ class BoozerSurfaceTests(unittest.TestCase):
         # this second time should not actually run
         boozer_surface.run_code(boozer_surface.res['iota'], G=boozer_surface.res['G'])
         
+        # run the BoozerExact algorithm without a guess for G
+        boozer_surface.need_to_run_code = True
+        boozer_surface.solve_residual_equation_exactly_newton(iota=boozer_surface.res['iota'])
+        
     def test_convergence_cpp_and_notcpp_same(self):
         """
         This unit test verifies that that the cpp and not cpp implementations converge to 

--- a/tests/geo/test_boozersurface.py
+++ b/tests/geo/test_boozersurface.py
@@ -365,15 +365,18 @@ class BoozerSurfaceTests(unittest.TestCase):
         # this second time should not actually run
         boozer_surface.run_code(boozer_surface.res['iota'], G=boozer_surface.res['G'])
         
+        for c in bs.coils:
+            c.current.fix_all()
+
+        boozer_surface.need_to_run_code=True
+        # run without providing value of G
+        boozer_surface.run_code(boozer_surface.res['iota'])
+
         bs, boozer_surface = get_boozer_surface(boozer_type='exact')
         boozer_surface.run_code(boozer_surface.res['iota'], G=boozer_surface.res['G'])
         
         # this second time should not actually run
         boozer_surface.run_code(boozer_surface.res['iota'], G=boozer_surface.res['G'])
-       
-        boozer_surface.need_to_run_code=True
-        # run without providing value of G
-        boozer_surface.run_code(boozer_surface.res['iota'])
         
     def test_convergence_cpp_and_notcpp_same(self):
         """


### PR DESCRIPTION
The user has the option to optimize coils using the BoozerLS algorithm while fixing the constant `G` to its theoretical value in vacuum field, i.e., providing `G=None` to boozer_surface.run_code().  When computing the gradient of an objective function that depends on such a BoozerLS surface (with `G=None`), the gradient formulas assume that coil currents are fixed.  In order to avoid confusion, I have added an assert to prevent the algorithm from proceeding if the currents are unfixed, as the computed gradient would be incorrect.