### PR TITLE
Update src/simsopt/mhd/vmec.py for non-stellarator-symmetric optimization

### DIFF
--- a/src/simsopt/mhd/vmec.py
+++ b/src/simsopt/mhd/vmec.py
@@ -522,6 +522,9 @@ class Vmec(Optimizable):
             raise ValueError("VMEC does not allow ntor > 101")
         vi.rbc[:, :] = 0
         vi.zbs[:, :] = 0
+        if vi.lasym:
+            vi.rbs[:, :] = 0
+            vi.zbc[:, :] = 0
         mpol_capped = np.min([boundary_RZFourier.mpol, 101])
         ntor_capped = np.min([boundary_RZFourier.ntor, 101])
         # Transfer boundary shape data from the surface object to VMEC:
@@ -529,6 +532,9 @@ class Vmec(Optimizable):
             for n in range(-ntor_capped, ntor_capped + 1):
                 vi.rbc[101 + n, m] = boundary_RZFourier.get_rc(m, n)
                 vi.zbs[101 + n, m] = boundary_RZFourier.get_zs(m, n)
+                if vi.lasym:
+                    vi.rbs[101 + n, m] = boundary_RZFourier.get_rs(m, n)
+                    vi.zbc[101 + n, m] = boundary_RZFourier.get_zc(m, n)
 
         # Set axis shape to something that is obviously wrong (R=0) to
         # trigger vmec's internal guess_axis.f to run. Otherwise the


### PR DESCRIPTION
## What does this PR do?
This PR hopes to fix a bug in the `set_indata` function within the `src/simsopt/mhd/vmec.py` file. The original implementation assumed **stellarator symmetry**, leading to inaccurate results when processing **non-stellarator-symmetric** configurations.

## Problem Explanation
This function transfers data from simsopt objects to Vmec's fortran module data. I think this function only transfers the stellarator-symmetric terms while neglecting the asymmetric ones, resulting in the boundary shape remaining stellarator-symmetric when Vmec is rerun, rather than evolving with the optimizer's changes.

## Solution
Considering that the `Vmec` class in this file already includes the non-stellarator-symmetric switch `vi.lasym`, I have added conditional judgment `if vi.lasym:` and performed data transfer for asymmetric terms `vi.rbs`, `vi.zbc` by analogy with symmetric terms `vi.rbc`, `vi.zbs`.
