### PR TITLE
Fix docs build errors

### DIFF
--- a/src/simsopt/field/coilset.py
+++ b/src/simsopt/field/coilset.py
@@ -81,16 +81,18 @@ class CoilSet(Optimizable):
     def for_surface(cls, surf, coil_current=1e5, coils_per_period=5, nfp=None, current_constraint="fix_all", **kwargs): 
         """
         Create a CoilSet for a given surface. The coils are created using
-        :obj:`create_equally_spaced_curves` with the given parameters.
+        :py:func:`simsopt.geo.create_equally_spaced_curves` with the given parameters.
+
+        The keyword arguments ``coils_per_period``, ``order``, ``R0``, ``R1``,
+        ``factor``, and ``use_stellsym`` are passed to the
+        :py:func:`~simsopt.geo.create_equally_spaced_curves` function.
 
         Args:
             surf: The surface for which to create the coils
             total_current: the total current in the CoilSet
             coils_per_period: the number of coils per field period
             nfp: The number of field periods.
-            current_constraint: "fix_one" or "fix_all" or "free_all" 
-
-        Keyword Args (passed to the create_equally_spaced_curves function)
+            current_constraint: ``"fix_one"`` or ``"fix_all"`` or ``"free_all"``
             coils_per_period: The number of coils per field period
             order: The order of the Fourier expansion
             R0: major radius of a torus on which the initial coils are placed
@@ -136,13 +138,14 @@ class CoilSet(Optimizable):
     def reduce(self, target_function, nsv='nonzero'):
         """
         Return a ReducedCoilSet based on this CoilSet using the SVD of the mapping
-        given by target_function. 
+        given by target_function.
+
         Args:
-            nsv: The number of singular vectors to keep, integer or 'nonzero' (for all nonzero singular values)
             target_function: a function that takes a CoilSet and maps to a different space that is relevant for the optimization problem. 
-                The SVD will be calculated on the Jacobian of f: coilDOFs -> target
+                The SVD will be calculated on the Jacobian of f: coilDOFs -> target.
                 For example a function that calculates the fourier coefficients of the
                 normal field on the surface. 
+            nsv: The number of singular vectors to keep, integer or ``"nonzero"`` (for all nonzero singular values)
         """
         return ReducedCoilSet.from_function(self, target_function, nsv)
 
@@ -439,16 +442,17 @@ class ReducedCoilSet(CoilSet):
     def from_function(cls, coilset, target_function, nsv='nonzero'):
         """
         Reduce an existing CoilSet to a ReducedCoilSet using the SVD of the mapping
-        given by target_function. 
+        given by target_function.
+
         Args:
             coilset: The CoilSet to reduce
             target_function: a function that takes a CoilSet and maps to a different space that is relevant for the optimization problem. 
                 The SVD will be calculated on the Jacobian of f: coilDOFs -> target
                 For example a function that calculates the fourier coefficients of the
                 normal field on the surface. 
-            nsv: The number of singular values to keep, either an integer or 'nonzero'. defaults to 'nonzero'. 
+            nsv: The number of singular values to keep, either an integer or ``"nonzero"``. defaults to ``"nonzero"``.
                 If an integer is given, this number of largest singular values will be kept.
-                If 'nonzero', all nonzero singular values are kept.
+                If ``"nonzero"``, all nonzero singular values are kept.
         """
         optfunction = make_optimizable(target_function, coilset)
         fd = FiniteDifference(optfunction.J)

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -512,18 +512,17 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
     
     def copy(self, **kwargs): 
         """
-        return a copy of the surfaceRZFourier object, but with the specified
-        attributes changed. 
-        key-worded arguments accepted: 
-            - ntheta: number of quadrature points in the theta direction
-            - nphi: number of quadrature points in the phi direction
-            - mpol: number of poloidal Fourier modes for the surface
-            - ntor: number of toroidal Fourier modes for the surface
-            - nfp: number of field periods
-            - stellsym: whether the surface is stellarator-symmetric
-            - quadpoints_theta: theta grid points
-            - quadpoints_phi: phi grid points
-        
+        Return a copy of the ``SurfaceRZFourier`` object, but with the specified
+        attributes changed. Keyword arguments accepted:
+
+        - ``ntheta``: number of quadrature points in the theta direction
+        - ``nphi``: number of quadrature points in the phi direction
+        - ``mpol``: number of poloidal Fourier modes for the surface
+        - ``ntor``: number of toroidal Fourier modes for the surface
+        - ``nfp``: number of field periods
+        - ``stellsym``: whether the surface is stellarator-symmetric
+        - ``quadpoints_theta``: theta grid points
+        - ``quadpoints_phi``: phi grid points
         
         """
         otherntheta = self.quadpoints_theta.size
@@ -799,31 +798,37 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
         r"""
         Compute the Fourier components of a scalar on the surface. The scalar
         is evaluated at the quadrature points on the surface. 
-        The Fourier uses the conventions of the FourierRZSurface series, 
-        with `npol` going from `-ntor` to `ntor` and `mpol` from 0 to `mpol`
+        The Fourier uses the conventions of the ``SurfaceRZFourier`` series, 
+        with ``npol`` going from ``-ntor`` to ``ntor`` and ``mpol`` from 0 to ``mpol``
         i.e.: 
-        :math:`f(\theta, \phi) = \Sum_{m=0}^{mpol} \Sum_{n=-npol}^{npol} A^{mn}_s \sin(m\theta - n*Nfp*\phi)\\
-            + A^{mn}_c \cos(m\theta - n*Nfp*\phi)`
+
+        .. math::
+            f(\theta, \phi) = \sum_{m=0}^{mpol} \sum_{n=-npol}^{npol} A^{mn}_s \sin(m\theta - n N_{fp} \phi)
+            + A^{mn}_c \cos(m\theta - n N_{fp} \phi)
+
         Where the cosine series is only evaluated if the surface is not stellarator
         symmetric (if the scalar does not adhere to the symmetry of the surface, 
-        request the cosine series by setting the kwarg stellsym=False)
-        By default, the poloidal and toroidal resolution are the same as those of the surface, but different quantities can be specified in the kwargs. 
-        *Arguments*:
-            - scalar: 2D array of shape (numquadpoints_phi, numquadpoints_theta).
-            - mpol: maximum poloidal mode number of the transform, if None,
+        request the cosine series by setting the kwarg ``stellsym=False``)
+        By default, the poloidal and toroidal resolution are the same as those
+        of the surface, but different quantities can be specified in the kwargs. 
+        
+        Args:
+            scalar: 2D array of shape ``(numquadpoints_phi, numquadpoints_theta)``.
+            mpol: maximum poloidal mode number of the transform, if ``None``,
                 the mpol attribute of the surface is used.
-            - ntor: maximum toroidal mode number of the transform if None, 
+            ntor: maximum toroidal mode number of the transform if ``None``, 
                 the ntor attribute of the surface is used.
-        *Optional keyword arguments*:
-            - normalization: Fourier transform normalization. Can be: 
-              None: forward and back transform are not normalized
-              float: forward transform is divided by this number
-            - stellsym: boolean to override the stellsym attribute 
-                of the surface if you want to force the calculation of the cosine series
-        *Returns*:
-            - A_mns: 2D array of shape (mpol+1, 2*ntor+1) containing the sine coefficients
-            - A_mnc: 2D array of shape (mpol+1, 2*ntor+1) containing the cosine coefficients 
-                (these are zero if the surface is stellarator symmetric)
+            normalization: (optional) Fourier transform normalization. Can be: 
+              ``None``: forward and back transform are not normalized.
+              ``float``: forward transform is divided by this number.
+            stellsym: (optional) boolean to override the stellsym attribute 
+                of the surface if you want to force the calculation of the
+                cosine series
+                
+        Returns:
+            2-element tuple ``(A_mns, A_mnc)``, where ``A_mns`` is a 2D array of shape ``(mpol+1, 2*ntor+1)`` containing the sine
+            coefficients, and ``A_mnc`` is a  2D array of shape ``(mpol+1, 2*ntor+1)`` containing the cosine coefficients 
+            (these are zero if the surface is stellarator symmetric).
         """
         assert scalar.shape[0] == self.quadpoints_phi.size, "scalar must be evaluated at the quadrature points on the surface.\n the scalar you passed in has shape {}".format(scalar.shape)
         assert scalar.shape[1] == self.quadpoints_theta.size, "scalar must be evaluated at the quadrature points on the surface.\n the scalar you passed in has shape {}".format(scalar.shape)
@@ -875,19 +880,21 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
         Compute the inverse Fourier transform of a scalar on the surface, specified by the Fourier coefficients. The quantity must be
         is evaluated at the quadrature points on the surface. The Fourier
         transform is defined as
-        :math:`f(\theta, \phi) = \Sum_{m=0}^{mpol} \Sum_{n=-npol}^{npol} A^{mn}_s \sin(m\theta - n*Nfp*\phi)\\
-            + A^{mn}_c \cos(m\theta - n*Nfp*\phi)`
-        Where the cosine series is only evaluated if the surface is not stellarator
-        symmetric.
+        :math:`f(\theta, \phi) = \Sum_{m=0}^{mpol} \Sum_{n=-npol}^{npol} A^{mn}_s \sin(m\theta - n*Nfp*\phi) + A^{mn}_c \cos(m\theta - n*Nfp*\phi)`
+        Where the cosine series is only evaluated if the surface is not stellarator symmetric.
         *Arguments*:
-            - A_mns: 2D array of shape (mpol+1, 2*ntor+1) containing the sine coefficients
-            - A_mnc: 2D array of shape (mpol+1, 2*ntor+1) containing the cosine coefficients 
-                (these are zero if the surface is stellarator symmetric)
+
+        - A_mns: 2D array of shape (mpol+1, 2*ntor+1) containing the sine coefficients
+        - A_mnc: 2D array of shape (mpol+1, 2*ntor+1) containing the cosine coefficients 
+            (these are zero if the surface is stellarator symmetric)
+
         *Optional keyword arguments*:
-            - normalization: Fourier transform normalization. Can be:
-                None: forward and back transform are not normalized
-                float: inverse transform is multiplied by this number
-            - stellsym: boolean to override the stellsym attribute of the surface
+
+        - normalization: Fourier transform normalization. Can be:
+            None: forward and back transform are not normalized
+            float: inverse transform is multiplied by this number
+        - stellsym: boolean to override the stellsym attribute of the surface
+
         """
         mpol = A_mns.shape[0] - 1
         ntor = int((A_mns.shape[1] - 1) / 2)

--- a/src/simsopt/mhd/spec.py
+++ b/src/simsopt/mhd/spec.py
@@ -751,17 +751,11 @@ class Spec(Optimizable):
         """
         Take a profile from the inputlist, and make it optimizable in 
         simsopt.
+
         Args:
-            longname: string, either 
-                - 'pressure'
-                - 'volume_current'
-                - 'interface_current'
-                - 'iota'
-                - 'oita'
-                - 'mu'
-                - 'pflux'
-                - 'tflux'
-                - 'helicity'
+            longname: string, one of ``"pressure"``, ``"volume_current"``, 
+                ``"interface_current"``, ``"iota"``, ``"oita"``, ``"mu"``, 
+                ``"pflux"``, ``"tflux"`` or ``"helicity"``.
         """
         profile_dict = {
             'pressure': {'specname': 'pressure', 'cumulative': False, 'length': self.nvol},


### PR DESCRIPTION
Presently, when building the docs by running `make html` from the `docs` directory, there are the following errors:
~~~~
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.copy:4: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.fourier_transform_scalar:7: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.fourier_transform_scalar:1: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.fourier_transform_scalar:8: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.fourier_transform_scalar:13: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.fourier_transform_scalar:18: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.inverse_fourier_transform_scalar:5: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.inverse_fourier_transform_scalar:1: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.inverse_fourier_transform_scalar:6: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.inverse_fourier_transform_scalar:9: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.inverse_fourier_transform_scalar:12: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/mattland/simsopt/simsopt/src/simsopt/mhd/spec.py:docstring of simsopt.mhd.spec.Spec.activate_profile:4: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/field/coilset.py:docstring of simsopt.field.coilset.CoilSet.for_surface:16: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/field/coilset.py:docstring of simsopt.field.coilset.CoilSet.for_surface:17: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/mattland/simsopt/simsopt/src/simsopt/field/coilset.py:docstring of simsopt.field.coilset.CoilSet.reduce:5: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/field/coilset.py:docstring of simsopt.field.coilset.ReducedCoilSet.from_function:5: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/field/coilset.py:docstring of simsopt.field.coilset.ReducedCoilSet.from_function:8: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.copy:4: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.fourier_transform_scalar:7: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.fourier_transform_scalar:1: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.fourier_transform_scalar:8: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.fourier_transform_scalar:13: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.fourier_transform_scalar:18: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.inverse_fourier_transform_scalar:5: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.inverse_fourier_transform_scalar:1: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.inverse_fourier_transform_scalar:6: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.inverse_fourier_transform_scalar:9: ERROR: Unexpected indentation.
/Users/mattland/simsopt/simsopt/src/simsopt/geo/surfacerzfourier.py:docstring of simsopt.geo.surfacerzfourier.SurfaceRZFourier.inverse_fourier_transform_scalar:12: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/mattland/simsopt/simsopt/src/simsopt/mhd/spec.py:docstring of simsopt.mhd.spec.Spec.activate_profile:4: ERROR: Unexpected indentation.
~~~~
This PR fixes these errors.