### PR TITLE
[VMEC,SurfaceRZFourier] fix inconsistency regarding mpol

### DIFF
--- a/src/simsopt/mhd/vmec.py
+++ b/src/simsopt/mhd/vmec.py
@@ -344,9 +344,13 @@ class Vmec(Optimizable):
             # object, but the mpol/ntor values of either the vmec object
             # or the boundary surface object can be changed independently
             # by the user.
+            # `vi.mpol` comes from VMEC, but VMEC only uses `m=0, 1, ..., (mpol-1)`,
+            # but `SurfaceRZFourier` includes `m=mpol`, so we have to
+            # initialize `SurfaceRZFourier` with the highest poloidal mode
+            # that VMEC uses, which is `vi.mpol-1`.
             self._boundary = SurfaceRZFourier.from_nphi_ntheta(nfp=vi.nfp,
                                                                stellsym=not vi.lasym,
-                                                               mpol=vi.mpol,
+                                                               mpol=vi.mpol - 1,
                                                                ntor=vi.ntor,
                                                                ntheta=ntheta,
                                                                nphi=nphi,
@@ -354,7 +358,8 @@ class Vmec(Optimizable):
             self.free_boundary = bool(vi.lfreeb)
 
             # Transfer boundary shape data from fortran to the ParameterArray:
-            for m in range(vi.mpol + 1):
+            # The highest mode number relevant to VMEC in its input is `vi.mpol-1`.
+            for m in range(vi.mpol):
                 for n in range(-vi.ntor, vi.ntor + 1):
                     self._boundary.rc[m, n + vi.ntor] = vi.rbc[101 + n, m]
                     self._boundary.zs[m, n + vi.ntor] = vi.zbs[101 + n, m]
@@ -523,7 +528,9 @@ class Vmec(Optimizable):
         mpol_capped = np.min([boundary_RZFourier.mpol, 101])
         ntor_capped = np.min([boundary_RZFourier.ntor, 101])
         # Transfer boundary shape data from the surface object to VMEC:
-        for m in range(mpol_capped + 1):
+        # The highest mode number that VMEC can use is `m=100`
+        # if the max resolution is `mpol=101`.
+        for m in range(mpol_capped):
             for n in range(-ntor_capped, ntor_capped + 1):
                 vi.rbc[101 + n, m] = boundary_RZFourier.get_rc(m, n)
                 vi.zbs[101 + n, m] = boundary_RZFourier.get_zs(m, n)
@@ -756,7 +763,7 @@ class Vmec(Optimizable):
                     os.remove(filename)
                 except FileNotFoundError:
                     logger.debug(f"Tried to delete the file {filename} but it was not found")
-                    
+
             self.files_to_delete = []
 
             # Record the latest output file to delete if we run again:

--- a/tests/geo/test_surface_rzfourier.py
+++ b/tests/geo/test_surface_rzfourier.py
@@ -234,11 +234,13 @@ class SurfaceRZFourierTests(unittest.TestCase):
         filename2 = TEST_DIR / 'wout_li383_low_res_reference.nc'
         s1 = SurfaceRZFourier.from_vmec_input(filename1)
         s2 = SurfaceRZFourier.from_wout(filename2)
-        mpol = min(s1.mpol, s2.mpol)
-        ntor = min(s1.ntor, s2.ntor)
-        places = 13
+        self.assertEqual(s1.mpol, s2.mpol)
+        self.assertEqual(s1.ntor, s2.ntor)
         self.assertEqual(s1.nfp, s2.nfp)
         self.assertEqual(s1.stellsym, s2.stellsym)
+        mpol = s1.mpol
+        ntor = s1.ntor
+        places = 13
         for m in range(mpol + 1):
             nmin = 0 if m == 0 else -ntor
             for n in range(nmin, ntor + 1):
@@ -266,8 +268,10 @@ class SurfaceRZFourierTests(unittest.TestCase):
         # coordinate-independent properties like the volume and area.
         self.assertAlmostEqual(np.abs(s1.volume()), np.abs(s2.volume()), places=13)
         self.assertAlmostEqual(s1.area(), s2.area(), places=7)
-        mpol = min(s1.mpol, s2.mpol)
-        ntor = min(s1.ntor, s2.ntor)
+        self.assertEqual(s1.mpol, s2.mpol)
+        self.assertEqual(s1.ntor, s2.ntor)
+        mpol = s1.mpol
+        ntor = s1.ntor
         places = 13
         for m in range(mpol + 1):
             nmin = 0 if m == 0 else -ntor
@@ -290,11 +294,13 @@ class SurfaceRZFourierTests(unittest.TestCase):
         with ScratchDir("."):
             s1.write_nml(new_filename)
             s2 = SurfaceRZFourier.from_vmec_input(new_filename)
-        mpol = min(s1.mpol, s2.mpol)
-        ntor = min(s1.ntor, s2.ntor)
-        places = 13
         self.assertEqual(s1.nfp, s2.nfp)
         self.assertEqual(s1.stellsym, s2.stellsym)
+        self.assertEqual(s1.mpol, s2.mpol)
+        self.assertEqual(s1.ntor, s2.ntor)
+        mpol = s1.mpol
+        ntor = s1.ntor
+        places = 13
         for m in range(mpol + 1):
             nmin = 0 if m == 0 else -ntor
             for n in range(nmin, ntor + 1):
@@ -310,11 +316,13 @@ class SurfaceRZFourierTests(unittest.TestCase):
             with open(new_filename, 'w') as f:
                 f.write(nml_str)
             s2 = SurfaceRZFourier.from_vmec_input(new_filename)
-        mpol = min(s1.mpol, s2.mpol)
-        ntor = min(s1.ntor, s2.ntor)
-        places = 13
         self.assertEqual(s1.nfp, s2.nfp)
         self.assertEqual(s1.stellsym, s2.stellsym)
+        self.assertEqual(s1.mpol, s2.mpol)
+        self.assertEqual(s1.ntor, s2.ntor)
+        mpol = s1.mpol
+        ntor = s1.ntor
+        places = 13
         for m in range(mpol + 1):
             nmin = 0 if m == 0 else -ntor
             for n in range(nmin, ntor + 1):
@@ -743,10 +751,10 @@ class SurfaceRZFourierTests(unittest.TestCase):
 
         # Create the grid of quadpoints:
         phi2d, theta2d = np.meshgrid(2 * np.pi * s.quadpoints_phi,
-                                     2 * np.pi * s.quadpoints_theta, 
+                                     2 * np.pi * s.quadpoints_theta,
                                      indexing='ij')
 
-        # create a test field where only Fourier elements [m=2, n=3] 
+        # create a test field where only Fourier elements [m=2, n=3]
         # and [m=4,n=5] are nonzero:
         field = 0.8 * np.sin(2*theta2d - 3*s.nfp*phi2d) + 0.2*np.sin(4*theta2d - 5*s.nfp*phi2d)+ 0.7*np.cos(3*theta2d - 3*s.nfp*phi2d)
 

--- a/tests/mhd/test_vmec.py
+++ b/tests/mhd/test_vmec.py
@@ -230,8 +230,10 @@ class VmecTests(unittest.TestCase):
 
         def compare_surfaces_sym(s1, s2):
             logger.debug('compare_surfaces_sym called')
-            mpol = min(s1.mpol, s2.mpol)
-            ntor = min(s1.ntor, s2.ntor)
+            self.assertEqual(s1.mpol, s2.mpol)
+            self.assertEqual(s1.ntor, s2.ntor)
+            mpol = s1.mpol
+            ntor = s1.ntor
             places = 13
             for m in range(mpol + 1):
                 nmin = 0 if m == 0 else -ntor
@@ -243,8 +245,10 @@ class VmecTests(unittest.TestCase):
             logger.debug('compare_surfaces_asym called')
             self.assertAlmostEqual(np.abs(s1.volume()), np.abs(s2.volume()), places=13)
             self.assertAlmostEqual(s1.area(), s2.area(), places=7)
-            mpol = min(s1.mpol, s2.mpol)
-            ntor = min(s1.ntor, s2.ntor)
+            self.assertEqual(s1.mpol, s2.mpol)
+            self.assertEqual(s1.ntor, s2.ntor)
+            mpol = s1.mpol
+            ntor = s1.ntor
             for m in range(mpol + 1):
                 nmin = 0 if m == 0 else -ntor
                 for n in range(nmin, ntor + 1):


### PR DESCRIPTION
VMEC only ever uses poloidal modes up to `m=mpol-1` with `mpol` being specified in the VMEC input. `SurfaceRZFourier` calls their poloidal Fourier resolution also `mpol`, but includes poloidal modes including up to `m=mpol`. This leads to inconsistencies when converting between VMEC input/output files and `SurfaceRZFourier`. This PR addresses this inconsistency.