### PR TITLE
[skip ci] Code links in the ReadTheDocs pointing to GitHub

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ build:
     python: "3.11"
   apt_packages:
     - doxygen
+    - libboost-all-dev
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,5 +49,5 @@ They linkage is given below:
 *. ``simsoptpp``: https://github.com/hiddenSymmetries/simsopt/tree/master/src/simsoptpp
 *. ``examples``: https://github.com/hiddenSymmetries/simsopt/tree/master/examples
 
-So, to point to the ``ci`` folder, use :simsopt:`ci`. Similarly to point to the ``geo`` folder, we use :simsoptpy:`geo`.
+So, to point to the ``ci`` folder, use :simsopt:`ci`. Similarly to point to the ``geo`` folder,  use :simsoptpy:`geo`.
 For pointing to files, use ``simsoptpy_file``, ``simsoptpp_file``, ``example_file``, ``tests_file``.

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,16 @@ They linkage is given below:
 *. ``simsoptpy``: https://github.com/hiddenSymmetries/simsopt/tree/master/src/simsopt
 *. ``simsoptpp``: https://github.com/hiddenSymmetries/simsopt/tree/master/src/simsoptpp
 *. ``examples``: https://github.com/hiddenSymmetries/simsopt/tree/master/examples
+*. ``tests``: https://github.com/hiddenSymmetries/simsopt/tree/master/tests
 
 So, to point to the ``ci`` folder, use :simsopt:`ci`. Similarly to point to the ``geo`` folder,  use :simsoptpy:`geo`.
-For pointing to files, use ``simsoptpy_file``, ``simsoptpp_file``, ``example_file``, ``tests_file``.
+
+For pointing to files, use ``simsopt_file``, ``simsoptpy_file``, ``simsoptpp_file``, ``example_file``, ``tests_file``.
+
+*. ``simsopt_file``: For any file in the simsopt repo
+*. ``simsoptpy_file``: For files in https://github.com/hiddenSymmetries/simsopt/tree/master/src/simsopt
+*. ``simsoptpp_file``: For files in https://github.com/hiddenSymmetries/simsopt/tree/master/src/simsoptpp
+*. ``example_file``: For files in https://github.com/hiddenSymmetries/simsopt/tree/master/examples
+*. ``test_file``: For files in https://github.com/hiddenSymmetries/simsopt/tree/master/tests
+
+So to refer to the ``test_boozersurface.py``, use :test_file:`geo/test_boozersurface.py`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,3 +38,16 @@ Whenever the code is updated, repopulate the code tree and run either step-1  or
 cd docs
 sphinx-apidoc -f -o source ../src/simsopt 
 ```
+
+## Refering to code on GitHub
+
+To point to the simsopt repo on GitHub, use the directives ``simsopt``, ``simsoptpy``, ``simsoptpp``, ``examples``, ``tests``.
+They linkage is given below:
+
+*. ``simsopt``: https://github.com/hiddenSymmetries/simsopt
+*. ``simsoptpy``: https://github.com/hiddenSymmetries/simsopt/tree/master/src/simsopt
+*. ``simsoptpp``: https://github.com/hiddenSymmetries/simsopt/tree/master/src/simsoptpp
+*. ``examples``: https://github.com/hiddenSymmetries/simsopt/tree/master/examples
+
+So, to point to the ``ci`` folder, use :simsopt:`ci`. Similarly to point to the ``geo`` folder, we use :simsoptpy:`geo`.
+For pointing to files, use ``simsoptpy_file``, ``simsoptpp_file``, ``example_file``, ``tests_file``.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx-rtd-theme >= 1.0, < 2.0
 sphinxcontrib-napoleon
 sphinx-autodoc-napoleon-typehints
 breathe
+docutils

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,7 @@ import os
 import sys
 import subprocess
 sys.path.insert(0, os.path.abspath('../../src'))
+sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Run Doxygen -------------------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,7 @@ extensions = [
               'sphinx.ext.mathjax',
               'sphinx.ext.intersphinx',
               'breathe',
+              'link-roles',
 ]
 
 autodoc_mock_imports=['mpi4py', 'pyoculus', 'py_spec']

--- a/docs/source/cpp.rst
+++ b/docs/source/cpp.rst
@@ -4,7 +4,7 @@ Simsopt C++ backend
 ``SIMSOPT`` uses C++ for performance critical functions such as the Biot Savart law, many of the geometric classes, and particle tracing.
 This section is aimed at advanced developers of ``SIMSOPT`` to give an overview over the interface between C++ and Python and to help avoid common pitfalls. For most users of ``SIMSOPT`` this is not relevant.
 
-The C++ code can be found in the folder ``src/simsoptpp``.
+The C++ code can be found in the folder :simsopt:`src/simsoptpp`.
 
 
 pybind11
@@ -16,7 +16,7 @@ The interfacing happens in the ``python.cpp`` and ``python_*.cpp`` files.
 
 Trampoline classes:
 In many cases we define some parent class in C++ that has virtual functions and then we want to inherit from this class on the python side and overload these functions.
-A good example for this is the :mod:`simsoptpp.MagneticField` class. This is the base class for magnetic fields and it takes care of things like caching, or coordinate systems for evaluating magnetic fields. When you create a new magnetic field, you overload functions such as ``B_impl``, in order to compute the magnetic field at given locations. In order for this overload to work on the python side, pybind requires so called `trampoline classes <https://pybind11-jagerman.readthedocs.io/en/latest/advanced/classes.html#overriding-virtual-functions-in-python>`_. In the case of magnetic fields, this can be found in ``src/simsoptpp/pymagneticfield.h``.
+A good example for this is the :mod:`simsoptpp.MagneticField` class. This is the base class for magnetic fields and it takes care of things like caching, or coordinate systems for evaluating magnetic fields. When you create a new magnetic field, you overload functions such as ``B_impl``, in order to compute the magnetic field at given locations. In order for this overload to work on the python side, pybind requires so called `trampoline classes <https://pybind11-jagerman.readthedocs.io/en/latest/advanced/classes.html#overriding-virtual-functions-in-python>`_. In the case of magnetic fields, this can be found in :simsoptpp_file:`pymagneticfield.h`.
 
 
 Lifetime of objects:

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -4,8 +4,9 @@ from docutils import nodes
 from subprocess import run
 
 
-dev run_cmd_get_output(cmd)
+def run_cmd_get_output(cmd):
     return run(cmd).stdout.strip()
+
 
 def get_github_rev():
     path = run_cmd_get_output('git rev-parse --short HEAD')
@@ -29,6 +30,7 @@ def setup(app):
     app.add_role('example_file', autolink('{}/blob/{}/examples/%s'.format(baseurl, rev)))
     app.add_role('tests', autolink('{}/blob/{}/tests/%s'.format(baseurl, rev)))
     app.add_role('tests_file', autolink('{}/blob/{}/tests/%s'.format(baseurl, rev)))
+
 
 def autolink(pattern):
     def role(name, rawtext, text, lineno, inliner, options={}, content=[]):

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -5,11 +5,11 @@ from subprocess import check_output
 
 
 def run_cmd_get_output(cmd):
-    return check_output(cmd).strip()
+    return check_output(cmd).decode('utf-8').strip()
 
 
 def get_github_rev():
-    path = run_cmd_get_output(['git', 'rev-parse', '--short', 'HEAD'])
+    path = run_cmd_get_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
     try:
         tag = run_cmd_get_output(['git', 'describe', '--exact-match'])
         print('Git commit ID: ', path)

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -36,7 +36,7 @@ def setup(app):
     app.add_role('simsoptpp_file', autolink('{}/blob/{}/src/simsoptpp/%s'.format(baseurl, rev)))
     app.add_role('example', autolink('{}/tree/{}/examples/%s'.format(baseurl, rev)))
     app.add_role('example_file', autolink('{}/blob/{}/examples/%s'.format(baseurl, rev)))
-    app.add_role('tests', autolink('{}/blob/{}/tests/%s'.format(baseurl, rev)))
+    app.add_role('tests', autolink('{}/tree/{}/tests/%s'.format(baseurl, rev)))
     app.add_role('tests_file', autolink('{}/blob/{}/tests/%s'.format(baseurl, rev)))
 
 

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -11,7 +11,7 @@ def run_cmd_get_output(cmd):
 def get_github_rev():
     path = run_cmd_get_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
     try:
-        tag = run_cmd_get_output(['git', 'describe', '--exact-match'])
+        tag = run_cmd_get_output(['git', 'describe', '--exact-match', '--tag'])
         print('Git commit ID: ', path)
         if len(tag):
             print('Git tag: ', tag)

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -9,7 +9,7 @@ def run_cmd_get_output(cmd):
 
 
 def get_github_rev():
-    path = run_cmd_get_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
+    path = run_cmd_get_output(['git', 'rev-parse', '--abbrev-ref=strict', 'HEAD'])
     print("==============*********========")
     print('Git branch ID: ', path)
     print("==============*********========")

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -9,7 +9,8 @@ def run_cmd_get_output(cmd):
 
 
 def get_github_rev():
-    path = run_cmd_get_output(['git', 'rev-parse', '--abbrev-ref=strict', 'HEAD'])
+    # path = run_cmd_get_output(['git', 'rev-parse', '--abbrev-ref=strict', 'HEAD'])
+    path = run_cmd_get_output(['git', 'symbolic-ref', '-q',  '--short', 'HEAD'])
     print("==============*********========")
     print('Git branch ID: ', path)
     print("==============*********========")

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -9,8 +9,8 @@ def run_cmd_get_output(cmd):
 
 
 def get_github_rev():
-    # path = run_cmd_get_output(['git', 'rev-parse', '--abbrev-ref=strict', 'HEAD'])
-    path = run_cmd_get_output(['git', 'symbolic-ref', '-q',  '--short', 'HEAD'])
+    path = run_cmd_get_output(['git', 'rev-parse', '--abbrev-ref=strict', 'HEAD'])
+    # path = run_cmd_get_output(['git', 'symbolic-ref', '-q',  '--short', 'HEAD'])
     print("==============*********========")
     print('Git branch ID: ', path)
     print("==============*********========")

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -10,11 +10,15 @@ def run_cmd_get_output(cmd):
 
 def get_github_rev():
     path = run_cmd_get_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
+    print("==============*********========")
+    print('Git branch ID: ', path)
+    print("==============*********========")
     try:
         tag = run_cmd_get_output(['git', 'describe', '--exact-match', '--tag'])
-        print('Git commit ID: ', path)
         if len(tag):
+            print("==============*********========")
             print('Git tag: ', tag)
+            print("==============*********========")
             path = tag
     except:
         pass

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -30,14 +30,15 @@ def setup(app):
     baseurl = 'https://github.com/hiddenSymmetries/simsopt'
     rev = get_github_rev()
     app.add_role('simsopt', autolink('{}/tree/{}/%s'.format(baseurl, rev)))
+    app.add_role('simsopt_file', autolink('{}/blob/{}/%s'.format(baseurl, rev)))
     app.add_role('simsoptpy', autolink('{}/tree/{}/src/simsopt/%s'.format(baseurl, rev)))
     app.add_role('simsoptpy_file', autolink('{}/blob/{}/src/simsopt/%s'.format(baseurl, rev)))
     app.add_role('simsoptpp', autolink('{}/tree/{}/src/simsoptpp/%s'.format(baseurl, rev)))
     app.add_role('simsoptpp_file', autolink('{}/blob/{}/src/simsoptpp/%s'.format(baseurl, rev)))
-    app.add_role('example', autolink('{}/tree/{}/examples/%s'.format(baseurl, rev)))
+    app.add_role('examples', autolink('{}/tree/{}/examples/%s'.format(baseurl, rev)))
     app.add_role('example_file', autolink('{}/blob/{}/examples/%s'.format(baseurl, rev)))
     app.add_role('tests', autolink('{}/tree/{}/tests/%s'.format(baseurl, rev)))
-    app.add_role('tests_file', autolink('{}/blob/{}/tests/%s'.format(baseurl, rev)))
+    app.add_role('test_file', autolink('{}/blob/{}/tests/%s'.format(baseurl, rev)))
 
 
 def autolink(pattern):

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -11,9 +11,9 @@ def run_cmd_get_output(cmd):
 def get_github_rev():
     path = run_cmd_get_output('git rev-parse --short HEAD')
     tag = run_cmd_get_output('git describe --exact-match')
-    print 'Git commit ID: ', path
+    print('Git commit ID: ', path)
     if len(tag):
-        print 'Git tag: ', tag
+        print('Git tag: ', tag)
         path = tag
     return path
 

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -17,7 +17,7 @@ def get_github_rev():
             print('Git tag: ', tag)
             path = tag
     except:
-        continue
+        pass
     return path
 
 

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -10,11 +10,14 @@ def run_cmd_get_output(cmd):
 
 def get_github_rev():
     path = run_cmd_get_output(['git', 'rev-parse', '--short', 'HEAD'])
-    tag = run_cmd_get_output(['git', 'describe', '--exact-match'])
-    print('Git commit ID: ', path)
-    if len(tag):
-        print('Git tag: ', tag)
-        path = tag
+    try:
+        tag = run_cmd_get_output(['git', 'describe', '--exact-match'])
+        print('Git commit ID: ', path)
+        if len(tag):
+            print('Git tag: ', tag)
+            path = tag
+    except:
+        continue
     return path
 
 

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -9,8 +9,8 @@ def run_cmd_get_output(cmd):
 
 
 def get_github_rev():
-    path = run_cmd_get_output('git rev-parse --short HEAD')
-    tag = run_cmd_get_output('git describe --exact-match')
+    path = run_cmd_get_output(['git', 'rev-parse', '--short', 'HEAD'])
+    tag = run_cmd_get_output(['git', 'describe', '--exact-match'])
     print('Git commit ID: ', path)
     if len(tag):
         print('Git tag: ', tag)

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -1,0 +1,38 @@
+# based on http://protips.readthedocs.io/link-roles.html
+
+from docutils import nodes
+from subprocess import run
+
+
+dev run_cmd_get_output(cmd)
+    return run(cmd).stdout.strip()
+
+def get_github_rev():
+    path = run_cmd_get_output('git rev-parse --short HEAD')
+    tag = run_cmd_get_output('git describe --exact-match')
+    print 'Git commit ID: ', path
+    if len(tag):
+        print 'Git tag: ', tag
+        path = tag
+    return path
+
+
+def setup(app):
+    baseurl = 'https://github.com/hiddenSymmetries/simsopt'
+    rev = get_github_rev()
+    app.add_role('simsopt', autolink('{}/tree/{}/%s'.format(baseurl, rev)))
+    app.add_role('simsoptpy', autolink('{}/tree/{}/src/simsopt/%s'.format(baseurl, rev)))
+    app.add_role('simsoptpy_file', autolink('{}/blob/{}/src/simsopt/%s'.format(baseurl, rev)))
+    app.add_role('simsoptpp', autolink('{}/tree/{}/src/simsoptpp/%s'.format(baseurl, rev)))
+    app.add_role('simsoptpp_file', autolink('{}/blob/{}/src/simsoptpp/%s'.format(baseurl, rev)))
+    app.add_role('example', autolink('{}/tree/{}/examples/%s'.format(baseurl, rev)))
+    app.add_role('example_file', autolink('{}/blob/{}/examples/%s'.format(baseurl, rev)))
+    app.add_role('tests', autolink('{}/blob/{}/tests/%s'.format(baseurl, rev)))
+    app.add_role('tests_file', autolink('{}/blob/{}/tests/%s'.format(baseurl, rev)))
+
+def autolink(pattern):
+    def role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+        url = pattern % (text,)
+        node = nodes.reference(rawtext, text, refuri=url, **options)
+        return [node], []
+    return role

--- a/docs/source/link-roles.py
+++ b/docs/source/link-roles.py
@@ -1,11 +1,11 @@
 # based on http://protips.readthedocs.io/link-roles.html
 
 from docutils import nodes
-from subprocess import run
+from subprocess import check_output
 
 
 def run_cmd_get_output(cmd):
-    return run(cmd).stdout.strip()
+    return check_output(cmd).strip()
 
 
 def get_github_rev():


### PR DESCRIPTION
Created the framework to point the code links in the documentation on the ReadTheDocs website to the simsopt GitHub repo. 
I updated the links only in two places in https://simsopt.readthedocs.io/mbk-gh_links/cpp.html. 

One drawback is branch names are not properly generated. The code to generate the branch names is working properly on my laptop and GH runner, but not on RTD runner. Since we point to only master and versioned releases in the docs, this should be OK. I didn't check the links generated for the releases yet. We can only do that after merging the PR and creating a new version of simsopt.

The README in the docs folder contains info on how to add links to GH code. 

