### PR TITLE
Curveplanar jacobian fix

### DIFF
--- a/src/simsopt/geo/curve.py
+++ b/src/simsopt/geo/curve.py
@@ -900,7 +900,7 @@ def create_equally_spaced_planar_curves(ncurves, nfp, stellsym, R0=1.0, R1=0.5, 
     from simsopt.geo.curveplanarfourier import CurvePlanarFourier
     for k in range(ncurves):
         angle = (k+0.5)*(2*np.pi) / ((1+int(stellsym))*nfp*ncurves)
-        curve = CurvePlanarFourier(numquadpoints, order, nfp, stellsym)
+        curve = CurvePlanarFourier(numquadpoints, order)
 
         rcCoeffs = np.zeros(order+1)
         rcCoeffs[0] = R1

--- a/src/simsopt/geo/curveplanarfourier.py
+++ b/src/simsopt/geo/curveplanarfourier.py
@@ -1,18 +1,20 @@
 import numpy as np
-
+import jax.numpy as jnp
+from itertools import chain
 import simsoptpp as sopp
-from .curve import Curve
+from .curve import Curve, JaxCurve
 
-__all__ = ['CurvePlanarFourier']
+__all__ = ['CurvePlanarFourier', 'JaxCurvePlanarFourier']
 
 
 class CurvePlanarFourier(sopp.CurvePlanarFourier, Curve):
     r"""
     ``CurvePlanarFourier`` is a curve that is restricted to lie in a plane. The
     shape of the curve within the plane is represented by a Fourier series in
-    polar coordinates. The resulting planar curve is then rotated in three
-    dimensions using a quaternion, and finally a translation is applied. The
-    Fourier series in polar coordinates is
+    polar coordinates centered at the center of curve. 
+    The resulting planar curve is then rotated in three
+    dimensions using a quaternion, and finally a translation is applied by the center point
+    (X, Y, Z). The Fourier series in polar coordinates is
 
     .. math::
 
@@ -43,23 +45,28 @@ class CurvePlanarFourier(sopp.CurvePlanarFourier, Curve):
     The dofs are stored in the order
 
     .. math::
-       [r_{c,0}, \cdots, r_{c,\text{order}}, r_{s,1}, \cdots, r_{s,\text{order}}, q_0, q_i, q_j, q_k, x_{\text{center}}, y_{\text{center}}, z_{\text{center}}]
+       [r_{c,0}, \cdots, r_{c,\text{order}}, r_{s,1}, \cdots, r_{s,\text{order}}, q_0, q_i, q_j, q_k, X, Y, Z]
 
-
+    Args:
+        quadpoints (array): Array of quadrature points.
+        order (int): Order of the Fourier series.
+        dofs (array): Array of dofs.
     """
 
-    def __init__(self, quadpoints, order, nfp, stellsym, dofs=None):
+    def __init__(self, quadpoints, order, dofs=None):
         if isinstance(quadpoints, int):
             quadpoints = list(np.linspace(0, 1., quadpoints, endpoint=False))
         elif isinstance(quadpoints, np.ndarray):
             quadpoints = list(quadpoints)
-        sopp.CurvePlanarFourier.__init__(self, quadpoints, order, nfp, stellsym)
+        sopp.CurvePlanarFourier.__init__(self, quadpoints, order)
         if dofs is None:
             Curve.__init__(self, external_dof_setter=CurvePlanarFourier.set_dofs_impl,
+                           names=self._make_names(order),
                            x0=self.get_dofs())
         else:
             Curve.__init__(self, external_dof_setter=CurvePlanarFourier.set_dofs_impl,
-                           dofs=dofs)
+                           dofs=dofs,
+                           names=self._make_names(order))
 
     def get_dofs(self):
         """
@@ -73,3 +80,133 @@ class CurvePlanarFourier(sopp.CurvePlanarFourier, Curve):
         """
         self.local_x = dofs
         sopp.CurvePlanarFourier.set_dofs(self, dofs)
+
+    def _make_names(self, order):
+        """
+        This function returns the names of the dofs associated to this object.
+
+        Args:
+            order (int): Order of the Fourier series.
+
+        Returns:
+            List of dof names.
+        """
+        x_names = ['rc(0)']
+        x_cos_names = [f'rc({i})' for i in range(1, order + 1)]
+        x_sin_names = [f'rs({i})' for i in range(1, order + 1)]
+        x_names += list(chain.from_iterable(zip(x_sin_names, x_cos_names)))
+
+        y_names = ['q0', 'qi', 'qj', 'qk']
+        z_names = ['X', 'Y', 'Z']
+        return x_names + y_names + z_names
+        
+
+
+def jaxplanarcurve_pure(dofs, quadpoints, order):
+    """
+    This pure function returns the curve in the plane.
+
+    Args:
+        dofs (array): Array of dofs.
+        quadpoints (array): Array of quadrature points.
+        order (int): Order of the Fourier series.
+
+    Returns:
+        Array of curve points.
+    """
+    coeffs = dofs[:2 * order + 1]
+    q = dofs[2 * order + 1: 2 * order + 5]
+    norm_q = jnp.linalg.norm(q)
+    q_norm = jnp.where(norm_q < 1e-8,
+                       q / (norm_q + 1e-8),  # safe division when norm is small
+                       q / norm_q)  # this shouldn't happen if the quaternion dofs are properly initialized
+    center = dofs[2 * order + 5:]
+    phi = 2 * np.pi * quadpoints  # points is an angle in [0, 1]
+    jrange = jnp.arange(1, order + 1)[:, None]
+    jphi = jrange * phi[None, :]
+    r_curve = coeffs[0] + jnp.sum(coeffs[1:order + 1, None] * jnp.cos(jphi)
+                                  + coeffs[order + 1: 2 * order + 1, None] * jnp.sin(jphi), axis=0)
+
+    x_curve_in_plane = r_curve * jnp.cos(phi)
+    y_curve_in_plane = r_curve * jnp.sin(phi)
+    # apply the quaternion rotation
+    return jnp.transpose(jnp.vstack((jnp.vstack(((1.0 - 2 * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3])) * x_curve_in_plane
+                                                 + 2 * (q_norm[1] * q_norm[2] - q_norm[3] * q_norm[0]) * y_curve_in_plane
+                                                 + center[0], (1.0 - 2 * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3])) * y_curve_in_plane
+                                                 + 2 * (q_norm[0] * q_norm[3] + q_norm[1] * q_norm[2]) * x_curve_in_plane
+                                                 + center[1])), 2 * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * x_curve_in_plane
+                                     + 2 * (q_norm[0] * q_norm[1] + q_norm[2] * q_norm[3]) * y_curve_in_plane
+                                     + center[2])))
+
+
+class JaxCurvePlanarFourier(JaxCurve):
+
+    """
+    A Python+Jax implementation of the CurvePlanarFourier class.  There is
+    actually no reason why one should use this over the C++ implementation in
+    :mod:`simsoptpp`, but the point of this class is to illustrate how jax can be used
+    to define a geometric object class and calculate all the derivatives (both
+    with respect to dofs and with respect to the angle :math:`\theta`) automatically.
+
+    [r_{c,0}, \cdots, r_{c,\text{order}}, r_{s,1}, \cdots, r_{s,\text{order}}, 
+    q_0, q_i, q_j, q_k, 
+    x_{\text{center}}, y_{\text{center}}, z_{\text{center}}]
+
+    Args:
+        quadpoints (array): Array of quadrature points.
+        order (int): Order of the Fourier series.
+        dofs (array): Array of dofs.
+    """
+
+    def __init__(self, quadpoints, order, dofs=None):
+        if isinstance(quadpoints, int):
+            quadpoints = np.linspace(0, 1, quadpoints, endpoint=False)
+
+        def pure(dofs, points): return jaxplanarcurve_pure(dofs, points, order)
+        self.order = order
+        self.dof_list = np.zeros(2 * order + 1 + 4 + 3)
+        if dofs is None:
+            super().__init__(quadpoints, pure, x0=self.dof_list,
+                             names=self._make_names(order),
+                             external_dof_setter=JaxCurvePlanarFourier.set_dofs_impl)
+        else:
+            super().__init__(quadpoints, pure, dofs=dofs,
+                             names=self._make_names(order),
+                             external_dof_setter=JaxCurvePlanarFourier.set_dofs_impl)
+
+    def num_dofs(self):
+        """
+        This function returns the number of dofs associated to this object.
+        """
+        return (2 * self.order + 1 + 4 + 3)
+
+    def get_dofs(self):
+        """
+        This function returns the dofs associated to this object.
+        """
+        return np.array(self.dof_list)
+
+    def set_dofs_impl(self, dofs):
+        """
+        This function sets the dofs associated to this object.
+        """
+        self.dof_list = np.array(dofs)
+
+    def _make_names(self, order):
+        """
+        This function returns the names of the dofs associated to this object.
+
+        Args:
+            order (int): Order of the Fourier series.
+
+        Returns:
+            List of dof names.
+        """
+        x_names = ['rc(0)']
+        x_cos_names = [f'rc({i})' for i in range(1, order + 1)]
+        x_sin_names = [f'rs({i})' for i in range(1, order + 1)]
+        x_names += list(chain.from_iterable(zip(x_sin_names, x_cos_names)))
+
+        y_names = ['q0', 'qi', 'qj', 'qk']
+        z_names = ['X', 'Y', 'Z']
+        return x_names + y_names + z_names

--- a/src/simsoptpp/curveplanarfourier.cpp
+++ b/src/simsoptpp/curveplanarfourier.cpp
@@ -16,9 +16,7 @@ void CurvePlanarFourier<Array>::gamma_impl(Array& data, Array& quadpoints) {
     double sinphi, cosphi, siniphi, cosiphi;
     int numquadpoints = quadpoints.size();
     data *= 0;
-
     Array q_norm = q * inv_magnitude();
-
 
     for (int k = 0; k < numquadpoints; ++k) {
         double phi = 2 * M_PI * quadpoints[k];
@@ -211,6 +209,7 @@ void CurvePlanarFourier<Array>::dgamma_by_dcoeff_impl(Array& data) {
             counter++;
         }
 
+        // i and j represent X0 and Y0 here before applying rotation
         i = rc[0] * cosphi;
         j = rc[0] * sinphi;
         k = 0;
@@ -224,279 +223,57 @@ void CurvePlanarFourier<Array>::dgamma_by_dcoeff_impl(Array& data) {
         double inv_sqrt_s = inv_magnitude();
         
         data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (inv_sqrt_s - q[0] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (- q[1] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (- q[2] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0]) 
-                            * (- q[3] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+                            - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0] + 0.5 * q_norm[3]))
+                            * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[0] - 0.5 * q_norm[3]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (inv_sqrt_s - q[0] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (- q[1] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (- q[2] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (- q[3] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
-
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (inv_sqrt_s - q[0] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (- q[1] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (- q[2] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (- q[3] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[0] + 0.5 * q_norm[2])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[0] - 0.5 * q_norm[1]))
+                            * inv_sqrt_s;
         counter++;
 
-        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0] 
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (- q[0] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (inv_sqrt_s - q[1] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (- q[2] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0])
-                            * (- q[3] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
+                    - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1] - 0.5 * q_norm[2]))
+                    * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3] - 1.0) * q_norm[1]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[1] - 0.5 * q_norm[2]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (- q[0] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (inv_sqrt_s - q[1] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (- q[2] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (- q[3] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[1] - 0.5 * q_norm[3])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[1] - 0.5 * q_norm[0]))
+                            * inv_sqrt_s;
 
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (- q[0] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (inv_sqrt_s - q[1] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (- q[2] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (- q[3] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
         counter++;
 
-        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0] 
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (- q[0] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            + 
-                            (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (- q[1] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (inv_sqrt_s - q[2] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0]) 
-                            * (- q[3] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3] - 1.0) * q_norm[2]
+            - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2] - 0.5 * q_norm[1]))
+            * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[2] - 0.5 * q_norm[1]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (- q[0] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (- q[1] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (inv_sqrt_s - q[2] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (- q[3] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2] + 0.5 * q_norm[0])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[2] - 0.5 * q_norm[3]))
+                            * inv_sqrt_s;
 
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (- q[0] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (- q[1] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (inv_sqrt_s - q[2] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (- q[3] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
         counter++;
 
-        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0] 
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (- q[0] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            + (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (- q[1] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (- q[2] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +                            
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0]) 
-                            * (inv_sqrt_s - q[3] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3] - 1.0) * q_norm[3]
+            - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3] + 0.5 * q_norm[0]))
+            * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3] - 1.0) * q_norm[3]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[3] - 0.5 * q_norm[0]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (- q[0] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (- q[1] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (- q[2] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (inv_sqrt_s - q[3] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
-
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (- q[0] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (- q[1] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (- q[2] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (inv_sqrt_s - q[3] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[3] - 0.5 * q_norm[1])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[3] - 0.5 * q_norm[2]))
+                            * inv_sqrt_s;
         counter++;
 
 
@@ -577,279 +354,57 @@ void CurvePlanarFourier<Array>::dgammadash_by_dcoeff_impl(Array& data) {
         double inv_sqrt_s = inv_magnitude();
 
         data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (inv_sqrt_s - q[0] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (- q[1] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (- q[2] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0]) 
-                            * (- q[3] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+                            - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0] + 0.5 * q_norm[3]))
+                            * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[0] - 0.5 * q_norm[3]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (inv_sqrt_s - q[0] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (- q[1] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (- q[2] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (- q[3] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
-
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (inv_sqrt_s - q[0] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (- q[1] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (- q[2] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (- q[3] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[0] + 0.5 * q_norm[2])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[0] - 0.5 * q_norm[1]))
+                            * inv_sqrt_s;
         counter++;
 
-        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0] 
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (- q[0] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (inv_sqrt_s - q[1] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (- q[2] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0])
-                            * (- q[3] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
+                    - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1] - 0.5 * q_norm[2]))
+                    * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3] - 1.0) * q_norm[1]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[1] - 0.5 * q_norm[2]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (- q[0] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (inv_sqrt_s - q[1] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (- q[2] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (- q[3] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[1] - 0.5 * q_norm[3])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[1] - 0.5 * q_norm[0]))
+                            * inv_sqrt_s;
 
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (- q[0] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (inv_sqrt_s - q[1] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (- q[2] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (- q[3] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
         counter++;
 
-        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0] 
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (- q[0] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            + 
-                            (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (- q[1] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (inv_sqrt_s - q[2] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0]) 
-                            * (- q[3] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3] - 1.0) * q_norm[2]
+            - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2] - 0.5 * q_norm[1]))
+            * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[2] - 0.5 * q_norm[1]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (- q[0] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (- q[1] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (inv_sqrt_s - q[2] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (- q[3] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2] + 0.5 * q_norm[0])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[2] - 0.5 * q_norm[3]))
+                            * inv_sqrt_s;
 
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (- q[0] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (- q[1] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (inv_sqrt_s - q[2] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (- q[3] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
         counter++;
 
-        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0] 
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (- q[0] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            + (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (- q[1] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (- q[2] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +                            
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0]) 
-                            * (inv_sqrt_s - q[3] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3] - 1.0) * q_norm[3]
+            - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3] + 0.5 * q_norm[0]))
+            * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3] - 1.0) * q_norm[3]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[3] - 0.5 * q_norm[0]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (- q[0] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (- q[1] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (- q[2] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (inv_sqrt_s - q[3] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
-
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (- q[0] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (- q[1] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (- q[2] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (inv_sqrt_s - q[3] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[3] - 0.5 * q_norm[1])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[3] - 0.5 * q_norm[2]))
+                            * inv_sqrt_s;
         counter++;
 
         for (int i = 0; i < 2; ++i) {
@@ -931,279 +486,57 @@ void CurvePlanarFourier<Array>::dgammadashdash_by_dcoeff_impl(Array& data) {
         double inv_sqrt_s = inv_magnitude();
         
         data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (inv_sqrt_s - q[0] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (- q[1] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (- q[2] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0]) 
-                            * (- q[3] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+                            - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0] + 0.5 * q_norm[3]))
+                            * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[0] - 0.5 * q_norm[3]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (inv_sqrt_s - q[0] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (- q[1] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (- q[2] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (- q[3] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
-
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (inv_sqrt_s - q[0] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (- q[1] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (- q[2] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (- q[3] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[0] + 0.5 * q_norm[2])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[0] - 0.5 * q_norm[1]))
+                            * inv_sqrt_s;
         counter++;
 
-        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0] 
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (- q[0] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (inv_sqrt_s - q[1] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (- q[2] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0])
-                            * (- q[3] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
+                    - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1] - 0.5 * q_norm[2]))
+                    * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3] - 1.0) * q_norm[1]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[1] - 0.5 * q_norm[2]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (- q[0] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (inv_sqrt_s - q[1] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (- q[2] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (- q[3] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[1] - 0.5 * q_norm[3])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[1] - 0.5 * q_norm[0]))
+                            * inv_sqrt_s;
 
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (- q[0] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (inv_sqrt_s - q[1] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (- q[2] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (- q[3] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
         counter++;
 
-        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0] 
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (- q[0] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            + 
-                            (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (- q[1] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (inv_sqrt_s - q[2] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0]) 
-                            * (- q[3] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3] - 1.0) * q_norm[2]
+            - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2] - 0.5 * q_norm[1]))
+            * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[2] - 0.5 * q_norm[1]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (- q[0] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (- q[1] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (inv_sqrt_s - q[2] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (- q[3] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2] + 0.5 * q_norm[0])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[2] - 0.5 * q_norm[3]))
+                            * inv_sqrt_s;
 
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (- q[0] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (- q[1] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (inv_sqrt_s - q[2] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (- q[3] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
         counter++;
 
-        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0] 
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (- q[0] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            + (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (- q[1] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (- q[2] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +                            
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0]) 
-                            * (inv_sqrt_s - q[3] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3] - 1.0) * q_norm[3]
+            - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3] + 0.5 * q_norm[0]))
+            * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3] - 1.0) * q_norm[3]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[3] - 0.5 * q_norm[0]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (- q[0] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (- q[1] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (- q[2] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (inv_sqrt_s - q[3] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
-
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (- q[0] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (- q[1] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (- q[2] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (inv_sqrt_s - q[3] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[3] - 0.5 * q_norm[1])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[3] - 0.5 * q_norm[2]))
+                            * inv_sqrt_s;
         counter++;
 
         for (int i = 0; i < 3; ++i) {
@@ -1306,279 +639,57 @@ void CurvePlanarFourier<Array>::dgammadashdashdash_by_dcoeff_impl(Array& data) {
         double inv_sqrt_s = inv_magnitude();
         
         data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (inv_sqrt_s - q[0] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (- q[1] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (- q[2] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0]) 
-                            * (- q[3] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+                            - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0] + 0.5 * q_norm[3]))
+                            * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[0] - 0.5 * q_norm[3]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (inv_sqrt_s - q[0] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (- q[1] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (- q[2] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (- q[3] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
-
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (inv_sqrt_s - q[0] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (- q[1] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (- q[2] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (- q[3] * q[0] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[0] + 0.5 * q_norm[2])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[0] - 0.5 * q_norm[1]))
+                            * inv_sqrt_s;
         counter++;
 
-        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0] 
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (- q[0] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (inv_sqrt_s - q[1] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (- q[2] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0])
-                            * (- q[3] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
+                    - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1] - 0.5 * q_norm[2]))
+                    * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3] - 1.0) * q_norm[1]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[1] - 0.5 * q_norm[2]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (- q[0] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (inv_sqrt_s - q[1] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (- q[2] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (- q[3] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[1] - 0.5 * q_norm[3])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[1] - 0.5 * q_norm[0]))
+                            * inv_sqrt_s;
 
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (- q[0] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (inv_sqrt_s - q[1] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (- q[2] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (- q[3] * q[1] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
         counter++;
 
-        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0] 
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (- q[0] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            + 
-                            (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (- q[1] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (inv_sqrt_s - q[2] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0]) 
-                            * (- q[3] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3] - 1.0) * q_norm[2]
+            - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2] - 0.5 * q_norm[1]))
+            * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[2] - 0.5 * q_norm[1]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (- q[0] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (- q[1] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (inv_sqrt_s - q[2] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (- q[3] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2] + 0.5 * q_norm[0])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[2] - 0.5 * q_norm[3]))
+                            * inv_sqrt_s;
 
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (- q[0] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (- q[1] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (inv_sqrt_s - q[2] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (- q[3] * q[2] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
         counter++;
 
-        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[0] 
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[0]
-                            - 2 * j * q_norm[3]) 
-                            * (- q[0] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            + (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[2]) 
-                            * (- q[1] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[0] * q_norm[0] + q_norm[1] * q_norm[1]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[1]) 
-                            * (- q[2] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +                            
-                            (- 4 * i * (q_norm[1] * q_norm[1] + q_norm[0] * q_norm[0]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3]
-                            - 2 * j * q_norm[0]) 
-                            * (inv_sqrt_s - q[3] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 0, counter) = (4 * i * (q_norm[2] * q_norm[2] + q_norm[3] * q_norm[3] - 1.0) * q_norm[3]
+            - 4 * j * ((q_norm[1] * q_norm[2] - q_norm[0] * q_norm[3]) * q_norm[3] + 0.5 * q_norm[0]))
+            * inv_sqrt_s;
 
+        data(m, 1, counter) = (4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3] - 1.0) * q_norm[3]
+                            - 4 * i * ((q_norm[1] * q_norm[2] + q_norm[0] * q_norm[3]) * q_norm[3] - 0.5 * q_norm[0]))
+                            * inv_sqrt_s;
 
-        data(m, 1, counter) = (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[0]
-                            + 2 * i * q_norm[3]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[0])
-                            * (- q[0] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[2]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[1]
-                            - 4 * j * q_norm[1])
-                            * (- q[1] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[2]
-                            + 2 * i * q_norm[1]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[2])
-                            * (- q[2] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[2] + q_norm[3] * q_norm[0]) * q_norm[3]
-                            + 2 * i * q_norm[0]
-                            + 4 * j * (q_norm[1] * q_norm[1] + q_norm[3] * q_norm[3]) * q_norm[3]
-                            - 4 * j * q_norm[3])
-                            * (inv_sqrt_s - q[3] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
-
-
-        data(m, 2, counter) = (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[0]
-                            - 2 * i * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[0]
-                            + 2 * j * q_norm[1])
-                            * (- q[0] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 4 * i * (q_norm[1] * q_norm[3] - q_norm[2] * q_norm[0]) * q_norm[1]
-                            + 2 * i * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[1]
-                            + 2 * j * q_norm[0])
-                            * (- q[1] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (- 2 * i * q_norm[0]
-                            - 4 * i * (q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[2]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[2]
-                            + 2 * j * q_norm[3])
-                            * (- q[2] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s)
-                            +
-                            (2 * i * q_norm[1]
-                            + 4 * i * (q_norm[2] * q_norm[0] - q_norm[1] * q_norm[3]) * q_norm[3]
-                            - 4 * j * (q_norm[1] * q_norm[0] + q_norm[2] * q_norm[3]) * q_norm[3]
-                            + 2 * j * q_norm[2])
-                            * (inv_sqrt_s - q[3] * q[3] * inv_sqrt_s * inv_sqrt_s * inv_sqrt_s);
+        data(m, 2, counter) = (- 4 * i * ((q_norm[1] * q_norm[3] - q_norm[0] * q_norm[2]) * q_norm[3] - 0.5 * q_norm[1])
+                            - 4 * j * ((q_norm[2] * q_norm[3] + q_norm[0] * q_norm[1]) * q_norm[3] - 0.5 * q_norm[2]))
+                            * inv_sqrt_s;
         counter++;
 
         for (int i = 0; i < 3; ++i) {

--- a/src/simsoptpp/curveplanarfourier.h
+++ b/src/simsoptpp/curveplanarfourier.h
@@ -8,7 +8,7 @@ class CurvePlanarFourier : public Curve<Array> {
         CurvePlanarFourier is a curve that is restricted to lie in a plane. In
         the plane, the curve is represented using a Fourier series in plane polar coordinates:
 
-           r(phi) = \sum_{n=0}^{order} x_{c,n}cos(n*nfp*phi) + \sum_{n=1}^order x_{s,n}sin(n*nfp*phi)
+           r(phi) = \sum_{n=0}^{order} x_{c,n}cos(n*phi) + \sum_{n=1}^order x_{s,n}sin(n*phi)
         
         The plane is rotated using a quarternion
 
@@ -31,8 +31,6 @@ class CurvePlanarFourier : public Curve<Array> {
        */
     public:
         const int order;
-        const int nfp;
-        const bool stellsym;
         using Curve<Array>::quadpoints;
         using Curve<Array>::numquadpoints;
         using Curve<Array>::check_the_persistent_cache;
@@ -42,21 +40,21 @@ class CurvePlanarFourier : public Curve<Array> {
         Array q;
         Array center;
 
-        CurvePlanarFourier(int _numquadpoints, int _order, int _nfp, bool _stellsym) : Curve<Array>(_numquadpoints), order(_order), nfp(_nfp), stellsym(_stellsym) {
+        CurvePlanarFourier(int _numquadpoints, int _order) : Curve<Array>(_numquadpoints), order(_order) {
             rc = xt::zeros<double>({order + 1});
             rs = xt::zeros<double>({order});
             q = xt::zeros<double>({4});
             center = xt::zeros<double>({3});
         }
 
-        CurvePlanarFourier(vector<double> _quadpoints, int _order, int _nfp, bool _stellsym) : Curve<Array>(_quadpoints), order(_order), nfp(_nfp), stellsym(_stellsym) {
+        CurvePlanarFourier(vector<double> _quadpoints, int _order) : Curve<Array>(_quadpoints), order(_order) {
             rc = xt::zeros<double>({order + 1});
             rs = xt::zeros<double>({order});
             q = xt::zeros<double>({4});
             center = xt::zeros<double>({3});
         }
 
-        CurvePlanarFourier(Array _quadpoints, int _order, int _nfp, bool _stellsym) : Curve<Array>(_quadpoints), order(_order), nfp(_nfp), stellsym(_stellsym) {
+        CurvePlanarFourier(Array _quadpoints, int _order) : Curve<Array>(_quadpoints), order(_order) {
             rc = xt::zeros<double>({order + 1});
             rs = xt::zeros<double>({order});
             q = xt::zeros<double>({4});

--- a/src/simsoptpp/dipole_field.cpp
+++ b/src/simsoptpp/dipole_field.cpp
@@ -748,6 +748,17 @@ Array define_a_uniform_cartesian_grid_between_two_toroidal_surfaces(Array& norma
     //           start of the ray, conclude point is outside the outer surface.
     //     8. If Step 4 was True but Step 5 was False, add the point to the final grid.
 
+    if(normal_inner.layout() != xt::layout_type::row_major)
+          throw std::runtime_error("normal_inner needs to be in row-major storage order");
+    if(normal_outer.layout() != xt::layout_type::row_major)
+          throw std::runtime_error("normal_outer needs to be in row-major storage order");
+    if(xyz_uniform.layout() != xt::layout_type::row_major)
+          throw std::runtime_error("xyz_uniform needs to be in row-major storage order");
+    if(xyz_inner.layout() != xt::layout_type::row_major)
+          throw std::runtime_error("xyz_inner needs to be in row-major storage order");
+    if(xyz_outer.layout() != xt::layout_type::row_major)
+          throw std::runtime_error("xyz_outer needs to be in row-major storage order");
+
     int num_inner = xyz_inner.shape(0);
     int num_outer = xyz_outer.shape(0);
     int ngrid = xyz_uniform.shape(0);

--- a/src/simsoptpp/python_curves.cpp
+++ b/src/simsoptpp/python_curves.cpp
@@ -135,13 +135,11 @@ void init_curves(py::module_ &m) {
     register_common_curve_methods<PyCurveRZFourier>(pycurverzfourier);
 
     auto pycurveplanarfourier = py::class_<PyCurvePlanarFourier, shared_ptr<PyCurvePlanarFourier>, PyCurvePlanarFourierTrampoline<PyCurvePlanarFourier>, PyCurve>(m, "CurvePlanarFourier")
-        .def(py::init<vector<double>, int, int, bool>())
+        .def(py::init<vector<double>, int>())
         .def_readwrite("rc", &PyCurvePlanarFourier::rc)
         .def_readwrite("rs", &PyCurvePlanarFourier::rs)
         .def_readwrite("q", &PyCurvePlanarFourier::q)
         .def_readwrite("center", &PyCurvePlanarFourier::center)
-        .def_readonly("order", &PyCurvePlanarFourier::order)
-        .def_readonly("stellsym", &PyCurvePlanarFourier::stellsym)
-        .def_readonly("nfp", &PyCurvePlanarFourier::nfp);
+        .def_readonly("order", &PyCurvePlanarFourier::order);
     register_common_curve_methods<PyCurvePlanarFourier>(pycurveplanarfourier);
 }

--- a/tests/geo/test_curve.py
+++ b/tests/geo/test_curve.py
@@ -76,7 +76,7 @@ def get_curve(curvetype, rotated, x=np.asarray([0.5])):
     elif curvetype == "CurveHelicalInitx0":
         curve = CurveHelical(x, order, 5, 2, 1.0, 0.3, x0=np.ones(2 * order + 1))
     elif curvetype == "CurvePlanarFourier":
-        curve = CurvePlanarFourier(x, order, 2, True)
+        curve = CurvePlanarFourier(x, order)
     elif curvetype == "CurveXYZFourierSymmetries1":
         curve = CurveXYZFourierSymmetries(x, order, 2, True)
     elif curvetype == "CurveXYZFourierSymmetries2":


### PR DESCRIPTION
This PR fixes two issues with the CurvePlanarFourier class:
1. The C++ jacobian calculation was incorrect, and now fixed. This is very stringently tested in upcoming PR with force/torque jacobian checks. 
2. The Python and C++ initializations asked for nfp and stellsym parameters, but these parameters were not used in the actual definition of the curve. So they are removed, and wherever CurvePlanarFourier is tested, the initialization call needs to change from CurvePlanarFourier(numquadpoints, order, nfp, stellsym) to just CurvePlanarFourier(numquadpoints, order)