### PR TITLE
Documented vmec diagnostics output type, replaced Struct

### DIFF
--- a/src/simsopt/mhd/vmec_diagnostics.py
+++ b/src/simsopt/mhd/vmec_diagnostics.py
@@ -850,7 +850,10 @@ def vmec_splines(vmec):
 class VmecGeometryResults:
     """
     A class to hold the output of the :func:`vmec_compute_geometry` and :func:`vmec_fieldlines` functions.
-    
+
+    The arguments required of this class have been hidden in the Sphinx documentation, since they are
+    extensively long. See the code for vmec_compute_geometry for an example of initializing this class.
+
     This data class contains geometric quantities computed from VMEC equilibria, including
     magnetic quantities, coordinates, metric tensors, and various geometric coefficients
     used in gyrokinetic simulations.


### PR DESCRIPTION
A first step in addressing issue https://github.com/hiddenSymmetries/simsopt/issues/547 of vmec_compute_geometry

<img width="1327" height="1609" alt="image" src="https://github.com/user-attachments/assets/36e46cd8-00fd-44c1-99da-9c24c2f37c36" />

<img width="873" height="1612" alt="image" src="https://github.com/user-attachments/assets/26d20e6b-deb7-4bbd-b9fc-74ffd8a5af6b" />
