### PR TITLE
Bug Fix for SurfaceXYZFourier/TensorFourier Dof Naming

### DIFF
--- a/src/simsopt/geo/surfacexyzfourier.py
+++ b/src/simsopt/geo/surfacexyzfourier.py
@@ -80,12 +80,12 @@ class SurfaceXYZFourier(sopp.SurfaceXYZFourier, Surface):
         x_names = []
         y_names = []
         z_names = []
-        
+
         for m in range(mpol + 1):
             if m == 0:
                 for n in range(ntor + 1):
                     x_names += [f'xc({m},{n})']
-            else: 
+            else:
                 for n in range(-ntor, ntor + 1):
                     x_names += [f'xc({m},{n})']
 
@@ -93,7 +93,7 @@ class SurfaceXYZFourier(sopp.SurfaceXYZFourier, Surface):
             if m == 0:
                 for n in range(1, ntor + 1):
                     y_names += [f'ys({m},{n})']
-            else: 
+            else:
                 for n in range(-ntor, ntor + 1):
                     y_names += [f'ys({m},{n})']
 
@@ -101,7 +101,7 @@ class SurfaceXYZFourier(sopp.SurfaceXYZFourier, Surface):
             if m == 0:
                 for n in range(1, ntor + 1):
                     z_names += [f'zs({m},{n})']
-            else: 
+            else:
                 for n in range(-ntor, ntor + 1):
                     z_names += [f'zs({m},{n})']
 
@@ -113,7 +113,7 @@ class SurfaceXYZFourier(sopp.SurfaceXYZFourier, Surface):
                 else:
                     for n in range(-ntor, ntor + 1):
                         x_names += [f'xs({m},{n})']
-            
+
             for m in range(mpol + 1):
                 if m == 0:
                     for n in range(ntor + 1):

--- a/src/simsopt/geo/surfacexyzfourier.py
+++ b/src/simsopt/geo/surfacexyzfourier.py
@@ -70,11 +70,67 @@ class SurfaceXYZFourier(sopp.SurfaceXYZFourier, Surface):
         self.xc[1, ntor] = 0.1
         self.zs[1, ntor] = 0.1
         if dofs is None:
-            Surface.__init__(self, x0=self.get_dofs(),
+            Surface.__init__(self, x0=self.get_dofs(), names=self._make_names(mpol, ntor, stellsym),
                              external_dof_setter=SurfaceXYZFourier.set_dofs_impl)
         else:
             Surface.__init__(self, dofs=dofs,
                              external_dof_setter=SurfaceXYZFourier.set_dofs_impl)
+
+    def _make_names(self, mpol, ntor, stellsym):
+        x_names = []
+        y_names = []
+        z_names = []
+        
+        for m in range(mpol + 1):
+            if m == 0:
+                for n in range(ntor + 1):
+                    x_names += [f'xc({m},{n})']
+            else: 
+                for n in range(-ntor, ntor + 1):
+                    x_names += [f'xc({m},{n})']
+
+        for m in range(mpol + 1):
+            if m == 0:
+                for n in range(1, ntor + 1):
+                    y_names += [f'ys({m},{n})']
+            else: 
+                for n in range(-ntor, ntor + 1):
+                    y_names += [f'ys({m},{n})']
+
+        for m in range(mpol + 1):
+            if m == 0:
+                for n in range(1, ntor + 1):
+                    z_names += [f'zs({m},{n})']
+            else: 
+                for n in range(-ntor, ntor + 1):
+                    z_names += [f'zs({m},{n})']
+
+        if not stellsym:
+            for m in range(mpol + 1):
+                if m == 0:
+                    for n in range(1, ntor + 1):
+                        x_names += [f'xs({m},{n})']
+                else:
+                    for n in range(-ntor, ntor + 1):
+                        x_names += [f'xs({m},{n})']
+            
+            for m in range(mpol + 1):
+                if m == 0:
+                    for n in range(ntor + 1):
+                        y_names += [f'yc({m},{n})']
+                else:
+                    for n in range(-ntor, ntor + 1):
+                        y_names += [f'yc({m},{n})']
+
+            for m in range(mpol + 1):
+                if m == 0:
+                    for n in range(ntor + 1):
+                        z_names += [f'zc({m},{n})']
+                else:
+                    for n in range(-ntor, ntor + 1):
+                        z_names += [f'zc({m},{n})']
+
+        return x_names + y_names + z_names
 
     def get_dofs(self):
         """

--- a/src/simsopt/geo/surfacexyztensorfourier.py
+++ b/src/simsopt/geo/surfacexyztensorfourier.py
@@ -72,11 +72,44 @@ class SurfaceXYZTensorFourier(sopp.SurfaceXYZTensorFourier, Surface):
         self.xcs[1, 0] = 0.1
         self.zcs[mpol+1, 0] = 0.1
         if dofs is None:
-            Surface.__init__(self, x0=self.get_dofs(),
+            Surface.__init__(self, x0=self.get_dofs(), names=self._make_names(mpol, ntor, stellsym),
                              external_dof_setter=SurfaceXYZTensorFourier.set_dofs_impl)
         else:
             Surface.__init__(self, dofs=dofs,
                              external_dof_setter=SurfaceXYZTensorFourier.set_dofs_impl)
+
+    def _make_names(self, mpol, ntor, stellsym):
+        dof_names = []
+        for m in range(2 * mpol + 1):
+            for n in range(2 * ntor + 1):
+                if self.skip(0, m, n, stellsym, mpol, ntor):
+                    continue
+                dof_names += [f'x({m},{n})']
+
+        for m in range(2 * mpol + 1):
+            for n in range(2 * ntor + 1):
+                if self.skip(1, m, n, stellsym, mpol, ntor):
+                    continue
+                dof_names += [f'y({m},{n})']
+
+        for m in range(2 * mpol + 1):
+            for n in range(2 * ntor + 1):
+                if self.skip(2, m, n, stellsym, mpol, ntor):
+                    continue
+                dof_names += [f'z({m},{n})']
+
+        return dof_names
+
+    @staticmethod
+    def skip(dim, m, n, stellsym, mpol, ntor):
+        if not stellsym:
+            return False
+        if dim == 0:
+            return (n <= ntor and m > mpol) or (n > ntor and m <= mpol)
+        elif dim == 1:
+            return (n <= ntor and m <= mpol) or (n > ntor and m > mpol)
+        else:
+            return (n <= ntor and m <= mpol) or (n > ntor and m > mpol)
 
     def get_dofs(self):
         """


### PR DESCRIPTION
This bug fix is part of the Simsopt fix-it week 2025. It addresses the issue of dofs not being appropriately named for the```SurfaceXYZFourier/SurfaceXYZTensorFourier``` classes. The current code sets them as the default `x0, x1, x2 ...`, and this commit correctly names them (according to the class documentation within the readthedocs pages).

For ```SurfaceXYZFourier```, the dofs are now named according to their $m$ and $n$ harmonics as described here (https://simsopt.readthedocs.io/en/latest/simsopt_user.geo.html#simsopt.geo.SurfaceXYZFourier), where $m$ goes from $0$ to $m_{pol}$ and $n$ goes from $-n_{tor}$ to $n_{tor}$. For example, the below script shows the dof names for a `SurfaceXYZFourier` with stellarator symmetry. I check that the dofs are being named using a test case, where I add $n_{tor}$ to $n$ to account for the starting index. The dofs can be set/retrieved using the notation `xc(m, n)` (or `ys, zs`, etc.).
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/a6ea1d98-f5e9-491f-a159-6760eb7b30ba" />

This is another example showing a non-stellarator symmetric case, where now the `xs, yc, and zc` arrays are shown. 
<img width="1170" alt="image" src="https://github.com/user-attachments/assets/56175283-dd11-4752-b0bb-007982d55ea0" />

For ```SurfaceXYZTensorFourier```, the dofs are named according to the $i$ and $j$ indices described here (https://simsopt.readthedocs.io/en/latest/simsopt.geo.html#simsopt.geo.surfacexyztensorfourier.SurfaceXYZTensorFourier), where both $i$ and $j$ go from $0$ to $2m_{pol}$ and $2n_{tor}$, respectively. I implemented the dof naming in a similar fashion to the `set_dofs_impl` in `surfacexyztensorfourier.py`, including the `skip` function.

For example, this is a non-stellarator symmetric case. I have used another test to make sure the dofs are being appropriately named with the actual arrays. **Note: the internal arrays are called `xcs`, `ycs`, `zcs` because they contain both sine and cosine terms. After speaking with Misha, we decided to maintain consistency with the readthedocs and call them `x, y, z` only.** The dofs can be set/retrieved using the `x(i, j)` notation. 
<img width="1171" alt="image" src="https://github.com/user-attachments/assets/c1eb1b9e-79cb-4548-b9b7-304de37bd8cb" />

A second example for a stellarator symmetric case. The available dof indices change according to $[0, m_{pol}] \times [0, n_{tor}] + [m_{pol}+1, 2m_{pol}] \times [n_{tor}+1, 2n_{tor}]$ for `x` and $[0, m_{pol}] \times [n_{tor}+1, 2n_{tor}] + [m_{pol}+1, 2m_{pol}] \times [0, n_{tor}]$ for `y` and `z`.
<img width="1168" alt="image" src="https://github.com/user-attachments/assets/8b25e072-e1f1-419a-a901-b1e84b253aa6" />

