### PR TITLE
Overflow error in Mgrid write method

### DIFF
--- a/src/simsopt/field/mgrid.py
+++ b/src/simsopt/field/mgrid.py
@@ -143,7 +143,7 @@ class MGrid():
             filename (str): output file name.
         '''
 
-        with netcdf_file(filename, 'w', mmap=False) as ds:
+        with netcdf_file(filename, 'w', mmap=False, version=2) as ds:
 
             # set netcdf dimensions
             ds.createDimension('stringsize', 30)
@@ -225,7 +225,7 @@ class MGrid():
             MGrid: ``MGrid`` object with data from file.
         '''
 
-        with netcdf_file(filename, 'r', mmap=False) as f:
+        with netcdf_file(filename, 'r', mmap=False, version=2) as f:
 
             # load grid
             nr = f.variables['ir'].getValue()


### PR DESCRIPTION
**Summary**
Using the `.write` method of the `Mgrid` class can lead to an Overflow error (see screenshot). 

**Context**
The `Mgrid` class is used to write `netcdf` files which can be used in free boundary VMEC. When setting the resolution parameters of the `Mgrid` class, `nr, nphi, nz`, to high values, the `write` method can overflow (see screenshot)

<img width="280" alt="Image" src="https://github.com/user-attachments/assets/bae87ec6-e62c-4784-8426-661ef3b346af" />

As seen in the screenshot, the write method attempts to write values to an array that is allocated for _single precision_. The error occurs because the values being written cannot be represented in 32 bits.

This overflow error is problematic because it limits users to only using coarse grids which poorly represent magnetic fields.

**Fix**
The `Mgrid` class uses Scipy's `netcdf_file` class to write the file. The `netcdf_file` class relies on the `version` argument,  which defaults to `version=1`. The `version` argument sets the array format for writing, where 1 means Classic format (32 bit in our case) and 2 means 64-bit offset format. Switching the `Mgrid.write` method to rely on `netcdf_file(... version=2)` forces the values to be written to a 64-bit array, which solves the problem. 

**Question/Uncertainty**
While setting `version=2` seems to prevent the overflow error from appearing, I do not understand the fortran side of the code well enough to know if this change will lead to misrepresentation of the magnetic fields in the Mgrid files. In other words, is using `64-bit offset format` appropriate? Perhaps you have a better sense, @mbkumar @landreman.