### PR TITLE
Respect prob.bounds in all solver wrappers

### DIFF
--- a/src/simsopt/solve/mpi.py
+++ b/src/simsopt/solve/mpi.py
@@ -200,6 +200,12 @@ def least_squares_mpi_solve(prob: LeastSquaresProblem,
         logger.debug(f"residuals are {residuals}")
         return residuals
 
+    if "bounds" in kwargs:
+        import warnings
+        warnings.warn("The bounds argument has been deprecated and is being ignored, \
+                      please use prob.bounds instead.", DeprecationWarning, 2)
+        kwargs.pop("bounds", None)
+
     # For MPI finite difference gradient, get the worker and leader action from
     # MPIFiniteDifference
     if grad:
@@ -211,10 +217,10 @@ def least_squares_mpi_solve(prob: LeastSquaresProblem,
                 logger.info("Using finite difference method implemented in "
                             "SIMSOPT for evaluating gradient")
                 try:
-                    result = least_squares(_f_proc0, x0, jac=fd.jac, verbose=2,
-                                           **kwargs)
+                    result = least_squares(_f_proc0, x0, bounds=prob.bounds, 
+                                           jac=fd.jac, verbose=2, **kwargs)
                 except:
-                    print("Failure on proc0_world")
+                    logger.error("Failure on proc0_world")
                     result = Struct()
                     result.x = x0
 
@@ -228,7 +234,8 @@ def least_squares_mpi_solve(prob: LeastSquaresProblem,
             # proc0_world does this block, running the optimization.
             x0 = np.copy(prob.x)
             logger.info("Using derivative-free method")
-            result = least_squares(_f_proc0, x0, verbose=2, **kwargs)
+            result = least_squares(_f_proc0, x0, bounds=prob.bounds,
+                                   verbose=2, **kwargs)
 
         # Stop loops for workers and group leaders:
         mpi.together()

--- a/src/simsopt/solve/serial.py
+++ b/src/simsopt/solve/serial.py
@@ -141,22 +141,30 @@ def least_squares_serial_solve(prob: LeastSquaresProblem,
         nevals += 1
         return residuals
 
+    if "bounds" in kwargs:
+        import warnings
+        warnings.warn("The bounds argument has been deprecated and is being ignored, \
+                      please use prob.bounds instead.", DeprecationWarning, 2)
+        kwargs.pop("bounds", None)
+
     logger.info("Beginning solve.")
     #if grad is None:
     #    grad = prob.dofs.grad_avail
 
     #if not 'verbose' in kwargs:
 
-    print('prob is ', prob)
+    logger.info('prob is {}'.format(prob))
     x0 = np.copy(prob.x)
     if grad:
         fd = FiniteDifference(prob.residuals, abs_step=abs_step,
                               rel_step=rel_step, diff_method=diff_method)
         logger.info("Using derivatives")
-        result = least_squares(objective, x0, verbose=2, jac=fd.jac, **kwargs)
+        result = least_squares(objective, x0, bounds=prob.bounds, 
+                               verbose=2, jac=fd.jac, **kwargs)
     else:
         logger.info("Using derivative-free method")
-        result = least_squares(objective, x0, verbose=2, **kwargs)
+        result = least_squares(objective, x0,bounds=prob.bounds, 
+                               verbose=2, **kwargs)
 
     datalogging_started = False
     objective_file.close()
@@ -248,6 +256,14 @@ def serial_solve(prob: Union[Optimizable, Callable],
         #    grad = prob.dofs.grad_avail
 
         #if not 'verbose' in kwargs:
+
+        if "bounds" in kwargs:
+            import warnings
+            warnings.warn("The bounds argument has been deprecated and is being ignored, \
+                        please use prob.bounds instead.", DeprecationWarning, 2)
+        # Only specify the bounds argument if they are finite
+        if np.isfinite(prob.lower_bounds).any() or np.isfinite(prob.upper_bounds).any():
+            kwargs['bounds'] = prob.bounds
 
         logger.info("Beginning solve.")
         x0 = np.copy(prob.x)


### PR DESCRIPTION
Only the constrained_solve overloads respected the problem bounds, the least_squares_solve overloads ignored them, unless passed with `bounds=prob.bounds` explicitly. This is unintuitive, since these functions are specifically overloads for `LeastSquaresProblem`, so I would expect it to use all the properties set on the object.

I suggest harmonizing the usage of `constrained_solve` and `least_squares_solve` to in both cases respect `prob.bounds` (as implemented in this PR), or at the very least raising a warning message to users, if `prob.bounds` were set, despite being ignored (I will adjust the PR if required). 