### PR TITLE
Fix indexing issue in wireframe plotting

### DIFF
--- a/src/simsopt/geo/wireframe_toroidal.py
+++ b/src/simsopt/geo/wireframe_toroidal.py
@@ -1533,7 +1533,7 @@ class ToroidalWireframe(object):
             raise ValueError('extent must be \'half period\', '
                              + '\'field period\', or \'torus\'')
 
-        pl_segments = np.zeros((n_half_periods*self.n_segments, 2, 2))
+        pl_segments = np.zeros((n_half_periods*self.n_segments, 2, 2), dtype=int)
         pl_quantity = np.zeros((n_half_periods*self.n_segments))
 
         # Calculate the toroidal and poloidal indices of each segment's


### PR DESCRIPTION
This PR attempts to resolve issue #553 in which one of the tests failed on a wireframe example due to an apparent indexing error. I wasn't able to reproduce the error on my machine, but I believe this arises from an issue in querying an array with an index that was converted from a floating point value. The code has been modified to avoid the float-integer conversion that gave rise to the error.