### PR TITLE
Silence SyntaxWarnings from unescaped \ in strings

### DIFF
--- a/examples/2_Intermediate/boozerQA.py
+++ b/examples/2_Intermediate/boozerQA.py
@@ -11,7 +11,7 @@ from simsopt.geo import SurfaceXYZTensorFourier, BoozerSurface, curves_to_vtk, b
 from simsopt.objectives import QuadraticPenalty
 from simsopt.util import in_github_actions
 
-"""
+r"""
 This example optimizes the NCSX coils and currents for QA on a single surface.  The objective is
 
     J = ( \int_S B_nonQA**2 dS )/(\int_S B_QA dS)

--- a/src/simsopt/field/mgrid.py
+++ b/src/simsopt/field/mgrid.py
@@ -91,7 +91,7 @@ class MGrid():
         self.ap_arr = []
 
     def add_field_cylindrical(self, br, bp, bz, ar=None, ap=None, az=None, name=None):
-        '''
+        r'''
         This function saves the magnetic field :math:`B`, and (optionally) the vector potential :math:`A`, to the ``MGrid`` object.
         :math:`B` and :math:`A` are provided on a tensor product grid in cylindrical components :math:`(R, \phi, z)`.
 

--- a/src/simsopt/geo/surfacegarabedian.py
+++ b/src/simsopt/geo/surfacegarabedian.py
@@ -112,13 +112,13 @@ class SurfaceGarabedian(sopp.Surface, Surface):
         self.local_full_x = Delta.flatten()
 
     def get_Delta(self, m, n):
-        """
+        r"""
         Return a particular :math:`\Delta_{m,n}` coefficient.
         """
         return self.Delta[m - self.mmin, n - self.nmin]
 
     def set_Delta(self, m, n, val):
-        """
+        r"""
         Set a particular :math:`\Delta_{m,n}` coefficient.
         """
         i = self.ndim * (m - self.mmin) + n - self.nmin

--- a/src/simsopt/geo/surfaceobjectives.py
+++ b/src/simsopt/geo/surfaceobjectives.py
@@ -1087,7 +1087,7 @@ def boozer_surface_dexactresidual_dcoils_dcurrents_vjp(lm, booz_surf, iota, G):
 
 
 def boozer_surface_dlsqgrad_dcoils_vjp(lm, booz_surf, iota, G, weight_inv_modB=True):
-    """
+    r"""
     For a given surface with points x on it, this function computes the
     vector-Jacobian product of \lm^T * dlsqgrad_dcoils, \lm^T * dlsqgrad_dcurrents:
     lm^T dresidual_dcoils    = lm^T [dr_dsurface]^T[dr_dcoils]    + sum r_i lm^T d2ri_dsdc

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -988,7 +988,7 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
         return scalars
 
     def make_rotating_ellipse(self, major_radius, minor_radius, elongation, torsion=0):
-        """
+        r"""
         Set the surface shape to be a rotating ellipse with the given
         parameters.
 

--- a/src/simsopt/mhd/profiles.py
+++ b/src/simsopt/mhd/profiles.py
@@ -100,7 +100,7 @@ class ProfileSpec(Profile):
         return self.local_full_x[lvol]
 
     def dfds(self, lvol):
-        """
+        r"""
         Returns the derivative of the profile w.r.t s accross interface. 
         The derivative is returned at the interface lvol, with
         the innermost interface being lvol=1. (Volume lvol is bounded

--- a/src/simsopt/mhd/vmec_diagnostics.py
+++ b/src/simsopt/mhd/vmec_diagnostics.py
@@ -1548,7 +1548,7 @@ def vmec_fieldlines(vs, s, alpha, theta1d=None, phi1d=None, phi_center=0, plot=F
         for j, variable in enumerate(variables):
             plt.subplot(nrows, ncols, j + 1)
             plt.plot(phi[0, 0, :], eval("results." + variable + '[0, 0, :]'))
-            plt.xlabel('Standard toroidal angle $\phi$')
+            plt.xlabel(r'Standard toroidal angle $\phi$')
             plt.title(variable)
 
         plt.figtext(0.5, 0.995, f's={s[0]}, alpha={alpha[0]}', ha='center', va='top')

--- a/src/simsopt/objectives/constrained.py
+++ b/src/simsopt/objectives/constrained.py
@@ -33,13 +33,13 @@ class ConstrainedProblem(Optimizable):
 
         .. math::
 
-            \min_x f(x) 
+            \\min_x f(x) 
 
             \\text{s.t.} 
 
-            l_{\\text{nlc}} \leq c(x) \leq u_{\\text{nlc}}
+            l_{\\text{nlc}} \\leq c(x) \\leq u_{\\text{nlc}}
 
-            l_{\\text{lc}} \leq Ax \leq u_{\\text{lc}}
+            l_{\\text{lc}} \\leq Ax \\leq u_{\\text{lc}}
 
     Constrained optimization problems can be solved with the ``constrained_mpi_solve`` or
     ``constrained_serial_solve`` functions. Typically, this class is used for Stage-I optimization.
@@ -107,7 +107,7 @@ class ConstrainedProblem(Optimizable):
 
     def nonlinear_constraints(self, x=None, *args, **kwargs):
         """
-        Evaluates the nonlinear constraints, :math:`l_{\\text{nlc}} \leq c(x) \leq u_{\\text{nlc}}`.
+        Evaluates the nonlinear constraints, :math:`l_{\\text{nlc}} \\leq c(x) \\leq u_{\\text{nlc}}`.
 
         Args:
             x (array, Optional): Degrees of freedom. If not provided, the current degrees of freedom are used.


### PR DESCRIPTION
Newer Python versions throw syntax warnings on import.
This can be avoided by using raw strings or escaping backslashes correctly.