### PR TITLE
Fix CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,6 @@ target_include_directories(profiling PRIVATE  "thirdparty/xtensor/include" "thir
 target_link_libraries(profiling PRIVATE fmt::fmt-header-only)
 
 
-
 #get_cmake_property(_variableNames VARIABLES)
 #list (SORT _variableNames)
 #foreach (_variableName ${_variableNames})


### PR DESCRIPTION
The CI appears to be broken. For the extensive tests with python 3.10 and 3.11 but not 3.9, there is a failure early on when pyoculus is installed.

This PR doesn't yet have a fix, just documenting that the problem occurs even for the master branch.