### PR TITLE
Enable open upper limits for the grids in interpolation code

### DIFF
--- a/src/simsopt/field/magneticfieldclasses.py
+++ b/src/simsopt/field/magneticfieldclasses.py
@@ -862,10 +862,14 @@ class InterpolatedField(sopp.InterpolatedField, MagneticField):
         Args:
             field: the underlying :mod:`simsopt.field.magneticfield.MagneticField` to be interpolated.
             degree: the degree of the piecewise polynomial interpolant.
-            rrange: a 3-tuple of the form ``(rmin, rmax, nr)``. This mean that the interval :math:`[rmin, rmax]` is
-                    split into ``nr`` many subintervals.
-            phirange: a 3-tuple of the form ``(phimin, phimax, nphi)``.
-            zrange: a 3-tuple of the form ``(zmin, zmax, nz)``.
+            rrange: a 3-tuple of the form ``(rmin, rmax, nr)`` or a 4-tuple of the form ``(rmin, rmax, nr, include_endpoint)``.
+            The default for `include_endpoint` is True. This mean that the interval :math:`[rmin, rmax]` is
+            split into ``nr`` many subintervals. When `include_endpoint` is False, interval :math:`[rmin, rmax)` is
+            split into ``nr`` many subintervals.
+            phirange: a 3-tuple of the form ``(phimin, phimax, nphi)`` or a 4-tuple of the form
+            ``(phimin, phimax, nphi, include_endpoint)``.
+            zrange: a 3-tuple of the form ``(zmin, zmax, nz)`` or a 4-tuple of the form
+            ``(zmin, zmax, nz, include_endpoint)``.
             extrapolate: whether to extrapolate the field when evaluate outside
                          the integration domain or to throw an error.
             nfp: Whether to exploit rotational symmetry. In this case any angle
@@ -900,7 +904,7 @@ class InterpolatedField(sopp.InterpolatedField, MagneticField):
                 return [False for _ in xs]
 
         sopp.InterpolatedField.__init__(self, field, degree, rrange, phirange, zrange, extrapolate, nfp, stellsym, skip)
-        self.__field = field
+        self._field = field
 
     def to_vtk(self, filename):
         """Export the field evaluated on a regular grid for visualisation with e.g. Paraview."""

--- a/src/simsoptpp/magneticfield_interpolated.h
+++ b/src/simsoptpp/magneticfield_interpolated.h
@@ -138,7 +138,8 @@ class InterpolatedField : public MagneticField<T> {
 
     public:
         const shared_ptr<MagneticField<T>> field;
-        const RangeTriplet r_range, phi_range, z_range;
+        // const RangeTriplet r_range, phi_range, z_range;
+        const RangeParams r_range, phi_range, z_range;
         using MagneticField<T>::npoints;
         const InterpolationRule rule;
 
@@ -146,9 +147,18 @@ class InterpolatedField : public MagneticField<T> {
                 shared_ptr<MagneticField<T>> field, InterpolationRule rule,
                 RangeTriplet r_range, RangeTriplet phi_range, RangeTriplet z_range,
                 bool extrapolate, int nfp, bool stellsym, std::function<std::vector<bool>(Vec, Vec, Vec)> skip) :
+                InterpolatedField(field, rule,
+                                  std::make_tuple(std::get<0>(r_range), std::get<1>(r_range), std::get<2>(r_range), true),
+                                  std::make_tuple(std::get<0>(phi_range), std::get<1>(phi_range), std::get<2>(phi_range), true),
+                                  std::make_tuple(std::get<0>(z_range), std::get<1>(z_range), std::get<2>(z_range), true),
+                                  extrapolate, nfp, stellsym, skip) {}
+
+        InterpolatedField(
+                shared_ptr<MagneticField<T>> field, InterpolationRule rule,
+                RangeParams r_range, RangeParams phi_range, RangeParams z_range,
+                bool extrapolate, int nfp, bool stellsym, std::function<std::vector<bool>(Vec, Vec, Vec)> skip) :
             field(field), rule(rule), r_range(r_range), phi_range(phi_range), z_range(z_range), extrapolate(extrapolate), nfp(nfp), stellsym(stellsym),
             skip(skip)
-             
         {
             fbatch_B = [this](Vec r, Vec phi, Vec z) {
                 int npoints = r.size();
@@ -184,6 +194,16 @@ class InterpolatedField : public MagneticField<T> {
         InterpolatedField(
                 shared_ptr<MagneticField<T>> field, int degree,
                 RangeTriplet r_range, RangeTriplet phi_range, RangeTriplet z_range,
+                bool extrapolate, int nfp, bool stellsym, std::function<std::vector<bool>(Vec, Vec, Vec)> skip) :
+                InterpolatedField(field, UniformInterpolationRule(degree),
+                                  std::make_tuple(std::get<0>(r_range), std::get<1>(r_range), std::get<2>(r_range), true),
+                                  std::make_tuple(std::get<0>(phi_range), std::get<1>(phi_range), std::get<2>(phi_range), true),
+                                  std::make_tuple(std::get<0>(z_range), std::get<1>(z_range), std::get<2>(z_range), true),
+                                  extrapolate, nfp, stellsym, skip) {}
+
+        InterpolatedField(
+                shared_ptr<MagneticField<T>> field, int degree,
+                RangeParams r_range, RangeParams phi_range, RangeParams z_range,
                 bool extrapolate, int nfp, bool stellsym, std::function<std::vector<bool>(Vec, Vec, Vec)> skip) : InterpolatedField(field, UniformInterpolationRule(degree), r_range, phi_range, z_range, extrapolate, nfp, stellsym, skip) {}
 
         std::pair<double, double> estimate_error_B(int samples) {

--- a/src/simsoptpp/python_magneticfield.cpp
+++ b/src/simsoptpp/python_magneticfield.cpp
@@ -109,6 +109,8 @@ void init_magneticfields(py::module_ &m){
     auto ifield = py::class_<PyInterpolatedField, shared_ptr<PyInterpolatedField>, PyMagneticField>(m, "InterpolatedField")
         .def(py::init<shared_ptr<PyMagneticField>, InterpolationRule, RangeTriplet, RangeTriplet, RangeTriplet, bool, int, bool, std::function<std::vector<bool>(Vec, Vec, Vec)>>())
         .def(py::init<shared_ptr<PyMagneticField>, int, RangeTriplet, RangeTriplet, RangeTriplet, bool, int, bool, std::function<std::vector<bool>(Vec, Vec, Vec)>>())
+        .def(py::init<shared_ptr<PyMagneticField>, InterpolationRule, RangeParams, RangeParams, RangeParams, bool, int, bool, std::function<std::vector<bool>(Vec, Vec, Vec)>>())
+        .def(py::init<shared_ptr<PyMagneticField>, int, RangeParams, RangeParams, RangeParams, bool, int, bool, std::function<std::vector<bool>(Vec, Vec, Vec)>>())
         .def("estimate_error_B", &PyInterpolatedField::estimate_error_B)
         .def("estimate_error_GradAbsB", &PyInterpolatedField::estimate_error_GradAbsB)
         .def_readonly("r_range", &PyInterpolatedField::r_range)

--- a/src/simsoptpp/regular_grid_interpolant_3d.h
+++ b/src/simsoptpp/regular_grid_interpolant_3d.h
@@ -171,11 +171,11 @@ class RegularGridInterpolant3D {
             pkzs = Vec(degree+1, 0.);
 
             // build a regular mesh on [xmin, xmax] x [ymin, ymax] x [zmin, zmax]
-            Vec xmesh(nx+1, 0);
+            xmesh.reserve(nx+1);
             hx = linspace(xmin, xmax, nx+1, x_endpoint, xmesh);
-            Vec ymesh(ny+1, 0);
+            ymesh.reserve(ny+1);
             hy = linspace(ymin, ymax, ny+1, y_endpoint, ymesh);
-            Vec zmesh(nz+1, 0);
+            zmesh.reserve(nz+1);
             hz = linspace(zmin, zmax, nz+1, z_endpoint, zmesh);
 
             int nmesh = (nx+1)*(ny+1)*(nz+1);

--- a/src/simsoptpp/regular_grid_interpolant_3d.h
+++ b/src/simsoptpp/regular_grid_interpolant_3d.h
@@ -172,10 +172,11 @@ class RegularGridInterpolant3D {
 
             // build a regular mesh on [xmin, xmax] x [ymin, ymax] x [zmin, zmax]
             xmesh.reserve(nx+1);
-            hx = linspace(xmin, xmax, nx+1, x_endpoint, xmesh);
             ymesh.reserve(ny+1);
+	    zmesh.reserve(nz+1);
+	
+	    hx = linspace(xmin, xmax, nx+1, x_endpoint, xmesh);
             hy = linspace(ymin, ymax, ny+1, y_endpoint, ymesh);
-            zmesh.reserve(nz+1);
             hz = linspace(zmin, zmax, nz+1, z_endpoint, zmesh);
 
             int nmesh = (nx+1)*(ny+1)*(nz+1);

--- a/src/simsoptpp/regular_grid_interpolant_3d_impl.h
+++ b/src/simsoptpp/regular_grid_interpolant_3d_impl.h
@@ -237,16 +237,16 @@ std::pair<double, double> RegularGridInterpolant3D<Array>::estimate_error(std::f
 
 
 
-Vec linspace(double min, double max, int n, bool endpoint) {
-    Vec res(n, 0.);
+double linspace(double min, double max, int n, bool endpoint, Vec& res) {
+    double h;
     if(endpoint) {
-        double h = (max-min)/(n-1);
+        h = (max-min)/(n-1);
         for (int i = 0; i < n; ++i)
             res[i] = min + i*h;
     } else {
-        double h = (max-min)/n;
+        h = (max-min)/n;
         for (int i = 0; i < n; ++i)
             res[i] = min + i*h;
     }
-    return res;
+    return h;
 }


### PR DESCRIPTION
This PR enables open endpoints for the upper limits of the meshes when doing interpolation. The main reason to enable this functionality is to allow for [0, phi_max) generated by BMW mesh.