### PR TITLE
Remove macos-13 from github actions workflows

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest,  macos-14]
+        platform: [ubuntu-latest,  macos-15]
         python-version: ["3.9"]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-14 is apple silicon
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-15-intel]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15, macos-15-intel]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Our wheel and conda workflows are failing because MacOS-13 has just been removed from Github Actions. See 

https://github.com/actions/runner-images/issues/13046

https://github.com/actions/runner-images/issues/13045

This PR should fix the workflows.

