### PR TITLE
SurfaceRZFourier cache isn't invalidated by setting rc, zs, rs, zc arrays

### DIFF
--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -548,6 +548,67 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
             raise IndexError('n must be <= ntor')
         if n < -self.ntor:
             raise IndexError('n must be >= -ntor')
+    
+    @property
+    def rc_array(self):
+        return self.rc
+    
+    @property
+    def zs_array(self):
+        return self.zs
+    
+    @property
+    def zc_array(self):
+        if self.stellsym:
+            raise ValueError(
+                'zc does not exist for this stellarator-symmetric surface.')
+        return self.zc
+    
+    @property
+    def rs_array(self):
+        if self.stellsym:
+            raise ValueError(
+                'rs does not exist for this stellarator-symmetric surface.')
+        return self.rs
+    
+    @rc_array.setter
+    def rc_array(self, rc):
+        print(self.rc.shape, rc.shape)
+        if rc.shape != (self.mpol + 1, self.ntor * 2 + 1):
+            raise ValueError('rc must have shape (mpol+1, 2*ntor+1)')
+        self.rc = rc
+        self.recompute_bell()
+        self.local_full_x = self.get_dofs()
+
+    @zs_array.setter
+    def zs_array(self, zs):
+        if zs.shape != (self.mpol + 1, self.ntor * 2 + 1):
+            raise ValueError('zs must have shape (mpol+1, 2*ntor+1)')
+        self.zs = zs
+        self.recompute_bell()
+        self.local_full_x = self.get_dofs()
+
+    @rs_array.setter
+    def rs_array(self, rs):
+        if rs.shape != (self.mpol + 1, self.ntor * 2 + 1):
+            raise ValueError('rs must have shape (mpol+1, 2*ntor+1)')
+        if self.stellsym:
+            raise ValueError(
+                'rs does not exist for this stellarator-symmetric surface.')
+        self.rs = rs
+        self.recompute_bell()
+        self.local_full_x = self.get_dofs()
+
+    @zc_array.setter
+    def zc_array(self, zc):
+        if zc.shape != (self.mpol + 1, self.ntor * 2 + 1):
+            raise ValueError('zc must have shape (mpol+1, 2*ntor+1)')
+        if self.stellsym:
+            raise ValueError(
+                'zc does not exist for this stellarator-symmetric surface.')
+        self.zc = zc
+        self.recompute_bell()
+        self.local_full_x = self.get_dofs()
 
     def get_rc(self, m, n):
         """


### PR DESCRIPTION
There are not setter properties for the variables `rc`, `zs`, `rs`, `zc`, so `recompute_bell()` is not triggered by overwriting them. 

For example, this means that plots, or depending objective functions aren't updated when overwriting the entire rc array, e.g. to scale a configuration by a constant factor. The following example script will plot the same torus twice, eventho the coefficients were changed (same problem with ). 
```python
from simsopt import geo
import matplotlib.pyplot as plt
s = geo.SurfaceRZFourier(3, True, 5, 8)
s.make_rotating_ellipse(1, .2, .5, .1)
s.plot()
plt.show()
scaling = 10
s.rc = s.rc * scaling # This doesn't invalidate the cache
s.zc *= scaling         # or equivalently
s.plot()
plt.show()
```
can now be done with
```python
from simsopt import geo
import matplotlib.pyplot as plt
s = geo.SurfaceRZFourier(3, True, 5, 8)
s.make_rotating_ellipse(1, .2, .5, .1)
s.plot()
plt.show()
scaling = 10
s.rc_array = s.rc * scaling
s.zc_array *= scaling
s.plot()
plt.show()
```

My suggestion is to either
- Add array setter properties to the fourier components of the surface (this PR)
- Refactor SurfaceRZFourier to have private `_rc` and property decorators for the accessors `rc`, but that would also involve changing the CPP class and seems quite invasive 
- Add a short warning to the `set_zs()` docstring:
`"""Modifyting the `zs` array directly is discouraged, since it doesn't trigger the recompute_bell(). """`
