### PR TITLE
ToroidalTransitStoppingCriterion: changed max_transits to double

### DIFF
--- a/src/simsoptpp/python_tracing.cpp
+++ b/src/simsoptpp/python_tracing.cpp
@@ -30,7 +30,7 @@ void init_tracing(py::module_ &m){
     py::class_<MinToroidalFluxStoppingCriterion, shared_ptr<MinToroidalFluxStoppingCriterion>, StoppingCriterion>(m, "MinToroidalFluxStoppingCriterion")
         .def(py::init<double>());
     py::class_<ToroidalTransitStoppingCriterion, shared_ptr<ToroidalTransitStoppingCriterion>, StoppingCriterion>(m, "ToroidalTransitStoppingCriterion")
-        .def(py::init<int,bool>());
+        .def(py::init<double,bool>());
     py::class_<LevelsetStoppingCriterion<PyTensor>, shared_ptr<LevelsetStoppingCriterion<PyTensor>>, StoppingCriterion>(m, "LevelsetStoppingCriterion")
         .def(py::init<shared_ptr<RegularGridInterpolant3D<PyTensor>>>());
 

--- a/src/simsoptpp/tracing.h
+++ b/src/simsoptpp/tracing.h
@@ -20,12 +20,12 @@ class StoppingCriterion {
 
 class ToroidalTransitStoppingCriterion : public StoppingCriterion {
     private:
-        int max_transits;
+        double max_transits;
         double phi_last;
         double phi_init;
         bool flux;
     public:
-        ToroidalTransitStoppingCriterion(int max_transits, bool flux) : max_transits(max_transits), flux(flux) {
+        ToroidalTransitStoppingCriterion(double max_transits, bool flux) : max_transits(max_transits), flux(flux) {
         };
         bool operator()(int iter, double t, double x, double y, double z) override {
             if (iter == 1) {
@@ -39,8 +39,8 @@ class ToroidalTransitStoppingCriterion : public StoppingCriterion {
               phi_init = phi;
             }
             phi_last = phi;
-            int ntransits = std::abs(std::floor((phi-phi_init)/(2*M_PI)));
-            return ntransits>=max_transits;
+            double ntransits = std::abs((phi - phi_init) / (2 * M_PI));
+            return ntransits >= max_transits;
         };
 };
 

--- a/tests/field/test_particle.py
+++ b/tests/field/test_particle.py
@@ -682,7 +682,7 @@ class BoozerGuidingCenterTracingTesting(unittest.TestCase):
 
         gc_tys, gc_phi_hits = trace_particles(bsh, xyz_inits, vpar_inits,
                                               tmax=tmax, mass=m, charge=q, Ekin=Ekin, phis=[], mode='gc_vac',
-                                              stopping_criteria=[ToroidalTransitStoppingCriterion(1, False)],
+                                              stopping_criteria=[ToroidalTransitStoppingCriterion(1.0, False)],
                                               tol=1e-12)
 
         mpol = compute_poloidal_transits(gc_tys, ma=ma, flux=False)
@@ -768,7 +768,7 @@ class BoozerGuidingCenterTracingTesting(unittest.TestCase):
 
         gc_tys, gc_phi_hits = trace_particles_boozer(bsh, stz_inits, vpar_inits,
                                                      tmax=tmax, mass=m, charge=q, Ekin=Ekin, zetas=[0], mode='gc_vac',
-                                                     stopping_criteria=[MinToroidalFluxStoppingCriterion(0.01), MaxToroidalFluxStoppingCriterion(0.99), ToroidalTransitStoppingCriterion(100, True)],
+                                                     stopping_criteria=[MinToroidalFluxStoppingCriterion(0.01), MaxToroidalFluxStoppingCriterion(0.99), ToroidalTransitStoppingCriterion(100.0, True)],
                                                      tol=1e-8)
 
         resonances = compute_resonances(gc_tys, gc_phi_hits, delta=0.01)


### PR DESCRIPTION
I've sometimes wanted to follow field lines for a number of toroidal transits that is not an integer, for field lines that are periodic in the (R,Z) plane after a number of field periods different from nfp. This isn't possible now with ToroidalTransitStoppingCriterion because the max_transits argument has type int. In this tiny PR I just change the type to double to enable this functionality.

Users who have been using the argument type `int` should notice no differences. For test coverage, I just randomly picked two of the tests that used ToroidalTransitStoppingCriterion and changed the argument from int to float. In other tests the argument remains an int, so both types are covered.