### PR TITLE
Update plot_poincare_data to use new cross_section angle convention

### DIFF
--- a/src/simsopt/field/tracing.py
+++ b/src/simsopt/field/tracing.py
@@ -919,7 +919,7 @@ def plot_poincare_data(fieldlines_phi_hits, phis, filename, mark_lost=False, asp
 
         # if passed a surface, plot the plasma surface outline
         if surf is not None:
-            cross_section = surf.cross_section(phi=phis[i])
+            cross_section = surf.cross_section(phi=phis[i]/(2.0*np.pi))
             r_interp = np.sqrt(cross_section[:, 0] ** 2 + cross_section[:, 1] ** 2)
             z_interp = cross_section[:, 2]
             axs[row, col].plot(r_interp, z_interp, linewidth=1, c='k')

--- a/tests/field/test_fieldline.py
+++ b/tests/field/test_fieldline.py
@@ -1,6 +1,7 @@
 import unittest
 import logging
 import numpy as np
+from pathlib import Path
 
 from simsopt.field.magneticfieldclasses import ToroidalField, PoloidalField, InterpolatedField, UniformInterpolationRule
 from simsopt.field.tracing import compute_fieldlines, particles_to_vtk, plot_poincare_data, \
@@ -10,6 +11,7 @@ from simsopt.configs.zoo import get_ncsx_data
 from simsopt.field.coil import coils_via_symmetries, Coil, Current
 from simsopt.geo.curvehelical import CurveHelical
 from simsopt.geo.curvexyzfourier import CurveXYZFourier
+from simsopt.geo.surfacerzfourier import SurfaceRZFourier
 
 logging.basicConfig()
 
@@ -76,6 +78,10 @@ class FieldlineTesting(unittest.TestCase):
 
     def test_poincare_plot(self):
         curves, currents, ma = get_ncsx_data()
+        TEST_DIR = (Path(__file__).parent / ".." / ".." / "tests"
+                    / "test_files").resolve()
+        surf = SurfaceRZFourier.from_focus(
+                   TEST_DIR / 'input.NCSX_c09r00_halfTeslaTF')
         nfp = 3
         coils = coils_via_symmetries(curves, currents, nfp, True)
         bs = BiotSavart(coils)
@@ -98,7 +104,8 @@ class FieldlineTesting(unittest.TestCase):
             bsh, R0, Z0, tmax=1000, phis=phis, stopping_criteria=[])
         try:
             import matplotlib  # noqa
-            plot_poincare_data(res_phi_hits, phis, '/tmp/fieldlines.png')
+            plot_poincare_data(res_phi_hits, phis, '/tmp/fieldlines.png',
+                               surf=surf)
         except ImportError:
             pass
 


### PR DESCRIPTION
This PR updates the function `plot_poincare_data` to use the new angle convention for `Surface.cross_section` if a user supplies a Surface class instance as an optional argument. Also modifies the unit test of plot_poincare_data to include surface cross-sections in the plot; hopefully this increases the test coverage a bit.