### PR TITLE
Fix wheel workflow

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,5 +1,7 @@
 name: Wheel Builder
 
+# This file is based on https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml
+
 on: [push, pull_request]
 
 jobs:
@@ -8,70 +10,59 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, ubuntu-24.04]
+        # macos-13 is an intel runner, macos-14 is apple silicon
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch all history for all tags
-        run: git fetch --prune --unshallow
-
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v2.22.0
         # To supply options, put them in 'env'
-        env:
-          # Only build for python 3.{9,10,11,12}
-          CIBW_BUILD : cp39-* cp310-* cp311-* cp312-*
-          # Supports only x86_64 arch for linux
-          CIBW_ARCHS_LINUX: x86_64
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
-          CIBW_SKIP: cp27-* cp36-* cp37-* cp38-*
-          CIBW_DEPENDENCY_VERSIONS: latest
+        # env:
+        #   # Only build for python 3.{9,10,11,12}
+        #   CIBW_BUILD : cp39-* cp310-* cp311-* cp312-*
+        #   # Supports only x86_64 arch for linux
+        #   CIBW_ARCHS_LINUX: x86_64
+        #   CIBW_ARCHS_MACOS: "x86_64 arm64"
+        #   CIBW_SKIP: cp27-* cp36-* cp37-* cp38-*
+        #   CIBW_DEPENDENCY_VERSIONS: latest
 
       - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch all history for all tags
-        run: git fetch --prune --unshallow
-
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.9'
-
-      - name: Download all submodules
-        run: git submodule update --init
-        
-      - name: Install setuptools_scm
-        run: python -m pip install setuptools_scm build
-
       - name: Build sdist
-        run: python -m build -s -o dist .
-        
+        run: pipx run build --sdist
+
       - uses: actions/upload-artifact@v4
         with:
+          name: cibw-sdist
           path: dist/*.tar.gz
 
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    # upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    environment: pypi
+    permissions:
+      id-token: write
     # if: github.event_name == 'release' && github.event.action == 'published'
+    # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
           path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -26,7 +26,8 @@ jobs:
           #   # Supports only x86_64 arch for linux
           #   CIBW_ARCHS_LINUX: x86_64
           #   CIBW_ARCHS_MACOS: "x86_64 arm64"
-          CIBW_SKIP: cp38-*
+          # Skip PyPy builds:
+          CIBW_SKIP: cp38-* pp*
           #   CIBW_DEPENDENCY_VERSIONS: latest
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -9,9 +9,10 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, ubuntu-20.04]
+        os: [macos-13, ubuntu-24.04]
 
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
           CIBW_SKIP: cp27-* cp36-* cp37-* cp38-*
           CIBW_DEPENDENCY_VERSIONS: latest
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -56,7 +56,7 @@ jobs:
       - name: Build sdist
         run: python -m build -s -o dist .
         
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -68,7 +68,7 @@ jobs:
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -26,7 +26,8 @@ jobs:
           #   # Supports only x86_64 arch for linux
           #   CIBW_ARCHS_LINUX: x86_64
           #   CIBW_ARCHS_MACOS: "x86_64 arm64"
-          # Skip PyPy builds:
+          #   # Skip python 3.8 and PyPy builds since there is are errors when building the
+          #   # wheel in those cases:
           CIBW_SKIP: cp38-* pp*
           #   CIBW_DEPENDENCY_VERSIONS: latest
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -19,14 +19,14 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0
         # To supply options, put them in 'env'
-        # env:
-        #   # Only build for python 3.{9,10,11,12}
-        #   CIBW_BUILD : cp39-* cp310-* cp311-* cp312-*
-        #   # Supports only x86_64 arch for linux
-        #   CIBW_ARCHS_LINUX: x86_64
-        #   CIBW_ARCHS_MACOS: "x86_64 arm64"
-        #   CIBW_SKIP: cp27-* cp36-* cp37-* cp38-*
-        #   CIBW_DEPENDENCY_VERSIONS: latest
+        env:
+          # Only build for python 3.{9,10,11,12}
+          # CIBW_BUILD : cp39-* cp310-* cp311-* cp312-*
+          #   # Supports only x86_64 arch for linux
+          #   CIBW_ARCHS_LINUX: x86_64
+          #   CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_SKIP: cp38-*
+          #   CIBW_DEPENDENCY_VERSIONS: latest
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The wheel workflow recently [stopped working](https://github.com/hiddenSymmetries/simsopt/actions/runs/13074530769). With this PR it is working again. I've mainly followed [this example from cibuildwheel](https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml). 

The workflow takes longer to run now because wheels are built for more platforms now, in particular `musllinux` and linux `i686` (in addition to `manylinux` and `x86_64`).  This is done by default in the cibuildwheel example workflow that I copied, and the wheels were built without error, so I kept these platforms. We could potentially remove these cases if nobody would use them and the longer workflow runtime is a problem.