### PR TITLE
(Minor Fix) two broken examples in docs

### DIFF
--- a/docs/source/example_islands.rst
+++ b/docs/source/example_islands.rst
@@ -109,10 +109,10 @@ We now combine the four residues into a least-squares objective
 function, by summing the squares of the residues::
 
   # Objective function is \sum_j residue_j ** 2
-  prob = LeastSquaresProblem.from_tuples([(residue1, 0, 1),
-                                          (residue2, 0, 1),
-                                          (residue3, 0, 1),
-                                          (residue4, 0, 1)])
+  prob = LeastSquaresProblem.from_tuples([(residue1.J, 0, 1),
+                                          (residue2.J, 0, 1),
+                                          (residue3.J, 0, 1),
+                                          (residue4.J, 0, 1)])
 
 If you wanted an island to be present instead of absent, which might
 be the case when designing an island divertor, a value other than zero

--- a/docs/source/example_quasisymmetry.rst
+++ b/docs/source/example_quasisymmetry.rst
@@ -387,7 +387,7 @@ at the edge and magnetic axis, in order to prescribe the magnetic shear::
   prob = LeastSquaresProblem.from_tuples([(vmec.aspect, 6, 1),
                                           (vmec.iota_axis, 0.465, 1),
                                           (vmec.iota_edge, 0.495, 1),
-                                          (qs.J, 0, 1)])
+                                          (qs.residuals, 0, 1)])
 
 It can be seen here that we are seeking a configuration with aspect
 ratio 6, and iota slightly below 0.5.

--- a/docs/source/example_quasisymmetry.rst
+++ b/docs/source/example_quasisymmetry.rst
@@ -268,7 +268,7 @@ axisymmetric::
   # Define objective function
   prob = LeastSquaresProblem.from_tuples([(vmec.aspect, 6, 1),
                                           (vmec.mean_iota, 0.42, 1),
-                                          (qs, 0, 1)])
+                                          (qs.J, 0, 1)])
 
 It can be seen here that we are seeking a configuration with aspect
 ratio 6, and average iota of 0.42, slightly above the resonance at 2 /
@@ -387,7 +387,7 @@ at the edge and magnetic axis, in order to prescribe the magnetic shear::
   prob = LeastSquaresProblem.from_tuples([(vmec.aspect, 6, 1),
                                           (vmec.iota_axis, 0.465, 1),
                                           (vmec.iota_edge, 0.495, 1),
-                                          (qs, 0, 1)])
+                                          (qs.J, 0, 1)])
 
 It can be seen here that we are seeking a configuration with aspect
 ratio 6, and iota slightly below 0.5.

--- a/docs/source/example_quasisymmetry.rst
+++ b/docs/source/example_quasisymmetry.rst
@@ -268,7 +268,7 @@ axisymmetric::
   # Define objective function
   prob = LeastSquaresProblem.from_tuples([(vmec.aspect, 6, 1),
                                           (vmec.mean_iota, 0.42, 1),
-                                          (qs.J, 0, 1)])
+                                          (qs.residuals, 0, 1)])
 
 It can be seen here that we are seeking a configuration with aspect
 ratio 6, and average iota of 0.42, slightly above the resonance at 2 /


### PR DESCRIPTION
Two examples in the documentation folder weren't working with the current simsopt version, because a `.J` was missing 