### PR TITLE
Escape strings correctly, so tests and imports become less noisy

### DIFF
--- a/src/simsopt/geo/curve.py
+++ b/src/simsopt/geo/curve.py
@@ -16,7 +16,7 @@ __all__ = ['Curve', 'JaxCurve', 'RotatedCurve', 'curves_to_vtk', 'create_equally
 
 @jit
 def centroid_pure(gamma, gammadash):
-    """
+    r"""
     This pure function is used in a Python+Jax implementation of formula for centroid.
 
     .. math::
@@ -30,7 +30,7 @@ def centroid_pure(gamma, gammadash):
 
 @jit
 def incremental_arclength_pure(d1gamma):
-    """
+    r"""
     This function is used in a Python+Jax implementation of the curve arc length formula.
 
     .. math::
@@ -47,7 +47,7 @@ incremental_arclength_vjp = jit(lambda d1gamma, v: vjp(lambda d1g: incremental_a
 
 @jit
 def kappa_pure(d1gamma, d2gamma):
-    """
+    r"""
     This function is used in a Python+Jax implementation of formula for curvature.
 
     .. math::
@@ -67,7 +67,7 @@ kappagrad1 = jit(lambda d1gamma, d2gamma: jacfwd(lambda d2g: kappa_pure(d1gamma,
 
 @jit
 def torsion_pure(d1gamma, d2gamma, d3gamma):
-    """
+    r"""
     This function is used in a Python+Jax implementation of formula for torsion.
 
     .. math::
@@ -454,7 +454,7 @@ class Curve(Optimizable):
         return dkappadash_by_dcoeff
 
     def centroid(self):
-        """ 
+        r""" 
         Compute the centroid of the curve
 
         .. math::

--- a/src/simsopt/geo/curveplanarfourier.py
+++ b/src/simsopt/geo/curveplanarfourier.py
@@ -140,8 +140,7 @@ def jaxplanarcurve_pure(dofs, quadpoints, order):
 
 
 class JaxCurvePlanarFourier(JaxCurve):
-
-    """
+    r"""
     A Python+Jax implementation of the CurvePlanarFourier class. This is an autodiff
     compatible version of the same CurvePlanarFourier class in the C++ implementation in
     :mod:`simsoptpp`. The point of this class is to illustrate how jax can be used

--- a/src/simsopt/geo/surface.py
+++ b/src/simsopt/geo/surface.py
@@ -325,7 +325,7 @@ class Surface(Optimizable):
         raise NotImplementedError
 
     def cross_section(self, phi, thetas=None, tol=1e-13):
-        """
+        r"""
         Computes an array of points on the cross section with cylindrical angle :math:`\phi`, using the bisection method.
         The poloidal angles of the points on the cross section are given by ``thetas``. This function assumes that the surface
         intersection with the :math:`\phi`-plane is a single curve: the surface should only go once around the z-axis,

--- a/src/simsopt/mhd/boozer.py
+++ b/src/simsopt/mhd/boozer.py
@@ -294,7 +294,7 @@ class Quasisymmetry(Optimizable):
         self.need_to_run_code = True
 
     def J(self) -> RealArray:
-        """
+        r"""
         Compute the quasisymmetry error on each flux surface ``s`` in ``self.s``.
         
         **MPI behavior:** when running under MPI, only group-leader ranks compute the error; all other ranks immediately return an empty array.

--- a/tests/core/test_optimizable.py
+++ b/tests/core/test_optimizable.py
@@ -875,7 +875,7 @@ class OptimizableTests(unittest.TestCase):
         self.assertEqual(len(test_obj.dof_names), 3)
         for name in test_obj.dof_names:
             self.assertTrue(comb_patt.match(name))
-        exc_patt = re.compile("OptClassWithParents\d+:val")
+        exc_patt = re.compile(r"OptClassWithParents\d+:val")
         for name in test_obj.dof_names:
             self.assertFalse(exc_patt.match(name))
 
@@ -883,14 +883,14 @@ class OptimizableTests(unittest.TestCase):
         self.assertEqual(len(test_obj.dof_names), 2)
         for name in test_obj.dof_names:
             self.assertTrue(comb_patt.match(name))
-        exc_patt = re.compile("Adder\d+:x1")
+        exc_patt = re.compile(r"Adder\d+:x1")
         for name in test_obj.dof_names:
             self.assertFalse(exc_patt.match(name))
 
         test_obj2 = OptClassWith2LevelParents(10, 20)
-        patt1 = "Adder\d+:x\d+"
-        patt2 = "OptClassWithParents\d+:val"
-        patt3 = "OptClassWith2LevelParents\d+:v\d"
+        patt1 = r"Adder\d+:x\d+"
+        patt2 = r"OptClassWithParents\d+:val"
+        patt3 = r"OptClassWith2LevelParents\d+:v\d"
         comb_patt = re.compile("|".join([patt1, patt2, patt3]))
         self.assertEqual(len(test_obj2.dof_names), 10)
         for name in test_obj2.dof_names:
@@ -900,7 +900,7 @@ class OptimizableTests(unittest.TestCase):
         self.assertEqual(len(test_obj2.dof_names), 9)
         for name in test_obj2.dof_names:
             self.assertTrue(comb_patt.match(name))
-        exc_patt = re.compile("OptClassWith2LevelParents\d+:v1")
+        exc_patt = re.compile(r"OptClassWith2LevelParents\d+:v1")
         for name in test_obj.dof_names:
             self.assertFalse(exc_patt.match(name))
 
@@ -921,9 +921,9 @@ class OptimizableTests(unittest.TestCase):
         self.assertEqual(len(test_obj2.full_dof_names), 10)
         test_obj2.fix(0)
         self.assertEqual(len(test_obj2.full_dof_names), 10)
-        patt1 = "Adder\d+:x\d+"
-        patt2 = "OptClassWithParents\d+:val"
-        patt3 = "OptClassWith2LevelParents\d+:v\d"
+        patt1 = r"Adder\d+:x\d+"
+        patt2 = r"OptClassWithParents\d+:val"
+        patt3 = r"OptClassWith2LevelParents\d+:v\d"
         comb_patt = re.compile("|".join([patt1, patt2, patt3]))
         for name in test_obj2.full_dof_names:
             self.assertTrue(comb_patt.match(name))


### PR DESCRIPTION
Another PR escaping strings correctly, to silence syntax warnings and make the warnings surfaced during tests more meaningful/easier to filter through.