### PR TITLE
Bug fix for adding dof names in CurveRZFourier Class

### DIFF
--- a/src/simsopt/geo/curverzfourier.py
+++ b/src/simsopt/geo/curverzfourier.py
@@ -38,19 +38,15 @@ class CurveRZFourier(sopp.CurveRZFourier, Curve):
             Curve.__init__(self, x0=self.get_dofs(), names=self._make_names(order, stellsym),
                            external_dof_setter=CurveRZFourier.set_dofs_impl)
         else:
-            Curve.__init__(self, dofs=dofs, 
+            Curve.__init__(self, dofs=dofs,
                            external_dof_setter=CurveRZFourier.set_dofs_impl)
 
     def _make_names(self, order, stellsym):
-        r_names = ['rc(0)']
-        r_names += [f'rc({i})' for i in range(1, order + 1)]
+        r_names = [f'rc({i})' for i in range(0, order + 1)]
+        z_names = [f'zs({i})' for i in range(1, order + 1)]
         if not stellsym:
             r_names += [f'rs({i})' for i in range(1, order + 1)]
-        z_names = []
-        if not stellsym:
-            z_names += ['zc(0)']
-            z_names += [f'zc({i})' for i in range(1, order + 1)]
-        z_names += [f'zs({i})' for i in range(1, order + 1)]
+            z_names = [f'zc({i})' for i in range(0, order + 1)] + z_names
         return r_names + z_names
 
     def get_dofs(self):

--- a/src/simsopt/geo/curverzfourier.py
+++ b/src/simsopt/geo/curverzfourier.py
@@ -38,8 +38,8 @@ class CurveRZFourier(sopp.CurveRZFourier, Curve):
             Curve.__init__(self, x0=self.get_dofs(), names=self._make_names(order, stellsym),
                            external_dof_setter=CurveRZFourier.set_dofs_impl)
         else:
-            Curve.__init__(self, dofs=dofs,
-                           external_dof_setter=CurveRZFourier.set_dofs_impl)
+            Curve.__init__(self, external_dof_setter=CurveRZFourier.set_dofs_impl,
+                           dofs=dofs)
 
     def _make_names(self, order, stellsym):
         r_names = [f'rc({i})' for i in range(0, order + 1)]

--- a/src/simsopt/geo/curverzfourier.py
+++ b/src/simsopt/geo/curverzfourier.py
@@ -1,4 +1,5 @@
 import numpy as np
+from itertools import chain
 
 import simsoptpp as sopp
 from .curve import Curve
@@ -35,11 +36,23 @@ class CurveRZFourier(sopp.CurveRZFourier, Curve):
             quadpoints = list(quadpoints)
         sopp.CurveRZFourier.__init__(self, quadpoints, order, nfp, stellsym)
         if dofs is None:
-            Curve.__init__(self, external_dof_setter=CurveRZFourier.set_dofs_impl,
-                           x0=self.get_dofs())
+            Curve.__init__(self, x0=self.get_dofs(), names=self._make_names(order, stellsym),
+                           external_dof_setter=CurveRZFourier.set_dofs_impl)
         else:
-            Curve.__init__(self, external_dof_setter=CurveRZFourier.set_dofs_impl,
-                           dofs=dofs)
+            Curve.__init__(self, dofs=dofs, 
+                           external_dof_setter=CurveRZFourier.set_dofs_impl)
+
+    def _make_names(self, order, stellsym):
+        r_names = ['rc(0)']
+        r_names += [f'rc({i})' for i in range(1, order + 1)]
+        if not stellsym:
+            r_names += [f'rs({i})' for i in range(1, order + 1)]
+        z_names = []
+        if not stellsym:
+            z_names += ['zc(0)']
+            z_names += [f'zc({i})' for i in range(1, order + 1)]
+        z_names += [f'zs({i})' for i in range(1, order + 1)]
+        return r_names + z_names
 
     def get_dofs(self):
         """

--- a/src/simsopt/geo/curverzfourier.py
+++ b/src/simsopt/geo/curverzfourier.py
@@ -1,5 +1,4 @@
 import numpy as np
-from itertools import chain
 
 import simsoptpp as sopp
 from .curve import Curve

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -778,6 +778,31 @@ class Testing(unittest.TestCase):
 
             os.remove("coils.file_to_load")
 
+    def test_curverzfourier_dofnames(self):
+        # test that the dof names correspond to how they are treated in the code
+        order = 3
+
+        # non-stellarator symmetric case
+        curve = CurveRZFourier(32, order, 1, False)
+        curve.set('rc(0)', 1)
+        curve.set('rs(1)', 2)
+        curve.set('zc(2)', 3)
+        curve.set('zs(3)', 4)
+        
+        # test rc, rs, zc, and zs, note sine arrays start from mode number 1
+        assert curve.rc[0] == curve.get('rc(0)')
+        assert curve.zc[2] == curve.get('zc(2)')
+        assert curve.rs[0] == curve.get('rs(1)')
+        assert curve.zs[2] == curve.get('zs(3)')
+
+        # stellarator symmetric case
+        curve = CurveRZFourier(32, order, 1, True)
+        curve.set('rc(1)', 1)
+        curve.set('zs(2)', 2)
+        
+        # test rc and zs
+        assert curve.rc[1] == curve.get('rc(1)')
+        assert curve.zs[1] == curve.get('zs(2)')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This bug-fix is part of **Simsopt fix-it week 2025**. 
It addresses a bug in the class `CurveRZFourier`. According to the documentation, the degrees of freedom (dofs) should be listed as 

```[r_{c,0}, \cdots, r_{c,\text{order}}, r_{s,1}, \cdots, r_{s,\text{order}}, z_{c,0},....]```

if `stellsym` is false, and

```[r_{c,0},...,r_{c,order},z_{s,1},...,z_{s,order}]```

if stellsym is True. 

However, a dof naming function did not exist so the dofs were being stored as 

```[x0, x1, /cdots, x{num_dofs]```.

This pull request fixes this issue by adding a `_make_names` function, which names the dofs according to the documentation. It is modeled after the existing function used to names the dofs in `CurveXYZFourier`. Its functionality has been tested for both stellarator symmetric and non-stellarator symmetric curves below

---------------------------------

**Test 1:**
Non-stellarator symmetric, order = 3: dofs are stored as [r_{c,0}, \cdots, r_{c,\text{order}}, r_{s,1}, \cdots, r_{s,\text{order}}, z_{c,0},....]
<img width="1246" alt="image" src="https://github.com/user-attachments/assets/4e354e79-2187-4d34-bc4e-3cbe3d96ff59" />

**Test 2:**
Stellarator symmetric, order = 6: dofs are stored as [r_{c,0},...,r_{c,order},z_{s,1},...,z_{s,order}]
<img width="1244" alt="image" src="https://github.com/user-attachments/assets/ef1c1240-6c63-4c9e-9ac7-ddea94508ac2" />

As a comparison, this is the output for a CurveXYZFourier object where the dofs are appropriately named and stored as 
```[x_{c,0}, x_{s,1}, x_{c,1},\cdots x_{s,\text{order}}, x_{c,\text{order}},y_{c,0},y_{s,1},y_{c,1},\cdots]```
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/f0b0a85d-4cc5-4cbc-bd20-a4205c2c4838" />
