### PR TITLE
Stop building wheels for non-HPC architectures

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -28,7 +28,7 @@ jobs:
           #   CIBW_ARCHS_MACOS: "x86_64 arm64"
           #   # Skip python 3.8 and PyPy builds since there is are errors when building the
           #   # wheel in those cases:
-          CIBW_SKIP: cp38-* pp*
+          CIBW_SKIP: cp38-* pp* *-manylinux_i686 *-musllinux*
           #   CIBW_DEPENDENCY_VERSIONS: latest
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Currently wheels are being built for i68c and musllinux architectures. Not worth building wheels not going to be used. 