### PR TITLE
clear spec cache to avoid sporadic mismatch

### DIFF
--- a/src/simsopt/mhd/spec.py
+++ b/src/simsopt/mhd/spec.py
@@ -141,7 +141,9 @@ class Spec(Optimizable):
                 filename = f"{filename}.sp"
             logger.info(f"Initializing a SPEC object from file: {filename}")
 
-        #If spec has run before, clear the f90wrap array caches.
+        # If spec has run before, clear the f90wrap array caches.
+        # See https://github.com/hiddenSymmetries/simsopt/pull/431
+        # This addresses the issue https://github.com/hiddenSymmetries/simsopt/issues/357
         if spec.allglobal._arrays:
             self._clear_f90wrap_array_caches()
 
@@ -722,7 +724,12 @@ class Spec(Optimizable):
 
     def _clear_f90wrap_array_caches(self):
         """
-        Clear the f90wrap array caches. This is necessary when a new file is read after SPEC has run before.
+        Clear the f90wrap array caches. This is necessary when a new file is
+        read after SPEC has run before.
+
+        See https://github.com/hiddenSymmetries/simsopt/pull/431
+
+        This function is for addressing the issue https://github.com/hiddenSymmetries/simsopt/issues/357
         """
         spec.allglobal._arrays = {}
         spec.inputlist._arrays = {}   

--- a/src/simsopt/mhd/spec.py
+++ b/src/simsopt/mhd/spec.py
@@ -141,6 +141,10 @@ class Spec(Optimizable):
                 filename = f"{filename}.sp"
             logger.info(f"Initializing a SPEC object from file: {filename}")
 
+        #If spec has run before, clear the f90wrap array caches.
+        if spec.allglobal._arrays:
+            self._clear_f90wrap_array_caches()
+
         if tolerance <= 0:
             raise ValueError(
                 'tolerance should be greater than zero'
@@ -716,6 +720,13 @@ class Spec(Optimizable):
             if p is not None:
                 p.phiedge = x[0]
 
+    def _clear_f90wrap_array_caches(self):
+        """
+        Clear the f90wrap array caches. This is necessary when a new file is read after SPEC has run before.
+        """
+        spec.allglobal._arrays = {}
+        spec.inputlist._arrays = {}   logger.debug("Done with init")
+
     def init(self, filename: str):
         """
         Initialize SPEC fortran state from an input file.
@@ -737,7 +748,6 @@ class Spec(Optimizable):
         spec.allglobal.broadcast_inputs()
         logger.debug('About to call preset')
         spec.preset()
-        logger.debug("Done with init")
 
     def run(self, update_guess: bool = True):
         """

--- a/src/simsopt/mhd/spec.py
+++ b/src/simsopt/mhd/spec.py
@@ -725,7 +725,7 @@ class Spec(Optimizable):
         Clear the f90wrap array caches. This is necessary when a new file is read after SPEC has run before.
         """
         spec.allglobal._arrays = {}
-        spec.inputlist._arrays = {}   logger.debug("Done with init")
+        spec.inputlist._arrays = {}   
 
     def init(self, filename: str):
         """
@@ -748,6 +748,7 @@ class Spec(Optimizable):
         spec.allglobal.broadcast_inputs()
         logger.debug('About to call preset')
         spec.preset()
+        logger.debug("Done with init")
 
     def run(self, update_guess: bool = True):
         """


### PR DESCRIPTION
Should fix the sporadic failure in the CI #357

The issue: f90wrap uses getter and setters to access the F90wrapped FORTRAN arrays, and the logic is as follows: 
```Python
handle = get_specific_array_handle(stuff)  #pointer to the array
if handle in self._arrays #dict with arrays and handles:
  return self._arrays[handle]
else:
  array = get_array_in_complicated_f90wrapway(stuff)
  self._arrays[handle]=array
  return array
```

Now for the race condition: If spec has run before, and the array has been accessed before (put in cache), and *by happenstance* the handle remains the same, python will return the cached array, and not access the FORTRAN memory. 

The handle is basically the pointer to the array, cast as an int. It is unlikely to be exactly the same EXCEPT when a conveniently shaped hole has just been emptied in memory by deallocation. 

This also explains why the fault is mostly seen in CI, as they have much smaller memories, and are more likely to write to the same location. But this is handled by the CPU and not reproducible. 
