### PR TITLE
make matplotlib a local import

### DIFF
--- a/src/simsopt/util/permanent_magnet_helper_functions.py
+++ b/src/simsopt/util/permanent_magnet_helper_functions.py
@@ -9,8 +9,6 @@ __all__ = [
            ]
 
 import numpy as np
-from matplotlib import pyplot as plt
-import matplotlib.animation as animation
 from pathlib import Path
 
 def initialize_coils_for_pm_optimization(config_flag, TEST_DIR, s, out_dir=''):
@@ -110,6 +108,9 @@ def make_optimization_plots(RS_history, m_history, m_proxy_history, pm_opt, out_
         pm_opt: PermanentMagnetGrid class object that was optimized.
         out_dir: Path or string for the output directory for saved files.
     """
+    from matplotlib import pyplot as plt
+    import matplotlib.animation as animation
+    
     out_dir = Path(out_dir)
 
     # Make plot of the relax-and-split convergence


### PR DESCRIPTION
when running simsopt on a shared memory architecture with multiple cores loading simsopt at the same time, I receive the warning:

`Matplotlib is building the font cache; this may take a moment.`

and the tasks all hang.  Apparently the font cache is being created in the same temporary location by all cores at once, causing memory contention issues and hanging.  The scripts for which this happens do not use matplotlib, meaning the package is being loaded despite the fact that I don't need it.

Moving the matplotlib import from a global one to a local one appears to fix this.