### PR TITLE
Fix for python 3.8 and numpy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [build-system]
 requires = [
-  "scikit-build-core>=0.3.3",
+  "scikit-build-core",
   "pybind11",
-  "oldest-supported-numpy",
+  "numpy >= 2.0.0; python_version > '3.8'",
+  "oldest-supported-numpy; python_version <= '3.8'",
   "setuptools_scm>=8.0",
   'tomli; python_version < "3.11"',]
 build-backend = "scikit_build_core.build"


### PR DESCRIPTION
This PR adds python-version specific dependencies to address numpy compatibility with v1.x and v2.x.

There is one spec test failing in 3.8. Could that be due to numpy 2.0 and numpy 1.x differences?
@smiet, can you please invetigate?