### PR TITLE
Fix relax_and_split kwargs dict passing

### DIFF
--- a/src/simsopt/solve/permanent_magnet_optimization.py
+++ b/src/simsopt/solve/permanent_magnet_optimization.py
@@ -200,9 +200,10 @@ def relax_and_split(pm_opt, m0=None, **kwargs):
 
     # set the nonconvex step in the algorithm
     reg_rs = 0.0
-    nu = kwargs.pop("nu", 1e100)
-    reg_l0 = kwargs.pop("reg_l0", 0.0)
-    reg_l1 = kwargs.pop("reg_l1", 0.0)
+    nu = kwargs.get("nu", 1e100)
+    reg_l0 = kwargs.get("reg_l0", 0.0)
+    reg_l1 = kwargs.get("reg_l1", 0.0)
+
     max_iter_RS = kwargs.pop('max_iter_RS', 1)
     epsilon_RS = kwargs.pop('epsilon_RS', 1e-3)
 


### PR DESCRIPTION
I noticed that the `relax_and_split()` method in the permanent magnet optimization tools was `.pop()'-ing keys such as `nu` and the regularization terms out of `kwargs`, even though these should actually be passed to the convex MwPGP algorithm in the code block:
```
algorithm_history, _, _, m = convex_step(
    A_obj=pm_opt.A_obj,
    b_obj=pm_opt.b_obj,
    ATb=ATb,
    m_proxy=np.ascontiguousarray(m_proxy.reshape(pm_opt.ndipoles, 3)),
    m0=np.ascontiguousarray(m.reshape(pm_opt.ndipoles, 3)),  # note updated m is new guess
    m_maxima=mmax,
    **kwargs
)
```
 This causes a bug where if you optimize with `relax_and_split()`, the default value of nu = 1e100 is used since this key has been removed from the kwargs dict when it is passed on to the convex MwPGP method. This pull request changes it to a `get()` method for the relevant keys instead.