### PR TITLE
np.NINF to -np.inf for np2.0 compatibility

### DIFF
--- a/src/simsopt/_core/optimizable.py
+++ b/src/simsopt/_core/optimizable.py
@@ -87,7 +87,7 @@ class DOFs(GSONable, Hashable):
             free: Array of boolean values denoting if the DOFs is are free.
                   False values implies the corresponding DOFs are fixed
             lower_bounds: Lower bounds for the DOFs. Meaningful only if
-                DOF is not fixed. Default is np.NINF
+                DOF is not fixed. Default is -np.inf
             upper_bounds: Upper bounds for the DOFs. Meaningful only if
                 DOF is not fixed. Default is np.inf
         """
@@ -106,7 +106,7 @@ class DOFs(GSONable, Hashable):
             free = np.asarray(free, dtype=np.bool_)
 
         if lower_bounds is None:
-            lower_bounds = np.full(len(x), np.NINF)
+            lower_bounds = np.full(len(x), -np.inf)
         else:
             lower_bounds = np.asarray(lower_bounds, np.double)
 

--- a/tests/core/test_dofs.py
+++ b/tests/core/test_dofs.py
@@ -168,7 +168,7 @@ class DOFsTests(unittest.TestCase):
                     names=np.array(['x', 'y', 'z']),
                     free=np.array([True, True, False]))
         self.assertTrue(np.allclose(dofs.free_lower_bounds,
-                                    np.array([np.NINF, np.NINF])))
+                                    np.array([-np.inf, -np.inf])))
 
         with self.assertRaises(DofLengthMismatchError):
             dofs.free_lower_bounds = np.array([-1000.0, -1001.0, -1002.0])
@@ -180,7 +180,7 @@ class DOFsTests(unittest.TestCase):
 
         dofs.unfix_all()
         self.assertTrue(np.allclose(dofs.free_lower_bounds,
-                                    np.array([-1000.0, -1001.0, np.NINF])))
+                                    np.array([-1000.0, -1001.0, -np.inf])))
 
         dofs.free_lower_bounds = np.array([-1000.0, -1001.0, -1002.])
         self.assertTrue(np.allclose(dofs.free_lower_bounds,


### PR DESCRIPTION
NINF was deprecated and should be replaced with -np.inf