### PR TITLE
Update the version specification approach for numpy in conda builds

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -10,6 +10,13 @@ on:
   release:
     types: [published]
 
+concurrency:
+  # Use github.run_id on main branch
+  # Use github.event.pull_request.number on pull requests, so it's unique per pull request
+  # Use github.ref on other branches, so it's unique per branch
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -11,9 +11,6 @@ on:
     types: [published]
 
 concurrency:
-  # Use github.run_id on main branch
-  # Use github.event.pull_request.number on pull requests, so it's unique per pull request
-  # Use github.ref on other branches, so it's unique per branch
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,13 @@ on:
     tags:
       - v*
 
+concurrency:
+  # Use github.run_id on main branch
+  # Use github.event.pull_request.number on pull requests, so it's unique per pull request
+  # Use github.ref on other branches, so it's unique per branch
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs_test.yml
+++ b/.github/workflows/docs_test.yml
@@ -2,6 +2,13 @@ name: Docs_test
 
 on: [push, pull_request]
 
+concurrency:
+  # Use github.run_id on main branch
+  # Use github.event.pull_request.number on pull requests, so it's unique per pull request
+  # Use github.ref on other branches, so it's unique per branch
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CI:
     runs-on: ubuntu-latest

--- a/.github/workflows/extensive_test.yml
+++ b/.github/workflows/extensive_test.yml
@@ -16,6 +16,13 @@ on:
     branches: [master]
   workflow_dispatch: 
 
+concurrency:
+  # Use github.run_id on main branch
+  # Use github.event.pull_request.number on pull requests, so it's unique per pull request
+  # Use github.ref on other branches, so it's unique per branch
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/non_simd_tests.yml
+++ b/.github/workflows/non_simd_tests.yml
@@ -15,6 +15,13 @@ on:
   pull_request:
     branches-ignore: [master]
 
+concurrency:
+  # Use github.run_id on main branch
+  # Use github.event.pull_request.number on pull requests, so it's unique per pull request
+  # Use github.ref on other branches, so it's unique per branch
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/singularity.yml
+++ b/.github/workflows/singularity.yml
@@ -14,6 +14,13 @@ on:
   pull_request: []
   workflow_dispatch:
 
+concurrency:
+  # Use github.run_id on main branch
+  # Use github.event.pull_request.number on pull requests, so it's unique per pull request
+  # Use github.ref on other branches, so it's unique per branch
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-containers:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,13 @@ on:
   pull_request:
     branches-ignore: [master]
 
+concurrency:
+  # Use github.run_id on main branch
+  # Use github.event.pull_request.number on pull requests, so it's unique per pull request
+  # Use github.ref on other branches, so it's unique per branch
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -4,6 +4,13 @@ name: Wheel Builder
 
 on: [push, pull_request]
 
+concurrency:
+  # Use github.run_id on main branch
+  # Use github.event.pull_request.number on pull requests, so it's unique per pull request
+  # Use github.ref on other branches, so it's unique per branch
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/conda.recipe/conda_build_config.yaml
+++ b/conda.recipe/conda_build_config.yaml
@@ -1,11 +1,9 @@
-numpy:
-  - 1.23
-  - 1.24
 python:
   - 3.9
   - 3.10
   - 3.11
+  - 3.12
+  - 3.13
 
 pin_run_as_build:
-  numpy: x.x
   python: x.x

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
   host:
     - pip
     - wheel
-    - numpy {{ numpy }}
+    - numpy
     - "setuptools_scm[toml]"
     - scikit-build-core
     - python {{ python }}
@@ -35,7 +35,7 @@ requirements:
 
   run:
     - python
-    - numpy {{ numpy }}
+    - numpy
     - jax >=0.2.5
     - jaxlib >=0.1.56
     - scipy >=1.5.4

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - libgomp      # [linux]
     - "setuptools_scm[toml]"
     - boost
-    - pybind11
+    - pybind11 < 3.0
     - scikit-build-core
 
   host:
@@ -31,7 +31,7 @@ requirements:
     - "setuptools_scm[toml]"
     - scikit-build-core
     - python {{ python }}
-    - pybind11
+    - pybind11 < 3.0
 
   run:
     - python

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - libgomp      # [linux]
     - "setuptools_scm[toml]"
     - boost
-    - pybind11 < 3.0
+    - pybind11 <3.0
     - scikit-build-core
 
   host:
@@ -31,7 +31,7 @@ requirements:
     - "setuptools_scm[toml]"
     - scikit-build-core
     - python {{ python }}
-    - pybind11 < 3.0
+    - pybind11 <3.0
 
   run:
     - python


### PR DESCRIPTION
Numpy version 2.0 is backward compatible for numpy versions < 2.0. This lifts the earlier limitations on how we can build and distribute simsopt via conda. Trying a newer version specification approach for numpy in conda builds to account for that.