### PR TITLE
Cbs/randomgen 2 numpy

### DIFF
--- a/docs/source/example_coils.rst
+++ b/docs/source/example_coils.rst
@@ -440,7 +440,7 @@ the previous examples, we additionally define::
   Jals = [ArclengthVariation(c) for c in base_curves]
 
   # Objective function for the coils and its perturbations
-  rg = np.random.Generator(PCG64(seed, inc=0))
+  rg = np.random.PCG64DXSM(seed)
   sampler = GaussianSampler(curves[0].quadpoints, SIGMA, L, n_derivs=1)
   Jfs = []
   curves_pert = []

--- a/examples/2_Intermediate/stage_two_optimization_stochastic.py
+++ b/examples/2_Intermediate/stage_two_optimization_stochastic.py
@@ -26,7 +26,7 @@ the latter is independent for each coil.
 
 import os
 from pathlib import Path
-from randomgen import PCG64
+from numpy.random import PCG64DXSM as PCG64
 import numpy as np
 from scipy.optimize import minimize
 from simsopt.field import BiotSavart, Current, Coil, coils_via_symmetries
@@ -125,7 +125,7 @@ Jmscs = [MeanSquaredCurvature(c) for c in base_curves]
 Jals = [ArclengthVariation(c) for c in base_curves]
 
 seed = 0
-rg = np.random.Generator(PCG64(seed, inc=0))
+rg = PCG64(seed)
 
 sampler = GaussianSampler(curves[0].quadpoints, SIGMA, L, n_derivs=1)
 Jfs = []

--- a/examples/2_Intermediate/stage_two_optimization_stochastic.py
+++ b/examples/2_Intermediate/stage_two_optimization_stochastic.py
@@ -26,7 +26,7 @@ the latter is independent for each coil.
 
 import os
 from pathlib import Path
-from numpy.random import PCG64DXSM as PCG64
+from numpy.random import PCG64DXSM, Generator
 import numpy as np
 from scipy.optimize import minimize
 from simsopt.field import BiotSavart, Current, Coil, coils_via_symmetries
@@ -125,7 +125,7 @@ Jmscs = [MeanSquaredCurvature(c) for c in base_curves]
 Jals = [ArclengthVariation(c) for c in base_curves]
 
 seed = 0
-rg = PCG64(seed)
+rg = Generator(PCG64DXSM(seed))
 
 sampler = GaussianSampler(curves[0].quadpoints, SIGMA, L, n_derivs=1)
 Jfs = []
@@ -214,7 +214,7 @@ proc0_print(f"Mean Flux Objective across perturbed coils: {Jmpi.J():.3e}")
 proc0_print(f"Flux Objective for exact coils coils      : {Jf.J():.3e}")
 
 # now draw some fresh samples to evaluate the out-of-sample error
-rg = np.random.Generator(PCG64(seed+1, inc=0))
+rg = Generator(PCG64DXSM(seed+1, inc=0))
 val = 0
 for i in range(N_OOS):
     # first add the 'systematic' error. this error is applied to the base curves and hence the various symmetries are applied to it.

--- a/src/simsopt/geo/curveperturbed.py
+++ b/src/simsopt/geo/curveperturbed.py
@@ -151,7 +151,7 @@ class CurvePerturbed(sopp.Curve, Curve):
 
         .. code-block:: python
 
-            from randomgen import SeedSequence, PCG64
+            from np.random import SeedSequence, PCG64DXSM
             import numpy as np
             curves = ...
             sigma = 0.01
@@ -163,7 +163,7 @@ class CurvePerturbed(sopp.Curve, Curve):
             idx_start, idx_end = split_range_between_mpi_rank(N) # e.g. [0, 5) on rank 0, [5, 10) on rank 1
             perturbed_curves = [] # this will be a List[List[Curve]], with perturbed_curves[i] containing the perturbed curves for the i-th stellarator
             for i in range(idx_start, idx_end):
-                rg = np.random.Generator(PCG64(seeds_sys[j], inc=0))
+                rg = np.random.Generator(PCG64DXSM(seeds_sys[j], inc=0))
                 stell = []
                 for c in curves:
                     pert = PerturbationSample(sampler_systematic, randomgen=rg)

--- a/src/simsopt/geo/curveperturbed.py
+++ b/src/simsopt/geo/curveperturbed.py
@@ -151,7 +151,7 @@ class CurvePerturbed(sopp.Curve, Curve):
 
         .. code-block:: python
 
-            from np.random import SeedSequence, PCG64DXSM
+            from np.random import SeedSequence, PCG64DXSM, Generator
             import numpy as np
             curves = ...
             sigma = 0.01
@@ -163,7 +163,7 @@ class CurvePerturbed(sopp.Curve, Curve):
             idx_start, idx_end = split_range_between_mpi_rank(N) # e.g. [0, 5) on rank 0, [5, 10) on rank 1
             perturbed_curves = [] # this will be a List[List[Curve]], with perturbed_curves[i] containing the perturbed curves for the i-th stellarator
             for i in range(idx_start, idx_end):
-                rg = np.random.Generator(PCG64DXSM(seeds_sys[j], inc=0))
+                rg = Generator(PCG64DXSM(seeds_sys[j], inc=0))
                 stell = []
                 for c in curves:
                     pert = PerturbationSample(sampler_systematic, randomgen=rg)

--- a/tests/geo/test_curveperturbed.py
+++ b/tests/geo/test_curveperturbed.py
@@ -1,5 +1,5 @@
 import unittest
-from randomgen import PCG64
+from numpy.random import PCG64DXSM, Generator
 import json
 
 import numpy as np
@@ -17,7 +17,7 @@ class CurvePerturbationTesting(unittest.TestCase):
         length_scale = 0.5
         points = np.linspace(0, 1, 200, endpoint=False)
         sampler = GaussianSampler(points, sigma, length_scale, n_derivs=2)
-        rg = np.random.Generator(PCG64(1))
+        rg = Generator(PCG64DXSM(1))
         sample = PerturbationSample(sampler, randomgen=rg)
 
         dphi = points[1]
@@ -42,7 +42,7 @@ class CurvePerturbationTesting(unittest.TestCase):
         n = 100
         points = np.linspace(0, 2, 2*n, endpoint=False)
         sampler = GaussianSampler(points, sigma, length_scale, n_derivs=0)
-        rg = np.random.Generator(PCG64(1))
+        rg = Generator(PCG64DXSM(1))
         sample = PerturbationSample(sampler, randomgen=rg)
         periodic_err = np.abs(sample[0][:n, :] - sample[0][n:, :])
         print("periodic_err", np.mean(periodic_err))
@@ -55,7 +55,7 @@ class CurvePerturbationTesting(unittest.TestCase):
         length_scale = 0.5
         points = np.linspace(0, 1, 200, endpoint=False)
         sampler = GaussianSampler(points, sigma, length_scale, n_derivs=3)
-        rg = np.random.Generator(PCG64(1))
+        rg = Generator(PCG64DXSM(1))
         sample = PerturbationSample(sampler, randomgen=rg)
 
         order = 4
@@ -94,7 +94,7 @@ class CurvePerturbationTesting(unittest.TestCase):
         length_scale = 0.2
         points = np.linspace(0, 1, 200, endpoint=False)
         sampler = GaussianSampler(points, sigma, length_scale, n_derivs=1)
-        rg = np.random.Generator(PCG64(1))
+        rg = Generator(PCG64DXSM(1))
         sample1 = PerturbationSample(sampler, randomgen=rg)
         sample2 = PerturbationSample(sampler, randomgen=rg)
 


### PR DESCRIPTION
randomgen was the last import that did not play nicely with numy2.0. (see #427)

Though it does now, It is probably beter to remove dependency on a rarely maintained package, so I updated to use numpy.random.PCG64DXSM. 