### PR TITLE
Cbs/change resolution fix

### DIFF
--- a/docs/source/example_islands.rst
+++ b/docs/source/example_islands.rst
@@ -47,7 +47,7 @@ configuration contains only modes up to m=3, we must increase the
 number of modes in the boundary shape in order to have m=6 modes
 available to vary::
 
-  s.boundary.change_resolution(6, s.boundary.ntor)
+  s.boundary = s.boundary.change_resolution(6, s.boundary.ntor)
 
 Now we can pick out a few modes of the boundary shape to vary in the
 optimization::

--- a/examples/2_Intermediate/eliminate_magnetic_islands.py
+++ b/examples/2_Intermediate/eliminate_magnetic_islands.py
@@ -33,7 +33,7 @@ s = Spec(os.path.join(os.path.dirname(__file__), 'inputs', 'QH-residues.sp'),
          mpi=mpi)
 
 # Expand number of Fourier modes to include larger poloidal mode numbers:
-s.boundary.change_resolution(6, s.boundary.ntor)
+s.boundary = s.boundary.change_resolution(6, s.boundary.ntor)
 # To make this example run relatively quickly, we will optimize in a
 # small parameter space. Here we pick out just 2 Fourier modes to vary
 # in the optimization:

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -564,51 +564,24 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
             else:
                 kwargs["quadpoints_phi"] = quadpoints_phi
         # create new surface in old resolution
-        surf = SurfaceRZFourier(mpol=self.mpol, ntor=self.ntor, nfp=nfp, stellsym=stellsym,
+        surf = SurfaceRZFourier(mpol=mpol, ntor=ntor, nfp=nfp, stellsym=stellsym,
                                 **kwargs)
-        surf.rc[:, :] = self.rc
-        surf.zs[:, :] = self.zs
-        if not self.stellsym:
-            surf.rs[:, :] = self.rs
-            surf.zc[:, :] = self.zc
-        # set to the requested resolution
-        surf.change_resolution(mpol, ntor)
+        for m in range(0, mpol):
+            for n in range(-ntor, ntor+1):
+                surf.set_rc(m, n, self.get_rc(m, n))
+                surf.set_zs(m, n, self.get_zs(m, n))
+                if self.stellsym:
+                    surf.set_rs(m, n, self.get_rc(m, n))
+                    surf.set_rs(m, n, self.get_rs(m, n))
+
         surf.local_full_x = surf.get_dofs()
         return surf
 
     def change_resolution(self, mpol, ntor):
         """
-        Change the values of `mpol` and `ntor`. Any new Fourier amplitudes
-        will have a magnitude of zero.  Any previous nonzero Fourier
-        amplitudes that are not within the new range will be
-        discarded.
+        return a new surface with Fourier resolution mpol, ntor
         """
-        old_mpol = self.mpol
-        old_ntor = self.ntor
-        old_rc = self.rc
-        old_zs = self.zs
-        if not self.stellsym:
-            old_rs = self.rs
-            old_zc = self.zc
-        self.mpol = mpol
-        self.ntor = ntor
-        self.allocate()
-        if mpol < old_mpol or ntor < old_ntor:
-            self.invalidate_cache()
-
-        min_mpol = np.min((mpol, old_mpol))
-        min_ntor = np.min((ntor, old_ntor))
-        for m in range(min_mpol + 1):
-            for n in range(-min_ntor, min_ntor + 1):
-                self.rc[m, n + ntor] = old_rc[m, n + old_ntor]
-                self.zs[m, n + ntor] = old_zs[m, n + old_ntor]
-                if not self.stellsym:
-                    self.rs[m, n + ntor] = old_rs[m, n + old_ntor]
-                    self.zc[m, n + ntor] = old_zc[m, n + old_ntor]
-        self._make_mn()
-
-        # Update the dofs object
-        self.replace_dofs(DOFs(self.get_dofs(), self._make_names()))
+        return self.copy(mpol=mpol, ntor=ntor)
 
     def to_RZFourier(self):
         """
@@ -1281,10 +1254,8 @@ class SurfaceRZPseudospectral(Optimizable):
             mpol: The new maximum poloidal mode number.
             ntor: The new maximum toroidal mode number, divided by ``nfp``.
         """
-        # Map to Fourier space:
-        surf2 = self.to_RZFourier()
-        # Change the resolution in Fourier space, by truncating the modes or padding 0s:
-        surf2.change_resolution(mpol=mpol, ntor=ntor)
+        # Map to Fourier space and return a surface with changed resolution
+        surf2 = self.to_RZFourier().change_resolution(mpol=mpol, ntor=ntor)
         # Map from Fourier space back to real space:
         surf3 = SurfaceRZPseudospectral.from_RZFourier(surf2,
                                                        r_shift=self.r_shift,

--- a/tests/geo/test_surface_rzfourier.py
+++ b/tests/geo/test_surface_rzfourier.py
@@ -403,9 +403,9 @@ class SurfaceRZFourierTests(unittest.TestCase):
         wout_filename = TEST_DIR / 'wout_LandremanPaul2021_QH_reactorScale_lowres_reference.nc'
         plasma_surf = SurfaceRZFourier.from_wout(wout_filename, range="full torus", ntheta=100, nphi=400)
 
-        coil_surf = SurfaceRZFourier.from_wout(wout_filename, range="half period", ntheta=71, nphi=70)
+        coil_surf_load = SurfaceRZFourier.from_wout(wout_filename, range="half period", ntheta=71, nphi=70)
         # Increase Fourier resolution so we can represent the surface accurately
-        coil_surf.change_resolution(24, 24)
+        coil_surf = coil_surf_load.change_resolution(24, 24)
         separation = 3.0
         coil_surf.extend_via_normal(separation)
 
@@ -437,9 +437,9 @@ class SurfaceRZFourierTests(unittest.TestCase):
         wout_filename = TEST_DIR / 'wout_LandremanSenguptaPlunk_section5p3_reference.nc'
         plasma_surf = SurfaceRZFourier.from_wout(wout_filename, range="full torus", ntheta=100, nphi=400)
 
-        coil_surf = SurfaceRZFourier.from_wout(wout_filename, range="field period", ntheta=101, nphi=100)
+        coil_surf_load = SurfaceRZFourier.from_wout(wout_filename, range="field period", ntheta=101, nphi=100)
         # Increase Fourier resolution so we can represent the surface accurately
-        coil_surf.change_resolution(24, 24)
+        coil_surf = coil_surf_load.change_resolution(24, 24)
         separation = 0.2
         coil_surf.extend_via_normal(separation)
 
@@ -522,33 +522,30 @@ class SurfaceRZFourierTests(unittest.TestCase):
         """
         for mpol in [1, 2]:
             for ntor in [0, 1]:
-                s = SurfaceRZFourier(mpol=mpol, ntor=ntor)
-                n = len(s.get_dofs())
-                s.set_dofs((np.random.rand(n) - 0.5) * 0.01)
-                s.set_rc(0, 0, 1.0)
-                s.set_rc(1, 0, 0.1)
-                s.set_zs(1, 0, 0.13)
-                v1 = s.volume()
-                a1 = s.area()
+                s_orig = SurfaceRZFourier(mpol=mpol, ntor=ntor)
+                n = len(s_orig.get_dofs())
+                s_orig.set_dofs((np.random.rand(n) - 0.5) * 0.01)
+                s_orig.set_rc(0, 0, 1.0)
+                s_orig.set_rc(1, 0, 0.1)
+                s_orig.set_zs(1, 0, 0.13)
+                v1 = s_orig.volume()
+                a1 = s_orig.area()
 
-                s.change_resolution(mpol+1, ntor)
-                s.recalculate = True
+                s = s_orig.change_resolution(mpol+1, ntor)
                 v2 = s.volume()
                 a2 = s.area()
                 self.assertAlmostEqual(v1, v2)
                 self.assertAlmostEqual(a1, a2)
 
-                s.change_resolution(mpol, ntor+1)
-                s.recalculate = True
-                v2 = s.volume()
-                a2 = s.area()
+                s2 = s.change_resolution(mpol, ntor+1)
+                v2 = s2.volume()
+                a2 = s2.area()
                 self.assertAlmostEqual(v1, v2)
                 self.assertAlmostEqual(a1, a2)
 
-                s.change_resolution(mpol+1, ntor+1)
-                s.recalculate = True
-                v2 = s.volume()
-                a2 = s.area()
+                s3 = s2.change_resolution(mpol+1, ntor+1)
+                v2 = s3.volume()
+                a2 = s3.area()
                 self.assertAlmostEqual(v1, v2)
                 self.assertAlmostEqual(a1, a2)
 

--- a/tests/mhd/test_integrated_mpi.py
+++ b/tests/mhd/test_integrated_mpi.py
@@ -167,7 +167,7 @@ class IntegratedTests(unittest.TestCase):
                 s = Spec(filename, mpi=mpi)
 
                 # Expand number of Fourier modes to include larger poloidal mode numbers:
-                s.boundary.change_resolution(6, s.boundary.ntor)
+                s.boundary = s.boundary.change_resolution(6, s.boundary.ntor)
                 # To make this example run relatively quickly, we will optimize in a
                 # small parameter space. Here we pick out just 2 Fourier modes to vary
                 # in the optimization:


### PR DESCRIPTION
This adapts the change_resolution to return a copy of the surface, fixes the issue with the cpp backend #478, and aligns it with the return signature of `SurfaceRZPseudospectral.change_resolution`. 