### PR TITLE
Simple change in test_biotsavart to use more quadrature points for th…

### DIFF
--- a/tests/field/test_biotsavart.py
+++ b/tests/field/test_biotsavart.py
@@ -360,6 +360,7 @@ class Testing(unittest.TestCase):
     def test_flux_through_disk(self):
         # this test makes sure that the toroidal flux through a disk (D)
         # given by \int_D B \cdot n dB = \int_{\partial D} A \cdot dl
+        np.random.seed(1)
 
         from scipy.spatial.transform import Rotation as R
         rot = R.from_euler('zyx', [21.234, 8.431, -4.86392], degrees=True).as_matrix()
@@ -383,7 +384,10 @@ class Testing(unittest.TestCase):
         r = 0.15
         fluxB = integrate.dblquad(f, 0, r, 0, 2*np.pi, epsabs=1e-15, epsrel=1e-15)
 
-        for num in range(20, 60):
+        # num range used to be (20, 60) but this fails for num <= 20-30 for certain
+        # random coil initializations since don't have enough quadrature points
+        # to integrate to numerical precision.
+        for num in range(40, 100):
             npoints = num
             angles = np.linspace(0, 2*np.pi, npoints, endpoint=False).reshape((-1, 1))
             t = np.concatenate((-np.sin(angles), np.cos(angles), np.zeros((angles.size, 1))), axis=1) @ rot.T
@@ -391,7 +395,6 @@ class Testing(unittest.TestCase):
             bs.set_points(pts)
             A = bs.A()
             fluxA = r*np.sum(A*t) * 2 * np.pi/npoints
-
             assert np.abs(fluxB[0]-fluxA)/fluxB[0] < 1e-14
 
     def test_biotsavart_vector_potential_coil_current_taylortest(self):


### PR DESCRIPTION
For certain initializations with 20-30 points, the biot savart flux test was failing (at least on my Mac) and adding more quadrature points and a random seed is sufficient to fix it. 