### PR TITLE
updates cross_section documentation

### DIFF
--- a/src/simsopt/geo/surface.py
+++ b/src/simsopt/geo/surface.py
@@ -325,15 +325,21 @@ class Surface(Optimizable):
 
     def cross_section(self, phi, thetas=None):
         """
-        This function takes in a cylindrical angle :math:`\phi` and returns the cross
-        section of the surface in that plane evaluated at `thetas`. This is
-        done using the method of bisection.
-        This function takes in a cylindrical angle :math:`\phi` and returns
-        the cross section of the surface in that plane evaluated at `thetas`.
-        This is done using the method of bisection.
-
+        Computes the cross-section at a given cylindrical angle :math:`\phi` at `thetas` using bisection.
         This function assumes that the surface intersection with the plane is a
         single curve.
+
+        Parameters
+        ----------
+            phi: float
+                toroidal angle
+            thetas: float array
+                collocation points to compute cross-section with
+
+        Returns
+        -------
+            cross_section: float
+                The cross-section evaluated at :math:`\phi` given support points `thetas`
         """
 
         # phi is assumed to be between [-pi, pi], so if it does not lie on that interval


### PR DESCRIPTION
This bug-fix is part of Simsopt fix-it week 2025.

It updates the documentation of simsopt.geo.Surface.cross_section.


![image](https://github.com/user-attachments/assets/fcb0ae0f-1e45-435c-b767-6fb4363d052c)


I assumed that cross_section is a float in [m²] and ran no tests because this only updates one documentation string.
