### PR TITLE
Unused pybind11 module removed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "thirdparty/xtl"]
 	path = thirdparty/xtl
 	url = https://github.com/xtensor-stack/xtl.git
-[submodule "thirdparty/pybind11"]
-	path = thirdparty/pybind11
-	url = https://github.com/pybind/pybind11.git
 [submodule "thirdparty/xsimd"]
 	path = thirdparty/xsimd
 	url = https://github.com/xtensor-stack/xsimd.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,6 @@ else()
     message(STATUS "Boost include dirs are ${Boost_INCLUDE_DIRS}")
 endif()
 
-# add_subdirectory(thirdparty/pybind11)
 add_subdirectory(thirdparty/fmt EXCLUDE_FROM_ALL)
 set(XTENSOR_USE_OPENMP 0)
 set(XTENSOR_USE_TBB 0)

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -3,9 +3,20 @@
 FROM --platform=linux/amd64 ubuntu:22.04 as intermediate
 
 RUN apt update && \
-    DEBIAN_FRONTEND=noninteractive  apt-get install -y  build-essential gfortran git m4 wget cmake ninja-build \
+    DEBIAN_FRONTEND=noninteractive  apt-get install -y  build-essential gfortran git m4 wget \
     libopenblas-dev libfftw3-dev libhdf5-dev libhdf5-serial-dev libnetcdf-dev libnetcdff-dev libgl1-mesa-dev \
     python3-dev python3-pip python3-venv libxrender1
+
+
+RUN python3 -m pip install wheel
+RUN python3 -m venv /venv/
+
+RUN /venv/bin/pip install -U pip
+# 2024-11-12 MJL: mpi4py < 4.0 in the next line is due to
+# https://github.com/hiddenSymmetries/simsopt/issues/455
+# Once NERSC gets Shifter working with mpi4py >= 4 we can remove this inequality
+RUN /venv/bin/python -m pip install numpy scipy jax jaxlib f90nml "mpi4py<4.0" jupyter notebook ipython qsc sympy scikit-build ninja "pybind11[global]" cmake f90wrap h5py
+ENV PATH="/venv/bin:${PATH}"
 
 # Install mpich manually
 WORKDIR /src
@@ -36,15 +47,6 @@ RUN \
      
 RUN /sbin/ldconfig
 
-RUN python3 -m pip install wheel
-RUN python3 -m venv /venv/
-
-RUN /venv/bin/pip install -U pip
-# 2024-11-12 MJL: mpi4py < 4.0 in the next line is due to
-# https://github.com/hiddenSymmetries/simsopt/issues/455
-# Once NERSC gets Shifter working with mpi4py >= 4 we can remove this inequality
-RUN /venv/bin/python -m pip install numpy scipy jax jaxlib f90nml "mpi4py<4.0" jupyter notebook ipython qsc sympy scikit-build ninja "pybind11[global]" cmake f90wrap h5py
-ENV PATH="/venv/bin:${PATH}"
 
 RUN git clone --depth 1 https://github.com/PrincetonUniversity/SPEC.git /src/SPEC && \
     cd /src/SPEC   &&  \

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -7,17 +7,6 @@ RUN apt update && \
     libopenblas-dev libfftw3-dev libhdf5-dev libhdf5-serial-dev libnetcdf-dev libnetcdff-dev libgl1-mesa-dev \
     python3-dev python3-pip python3-venv libxrender1
 
-
-RUN python3 -m pip install wheel
-RUN python3 -m venv /venv/
-
-RUN /venv/bin/pip install -U pip
-# 2024-11-12 MJL: mpi4py < 4.0 in the next line is due to
-# https://github.com/hiddenSymmetries/simsopt/issues/455
-# Once NERSC gets Shifter working with mpi4py >= 4 we can remove this inequality
-RUN /venv/bin/python -m pip install numpy scipy jax jaxlib f90nml "mpi4py<4.0" jupyter notebook ipython qsc sympy scikit-build ninja "pybind11[global]" cmake f90wrap h5py
-ENV PATH="/venv/bin:${PATH}"
-
 # Install mpich manually
 WORKDIR /src
 ARG mpich=4.0.3
@@ -34,8 +23,17 @@ RUN \
     cd ..                           && \
     rm -rf $mpich_prefix
 
-
 RUN /sbin/ldconfig
+
+RUN python3 -m pip install wheel
+RUN python3 -m venv /venv/
+
+RUN /venv/bin/pip install -U pip
+# 2024-11-12 MJL: mpi4py < 4.0 in the next line is due to
+# https://github.com/hiddenSymmetries/simsopt/issues/455
+# Once NERSC gets Shifter working with mpi4py >= 4 we can remove this inequality
+RUN /venv/bin/python -m pip install numpy scipy jax jaxlib f90nml "mpi4py<4.0" jupyter notebook ipython qsc sympy scikit-build ninja "pybind11[global]" cmake f90wrap h5py
+ENV PATH="/venv/bin:${PATH}"
 
 RUN \
     git clone --depth 1 https://github.com/Reference-ScaLAPACK/scalapack.git scalapack && \


### PR DESCRIPTION
The way pybind11 is sourced changed long time ago. Instead of using a git submodule, the pybind11 package is downloaded and installed using python's build framework. The orphaned pybind11 submodule is removed.