### PR TITLE
Fix integrated tests in simple tests CI

### DIFF
--- a/.github/workflows/extensive_test.yml
+++ b/.github/workflows/extensive_test.yml
@@ -193,7 +193,7 @@ jobs:
         ./run_serial_examples
 
     - name: Run simple parallel examples as part of integrated tests
-      if: contains(matrix.test-type, 'integrated') && contains(matrix.packages, 'all')
+      if: contains(matrix.test-type, 'integrated') && contains(matrix.packages, 'none')
       run: |
         cd examples
         ./run_parallel_examples

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     env:
       OMPI_ALLOW_RUN_AS_ROOT: 1


### PR DESCRIPTION
The integrated tests in the (non-extensive) Tests workflow are failing, with a weird error when `plt.savefig()` is called in one of our routines:
https://github.com/hiddenSymmetries/simsopt/actions/runs/19766988315/job/56642085093
It looks like this is not our fault, but a bug in matplotlib. The same test passes in our Extensive tests CI. The version of ubuntu was different (ubuntu-latest vs ubuntu-22.04), so I tried changing the version to 22.04 in tests.yml to match extensive_tests.yml. This resolves the problem. Hopefully eventually the bug in matplotlib will be fixed so we can use ubuntu-latest.

Also, I realized that `run_parallel_examples` was not being called in the `extensive_test.yml` workflow now that we removed SPEC today in #571. This is corrected here.

There is still an issue with the unit tests in the tests.yml workflow taking forever to run. This seems unrelated to the issue with the integrated tests so I'll defer it to a separate issue and PR.