### PR TITLE
Improve CurveHelical

### DIFF
--- a/src/simsopt/geo/curvehelical.py
+++ b/src/simsopt/geo/curvehelical.py
@@ -1,69 +1,114 @@
-import jax.numpy as jnp
-from math import pi
 import numpy as np
+import jax.numpy as jnp
 from .curve import JaxCurve
 
-__all__ = ['CurveHelical']
+__all__ = ["CurveHelical"]
 
 
-def jaxHelicalfouriercurve_pure(dofs, quadpoints, order, n0, l0, R0, r0):
-    A = dofs[:order]
-    B = dofs[order:]
-    phi = quadpoints*2*pi*l0
-    m, phiV = jnp.meshgrid(jnp.arange(order), phi)
-    AcosArray = jnp.sum(A*jnp.cos(m*phiV*n0/l0), axis=1)
-    BsinArray = jnp.sum(B*jnp.sin(m*phiV*n0/l0), axis=1)
-    eta = n0*phi/l0+AcosArray+BsinArray
-    gamma = jnp.zeros((len(quadpoints), 3))
-    gamma = gamma.at[:, 0].add((R0 + r0 * jnp.cos(eta)) * jnp.cos(phi))
-    gamma = gamma.at[:, 1].add((R0 + r0 * jnp.cos(eta)) * jnp.sin(phi))
-    gamma = gamma.at[:, 2].add(-r0 * jnp.sin(eta))
+def jaxHelicalfouriercurve_pure(dofs, quadpoints, order, m, ell, R0, r):
+    """Pure function for the position vector used by CurveHelical."""
+    A = dofs[: order + 1]
+    B = jnp.concatenate(
+        (jnp.zeros(1), dofs[order + 1 :])
+    )  # Add 0 at the start for k = 0
+    phi = quadpoints * 2 * jnp.pi * ell
+    k, phi_2D = jnp.meshgrid(jnp.arange(order + 1), phi)
+    eta = m * phi / ell + jnp.sum(
+        A * jnp.cos(k * phi_2D * m / ell) + B * jnp.sin(k * phi_2D * m / ell), axis=1
+    )
+    R = R0 + r * jnp.cos(eta)
+    x = R * jnp.cos(phi)
+    y = R * jnp.sin(phi)
+    z = -r * jnp.sin(eta)
+    gamma = jnp.column_stack((x, y, z))
     return gamma
 
 
 class CurveHelical(JaxCurve):
-    r'''Curve representation of a helical coil.
-    The helical coil positions are specified by a poloidal angle eta that is a function of the toroidal angle phi with Fourier coefficients :math:`A_k` and :math:`B_k`.
-    The poloidal angle is represented as 
+    r"""Curve representation of a helical coil lying on a circular-cross-section
+    axisymmetric torus.
+
+    This curve type can describe the coils from the
+    `Hanson & Cary (1984) <https://doi.org/10.1063/1.864692>`__
+    and
+    `Cary & Hanson (1986) <https://doi.org/10.1063/1.865539>`__
+    papers on optimization for reduced stochasticity, as well as the Compact
+    Toroidal Hybrid (CTH) device at Auburn University.
+
+    The helical coil lies on a circular-cross-section axisymmetric torus with
+    major radius :math:`R_0` and minor radius :math:`r`. Following Hanson and
+    Cary, the position along the coil is written in terms of a poloidal angle
+    on the winding surface :math:`\eta` and the standard toroidal angle :math:`\phi`:
+
+    .. math::
+        \begin{align*}
+        x &= [R_0 + r \cos(\eta)] \cos(\phi), \\
+        y &= [R_0 + r \cos(\eta)] \sin(\phi), \\
+        z &= -r \sin(\eta).
+        \end{align*}
+
+    Along the coil, the poloidal angle depends on the toroidal angle both
+    through a secular linear term and periodic Fourier terms:
 
     .. math:: 
-        \eta = m_0 \phi/l_0 + \sum_k A_k \cos(n_0 \phi k/l_0) + B_k \sin(n_0 \phi k/l_0)
+        \eta = \frac{m \phi}{l}
+        + A_0 + \sum_{k=1}^N \left[ A_k \cos(k \phi m / l) + B_k \sin(k \phi m / l) \right]
+
+    When the toroidal angle :math:`\phi` increases by :math:`2 \pi l`,
+    the poloidal angle :math:`\eta` increases by :math:`2 \pi m`, so the
+    "rotational transform" of the coil is :math:`m / l`.
+    The shape of the helical coil on the surface can be adjusted through the
+    :math:`A_k` and :math:`B_k` Fourier coefficients, which are the optimizable degrees of
+    freedom for this class.
+
+    The order in which the degrees of freedom are stored in the state vector
+    ``x`` is
+
+    .. math::
+        A_0, A_1, \ldots, A_N, B_1, \ldots, B_N
+
+    The default values of ``m``, ``ell``, ``R0``, and ``r`` correspond to the
+    coils in the Hanson-Cary and Cary-Hanson papers.
 
     Args:
-        quadpoints: number of grid points/resolution along the curve;
-        order:  number of fourier coefficients, i.e., the length of the array A (or B);
-        n0:  toroidal periodicity/number of field periods
-        l0:  number of :math:`2\pi` turns in :math:`\phi`
-        R0:  major radius
-        r0:  minor radius
-    '''
+        quadpoints: (int or array-like) Grid points (or number thereof) along the curve.
+        order:  Maximum (inclusive) Fourier mode number :math:`N` for :math:`A_k` and :math:`B_k`.
+        m:  Integer describing helicity of the coil.
+        ell:  Integer :math:`l` describing helicity of the coil.
+        R0:  Major radius of the toroidal surface on which the coil lies.
+        r:  Minor radius of the toroidal surface on which the coil lies.
+    """
 
-    def __init__(self, quadpoints, order, n0, l0, R0, r0, **kwargs):
+    def __init__(self, quadpoints, order, m=5, ell=2, R0=1.0, r=0.3, **kwargs):
         if isinstance(quadpoints, int):
             quadpoints = np.linspace(0, 1, quadpoints, endpoint=False)
-        def pure(dofs, points): return jaxHelicalfouriercurve_pure(
-            dofs, points, order, n0, l0, R0, r0)
+
+        def pure(dofs, points):
+            return jaxHelicalfouriercurve_pure(dofs, points, order, m, ell, R0, r)
+
         self.order = order
-        self.n0 = n0
-        self.l0 = l0
+        self.m = m
+        self.ell = ell
         self.R0 = R0
-        self.r0 = r0
-        self.coefficients = [np.zeros((order,)), np.zeros((order,))]
+        self.r = r
+        self.coefficients = np.zeros(self.num_dofs())
+        dof_names = [f"A_{i}" for i in range(order + 1)] + [
+            f"B_{i}" for i in range(1, order + 1)
+        ]
+
         if "dofs" not in kwargs:
             if "x0" not in kwargs:
-                kwargs["x0"] = np.concatenate(self.coefficients)
+                kwargs["x0"] = np.zeros(1 + 2 * order)
             else:
                 self.set_dofs_impl(kwargs["x0"])
 
-        super().__init__(quadpoints, pure, **kwargs)
+        super().__init__(quadpoints, pure, names=dof_names, **kwargs)
 
     def num_dofs(self):
-        return 2*self.order
+        return 1 + 2 * self.order
 
     def get_dofs(self):
-        return np.concatenate(self.coefficients)
+        return self.coefficients
 
     def set_dofs_impl(self, dofs):
-        order = int(len(dofs)/2)
-        for i in range(2):
-            self.coefficients[i] = dofs[i*order:(i+1)*order]
+        self.coefficients[:] = dofs

--- a/src/simsopt/geo/curvehelical.py
+++ b/src/simsopt/geo/curvehelical.py
@@ -25,8 +25,7 @@ def jaxHelicalfouriercurve_pure(dofs, quadpoints, order, m, ell, R0, r):
 
 
 class CurveHelical(JaxCurve):
-    r"""Curve representation of a helical coil lying on a circular-cross-section
-    axisymmetric torus.
+    r"""A helical curve lying on a circular-cross-section axisymmetric torus.
 
     This curve type can describe the coils from the
     `Hanson & Cary (1984) <https://doi.org/10.1063/1.864692>`__
@@ -35,9 +34,9 @@ class CurveHelical(JaxCurve):
     papers on optimization for reduced stochasticity, as well as the Compact
     Toroidal Hybrid (CTH) device at Auburn University.
 
-    The helical coil lies on a circular-cross-section axisymmetric torus with
+    The helical curve lies on a circular-cross-section axisymmetric torus with
     major radius :math:`R_0` and minor radius :math:`r`. Following Hanson and
-    Cary, the position along the coil is written in terms of a poloidal angle
+    Cary, the position along the curve is written in terms of a poloidal angle
     on the winding surface :math:`\eta` and the standard toroidal angle :math:`\phi`:
 
     .. math::
@@ -47,25 +46,31 @@ class CurveHelical(JaxCurve):
         z &= -r \sin(\eta).
         \end{align*}
 
-    Along the coil, the poloidal angle depends on the toroidal angle both
+    Along the curve, the poloidal angle depends on the toroidal angle both
     through a secular linear term and periodic Fourier terms:
 
     .. math:: 
         \eta = \frac{m \phi}{l}
         + A_0 + \sum_{k=1}^N \left[ A_k \cos(k \phi m / l) + B_k \sin(k \phi m / l) \right]
 
-    When the toroidal angle :math:`\phi` increases by :math:`2 \pi l`,
-    the poloidal angle :math:`\eta` increases by :math:`2 \pi m`, so the
-    "rotational transform" of the coil is :math:`m / l`.
-    The shape of the helical coil on the surface can be adjusted through the
-    :math:`A_k` and :math:`B_k` Fourier coefficients, which are the optimizable degrees of
-    freedom for this class.
+    When the toroidal angle :math:`\phi` increases by :math:`2 \pi l`, the
+    poloidal angle :math:`\eta` increases by :math:`2 \pi m`, so the "rotational
+    transform" of the curve is :math:`m / l`. The shape of the helical curve on
+    the surface can be adjusted through the :math:`A_k` and :math:`B_k` Fourier
+    coefficients, which are the optimizable degrees of freedom for this class.
+
+    The 1986 Cary-Hanson paper has a more general parameterization than the 1984
+    Hanson-Cary paper, relaxing the constraint that the curves lie on a circle
+    in the R-z plane, although no results in the paper use this freedom. We do
+    not consider this more general parameterization here in this class. For a
+    more general parameterization of helical curves and coils in simsopt, see
+    :class:`simsopt.geo.CurveXYZFourierSymmetries`.
 
     The order in which the degrees of freedom are stored in the state vector
     ``x`` is
 
     .. math::
-        A_0, A_1, \ldots, A_N, B_1, \ldots, B_N
+        A_0, A_1, \ldots, A_N, B_1, \ldots, B_N.
 
     The default values of ``m``, ``ell``, ``R0``, and ``r`` correspond to the
     coils in the Hanson-Cary and Cary-Hanson papers.

--- a/src/simsopt/geo/curvehelical.py
+++ b/src/simsopt/geo/curvehelical.py
@@ -92,13 +92,11 @@ class CurveHelical(JaxCurve):
         self.R0 = R0
         self.r = r
         self.coefficients = np.zeros(self.num_dofs())
-        dof_names = [f"A_{i}" for i in range(order + 1)] + [
-            f"B_{i}" for i in range(1, order + 1)
-        ]
+        dof_names = [f"A_{i}" for i in range(order + 1)] + [f"B_{i}" for i in range(1, order + 1)]
 
         if "dofs" not in kwargs:
             if "x0" not in kwargs:
-                kwargs["x0"] = np.zeros(1 + 2 * order)
+                kwargs["x0"] = self.coefficients
             else:
                 self.set_dofs_impl(kwargs["x0"])
 

--- a/src/simsopt/geo/curvehelical.py
+++ b/src/simsopt/geo/curvehelical.py
@@ -5,7 +5,7 @@ from .curve import JaxCurve
 __all__ = ["CurveHelical"]
 
 
-def jaxHelicalfouriercurve_pure(dofs, quadpoints, order, m, ell, R0, r):
+def curve_helical_pure(dofs, quadpoints, order, m, ell, R0, r):
     """Pure function for the position vector used by CurveHelical."""
     A = dofs[: order + 1]
     B = jnp.concatenate(
@@ -58,6 +58,9 @@ class CurveHelical(JaxCurve):
     transform" of the curve is :math:`m / l`. The shape of the helical curve on
     the surface can be adjusted through the :math:`A_k` and :math:`B_k` Fourier
     coefficients, which are the optimizable degrees of freedom for this class.
+    Although :math:`\phi` in the above formulas is periodic in the range
+    :math:`[0, 2 \pi)`, the ``quadpoints`` argument should be in the range
+    :math:`[0, 1)` as usual for simsopt curves.
 
     The 1986 Cary-Hanson paper has a more general parameterization than the 1984
     Hanson-Cary paper, relaxing the constraint that the curves lie on a circle
@@ -78,7 +81,7 @@ class CurveHelical(JaxCurve):
     Args:
         quadpoints: (int or array-like) Grid points (or number thereof) along the curve.
         order:  Maximum (inclusive) Fourier mode number :math:`N` for :math:`A_k` and :math:`B_k`.
-        m:  Integer describing helicity of the coil.
+        m:  Integer :math:`m` describing helicity of the coil.
         ell:  Integer :math:`l` describing helicity of the coil.
         R0:  Major radius of the toroidal surface on which the coil lies.
         r:  Minor radius of the toroidal surface on which the coil lies.
@@ -89,7 +92,7 @@ class CurveHelical(JaxCurve):
             quadpoints = np.linspace(0, 1, quadpoints, endpoint=False)
 
         def pure(dofs, points):
-            return jaxHelicalfouriercurve_pure(dofs, points, order, m, ell, R0, r)
+            return curve_helical_pure(dofs, points, order, m, ell, R0, r)
 
         self.order = order
         self.m = m

--- a/tests/field/test_coil.py
+++ b/tests/field/test_coil.py
@@ -30,7 +30,7 @@ def get_curve(curvetype, rotated, x=np.asarray([0.5])):
     elif curvetype == "CurveRZFourier":
         curve = CurveRZFourier(x, order, 2, True)
     elif curvetype == "CurveHelical":
-        curve = CurveHelical(x, order, 5, 2, 1.0, 0.3)
+        curve = CurveHelical(x, order, 5, 1, 1.0, 0.3)
     else:
         assert False
     dofs = np.zeros((curve.dof_size, ))

--- a/tests/field/test_fieldline.py
+++ b/tests/field/test_fieldline.py
@@ -116,20 +116,20 @@ class FieldlineTesting(unittest.TestCase):
             assert np.linalg.norm(ma.gamma()[i+1, :] - res_phi_hits[0][i, 2:5]) < 1e-4
 
     def test_poincare_caryhanson(self):
-        # Test with a known magnetic field - optimized Cary&Hanson configuration
+        # Test with a known magnetic field - optimized Cary & Hanson configuration
         # with a magnetic axis at R=0.9413. Field created using the Biot-Savart
         # solver given a set of two helical coils created using the CurveHelical
         # class. The total magnetic field is a superposition of a helical and
         # a toroidal magnetic field.
-        curves = [CurveHelical(200, 2, 5, 2, 1., 0.3) for i in range(2)]
-        curves[0].set_dofs(np.concatenate(([np.pi/2, 0.2841], [0, 0])))
-        curves[1].set_dofs(np.concatenate(([0, 0], [0, 0.2933])))
+        curves = [CurveHelical(200, 1, 5, 2, 1., 0.3) for i in range(2)]
+        curves[0].x = [np.pi/ 2, 0.2841, 0]
+        curves[1].x = [0, 0, 0.2933]
         currents = [3.07e5, -3.07e5]
         Btoroidal = ToroidalField(1.0, 1.0)
         Bhelical = BiotSavart([
             Coil(curves[0], Current(currents[0])),
             Coil(curves[1], Current(currents[1]))])
-        bs = Bhelical+Btoroidal
+        bs = Bhelical + Btoroidal
         ma = CurveXYZFourier(300, 1)
         magnetic_axis_radius = 0.9413
         ma.set_dofs([0, 0, magnetic_axis_radius, 0, magnetic_axis_radius, 0, 0, 0, 0])

--- a/tests/field/test_magneticfields.py
+++ b/tests/field/test_magneticfields.py
@@ -89,9 +89,9 @@ class Testing(unittest.TestCase):
         points = np.asarray(npoints * [[-1.41513202e-03, 8.99999382e-01, -3.14473221e-04]])
         points += pointVar * (np.random.rand(*points.shape)-0.5)
         # Set up helical field
-        curves = [CurveHelical(101, 2, 5, 2, 1., 0.3) for i in range(2)]
-        curves[0].set_dofs(np.concatenate(([np.pi/2, 0], [0, 0])))
-        curves[1].set_dofs(np.concatenate(([0, 0], [0, 0])))
+        curves = [CurveHelical(101, 1, 5, 2, 1., 0.3) for i in range(2)]
+        curves[0].x = [np.pi / 2, 0, 0]
+        curves[1].x = [0, 0, 0]
         currents = [-2.1e5, 2.1e5]
         Bhelical = BiotSavart([
             Coil(curves[0], Current(currents[0])),
@@ -477,9 +477,9 @@ class Testing(unittest.TestCase):
         point = np.asarray([[-1.41513202e-03, 8.99999382e-01, -3.14473221e-04]])
         field = [[-0.00101961, 0.20767292, -0.00224908]]
         derivative = [[[0.47545098, 0.01847397, 1.10223595], [0.01847426, -2.66700072, 0.01849548], [1.10237535, 0.01847085, 2.19154973]]]
-        curves = [CurveHelical(100, 2, 5, 2, 1., 0.3) for i in range(2)]
-        curves[0].set_dofs(np.concatenate(([0, 0], [0, 0])))
-        curves[1].set_dofs(np.concatenate(([np.pi/2, 0], [0, 0])))
+        curves = [CurveHelical(100, 1, 5, 2, 1., 0.3) for i in range(2)]
+        curves[0].x = [0, 0, 0]
+        curves[1].x =[np.pi / 2, 0, 0]
         currents = [-3.07e5, 3.07e5]
         Bhelical = BiotSavart([
             Coil(curves[0], Current(currents[0])),

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -74,7 +74,7 @@ def get_curve(curvetype, rotated, x=np.asarray([0.5])):
     elif curvetype == "CurveHelical":
         curve = CurveHelical(x, order, 5, 2, 1.0, 0.3)
     elif curvetype == "CurveHelicalInitx0":
-        curve = CurveHelical(x, order, 5, 2, 1.0, 0.3, x0=np.ones((2*order,)))
+        curve = CurveHelical(x, order, 5, 2, 1.0, 0.3, x0=np.ones(2 * order + 1))
     elif curvetype == "CurvePlanarFourier":
         curve = CurvePlanarFourier(x, order, 2, True)
     elif curvetype == "CurveXYZFourierSymmetries1":
@@ -191,7 +191,7 @@ class Testing(unittest.TestCase):
         curve1.set('xc(0)', R)
         curve1.set('xc(1)', r)
         curve1.set('zs(1)', -r)
-        curve2 = CurveHelical(np.linspace(0, 1, 100, endpoint=False), order, nfp, 1, R, r, x0=np.zeros((2*order,)))
+        curve2 = CurveHelical(np.linspace(0, 1, 100, endpoint=False), order, nfp, 1, R, r, x0=np.zeros(2 * order + 1))
         np.testing.assert_allclose(curve1.gamma(), curve2.gamma(), atol=1e-14)
 
     def test_trefoil_nonstellsym(self):
@@ -370,8 +370,8 @@ class Testing(unittest.TestCase):
 
     def test_curve_helical_xyzfourier(self):
         x = np.asarray([0.6])
-        curve1 = CurveHelical(x, 2, 5, 2, 1.0, 0.3)
-        curve1.x = [np.pi/2, 0, 0, 0]
+        curve1 = CurveHelical(x, 1, 5, 2, 1.0, 0.3)
+        curve1.x = [np.pi/2, 0, 0]
         curve2 = CurveXYZFourier(x, 7)
         curve2.x = \
             [0, 0, 0, 0, 1, -0.15, 0, 0, 0, 0, 0, 0, 0, -0.15, 0,

--- a/tests/geo/test_curve_helical.py
+++ b/tests/geo/test_curve_helical.py
@@ -7,16 +7,25 @@ class Tests(unittest.TestCase):
     def test_dof_names(self):
         """Check the names of the dofs."""
         curve = CurveHelical(10, 2)
-        np.testing.assert_equal(curve.local_dof_names, ["A_0", "A_1", "A_2", "B_1", "B_2"])
+        np.testing.assert_equal(
+            curve.local_dof_names,
+            ["A_0", "A_1", "A_2", "B_1", "B_2"],
+            "CurveHelical dof names are not as expected",
+        )
         curve.set("A_0", 1.1)
         curve.set("A_1", 2.2)
         curve.set("A_2", 3.3)
         curve.set("B_1", 4.4)
         curve.set("B_2", 5.5)
-        np.testing.assert_equal(curve.x, [1.1, 2.2, 3.3, 4.4, 5.5])
+        np.testing.assert_equal(
+            curve.x,
+            [1.1, 2.2, 3.3, 4.4, 5.5],
+            "CurveHelical dof values are not as expected",
+        )
         np.testing.assert_allclose(
             [curve.get("A_0"), curve.get("A_1"), curve.get("A_2"), curve.get("B_1"), curve.get("B_2")],
-            [1.1, 2.2, 3.3, 4.4, 5.5]
+            [1.1, 2.2, 3.3, 4.4, 5.5],
+            err_msg="CurveHelical dof values from get() are not as expected",
         )
 
 if __name__ == "__main__":

--- a/tests/geo/test_curve_helical.py
+++ b/tests/geo/test_curve_helical.py
@@ -1,0 +1,23 @@
+import unittest
+import numpy as np
+
+from simsopt.geo import CurveHelical
+
+class Tests(unittest.TestCase):
+    def test_dof_names(self):
+        """Check the names of the dofs."""
+        curve = CurveHelical(10, 2)
+        np.testing.assert_equal(curve.local_dof_names, ["A_0", "A_1", "A_2", "B_1", "B_2"])
+        curve.set("A_0", 1.1)
+        curve.set("A_1", 2.2)
+        curve.set("A_2", 3.3)
+        curve.set("B_1", 4.4)
+        curve.set("B_2", 5.5)
+        np.testing.assert_equal(curve.x, [1.1, 2.2, 3.3, 4.4, 5.5])
+        np.testing.assert_allclose(
+            [curve.get("A_0"), curve.get("A_1"), curve.get("A_2"), curve.get("B_1"), curve.get("B_2")],
+            [1.1, 2.2, 3.3, 4.4, 5.5]
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR addresses several issues with `CurveHelical`:

* Previously `order` had been defined so the maximum mode number was `order - 1`, inconsistent with the rest of simsopt where the maximum mode number is `order` (inclusive). With this PR, the maximum mode number is changed to be `order` for consistency.
* The dofs had included a mode amplitude for the k=0 term in the sine terms, which is meaningless. This dof is now removed.
* There wasn't much description in the docstring. More detail is added here.
* Some of the curve parameter names weren't consistent with the Cary-Hanson and Hanson-Cary papers, which are a major motivation for this curve type. E.g. n0 instead of m, r0 instead of r. In this PR, these parameters are renamed to match the papers.
* The dofs previously used the default names x0, x1, ... Now, the dof names are set to `A_0`, `A_1`, ..., `B_1`, ... for better intelligibility and for consistency with Cary-Hanson and Hanson-Cary.