### PR TITLE
Resolve issue 482: update instructions for recompiling simsoptpp

### DIFF
--- a/docs/source/cpp.rst
+++ b/docs/source/cpp.rst
@@ -52,13 +52,18 @@ First, install ``SIMSOPT`` in the usual way::
 
     git clone --recursive git@github.com:hiddenSymmetries/simsopt.git
     cd simsopt
-    pip3 install -e .
+    pip install -e .
+
+Install ``cmake`` and ``pybind11`` using ``pip`` if they are not already installed::
+
+    pip install cmake
+    pip install pybind11
 
 Then, recompile the C++ code in a new directory (``cmake_build``)::
 
     mkdir cmake-build
     cd cmake-build
-    cmake ..
+    cmake .. -Dpybind11_DIR=$(python -c "import pybind11; print(pybind11.__path__[0])")/share/cmake/pybind11/
     make -j
 
 If the compilation executed successfully, there should now be a shared object file (ending with ``.so``) for ``simsoptpp`` in the ``cmake-build`` directory. After verifying that this ``.so`` file exists, execute the following command::

--- a/docs/source/cpp.rst
+++ b/docs/source/cpp.rst
@@ -46,20 +46,23 @@ For simple computations that are compute bound, we use SIMD (`Single Instruction
 CMake
 ^^^^^
 
-When editing the C++ code, it may be useful to use ``CMake`` and ``make`` directly to only recompile those parts of the code that changed. This can be achieved as below
+When editing the C++ code, it may be useful to use ``CMake`` and ``make`` directly to only recompile those parts of the code that changed. This can be achieved as follows.
 
-.. code-block::
+First, install ``SIMSOPT`` in the usual way::
 
     git clone --recursive git@github.com:hiddenSymmetries/simsopt.git
     cd simsopt
     pip3 install -e .
+
+Then, recompile the C++ code in a new directory (``cmake_build``)::
+
     mkdir cmake-build
     cd cmake-build
     cmake ..
     make -j
-    cd ../src
-    rm simsoptpp.cpython-38-x86_64-linux-gnu.so
-    ln -s ../cmake-build/simsoptpp.cpython-38-x86_64-linux-gnu.so .
 
-You may have to adjust the last two lines to match your local system.
+If the compilation executed successfully, there should now be a shared object file (ending with ``.so``) for ``simsoptpp`` in the ``cmake-build`` directory. After verifying that this ``.so`` file exists, execute the following command::
+
+    ln -sf $(realpath *.so) $(python -c "import simsoptpp; print(simsoptpp.__file__)")
+
 From then on, you can always just call ``make -j`` inside the ``cmake-build`` directory to recompile the C++ part of the code.


### PR DESCRIPTION
This PR is a proposed resolution to issue #482.

The previous version of the instructions for recompiling ``simsoptpp`` presumed that the shared object file for simsoptpp used by Python would be stored in the ``src`` directory. However, this is no longer the case in the latest versions, and the instructions in their original form would no achieve the desired outcome.

This commit updates the instructions to be agnostic to the location of the shared object file used by Python, using the Python command ``print(simsoptpp.__file__)`` to directly look up the correct location.