### PR TITLE
Bug in Surface Cross Section arguments

### DIFF
--- a/tests/geo/test_surface.py
+++ b/tests/geo/test_surface.py
@@ -503,6 +503,10 @@ class isSelfIntersecting(unittest.TestCase):
         xs_array = surfaces[-1].cross_section(angle/(2*np.pi), thetas=thetas, tol=1e-13)
         np.testing.assert_allclose(xs, xs_array, atol=1e-13, err_msg="The cross_section method should return the same result for an array of thetas.")
         
+        # check that an exception is raised if theta is 2D
+        with self.assertRaises(Exception):
+            _ = surfaces[-1].cross_section(angle/(2*np.pi), thetas=[[0, 0.8], [0.5, 0.7]])
+
         """
         Take this surface, and rotate it 30 degrees about the x-axis.  This should cause
         the surface to 'go back' on itself, and trigger the exception.

--- a/tests/geo/test_surface.py
+++ b/tests/geo/test_surface.py
@@ -488,17 +488,25 @@ class isSelfIntersecting(unittest.TestCase):
                      "Libraries to check whether self-intersecting or not are missing")
 
     def test_cross_section(self):
-        # this cross section calculation fails on the previous implementation of the cross
-        # section algorithm
+        """ Test the cross_section method for a surface that is not self-intersecting. """
         filename = os.path.join(TEST_DIR, 'serial2680021.json')
         [surfaces, coils] = load(filename)
         angle = np.pi/10
+
+        # check that the cross_section method works for a surface that is not self-intersecting
         xs = surfaces[-1].cross_section(angle/(2*np.pi), thetas=256)
         Z = xs[:, 2]
-        assert np.all(Z<-0.08)
+        self.assertTrue(np.all(Z < -0.08), msg="The Z coordinate should be < - 0.8 for this surface.")
+
+        # check that the same answer is returned for an array valued thetas
+        thetas = np.linspace(0, 1, 256, endpoint=False)
+        xs_array = surfaces[-1].cross_section(angle/(2*np.pi), thetas=thetas, tol=1e-13)
+        np.testing.assert_allclose(xs, xs_array, atol=1e-13, err_msg="The cross_section method should return the same result for an array of thetas.")
         
-        # take this surface, and rotate it 30 degrees about the x-axis.  This should cause
-        # the surface to 'go back' on itself, and trigger the exception.
+        """
+        Take this surface, and rotate it 30 degrees about the x-axis.  This should cause
+        the surface to 'go back' on itself, and trigger the exception.
+        """
         surface_orig = SurfaceXYZTensorFourier(mpol=surfaces[-1].mpol, ntor=surfaces[-1].ntor,\
                 stellsym=True, nfp=surfaces[-1].nfp, quadpoints_phi=np.linspace(0, 1, 100),\
                 quadpoints_theta=surfaces[-1].quadpoints_theta)
@@ -518,9 +526,10 @@ class isSelfIntersecting(unittest.TestCase):
         with self.assertRaises(Exception):
             _ = surface_rotated.cross_section(0., thetas=256)
 
+        # check that cross_section raises an exception if thetas is not an appropriate argument
         with self.assertRaises(Exception):
             _ = surface_rotated.cross_section(0., thetas='wrong')
-        
+
     def test_is_self_intersecting(self):
         # dofs results in a surface that is self-intersecting
         dofs = np.array([1., 0., 0., 0., 0., 0.1, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.1,


### PR DESCRIPTION
This PR makes two fixes to the `Surface.cross_section` function. 
1. The documentation was not compiling correctly, which made it difficult to understand what the arguments and returns were. The documentation has now been corrected. See attached.
2. The `thetas` argument can be one of `int, Array, None`.  However, when an array or list was passed in, an error would be thrown. The error was arising because of improper validation of inputs: there was no handling for the case when `thetas` is an array. In this PR, we correct the validation of the inputs to allow for `thetas` to be an array, as the documentation states it can be.

**Changes**
- Small changes have been made to the `cross_section` method and documentation.
- A basic unit test has been added to check that an array can be used as input.


**New Documenation Image** 
<img width="100" alt="Screenshot 2025-08-04 at 3 18 47 PM" src="https://github.com/user-attachments/assets/f0b3663e-7f9f-42c6-a545-0a38ebe5982e" />

**Old Documentation Image**
<img width="100" alt="Screenshot 2025-08-04 at 3 15 02 PM" src="https://github.com/user-attachments/assets/5c8dc6e7-efbb-46b7-af85-52a14fbbc14f" /> 


