### PR TITLE
adapt BS pointsetting in QFM label functions

### DIFF
--- a/tests/geo/test_qfm.py
+++ b/tests/geo/test_qfm.py
@@ -26,10 +26,9 @@ class QfmSurfaceTests(unittest.TestCase):
 
         s = get_exact_surface()
         base_curves, base_currents, ma, nfp, bs = get_data("ncsx")
-        bs_tf = BiotSavart(bs.coils)
 
         weight = 1.
-        tf = ToroidalFlux(s, bs_tf)
+        tf = ToroidalFlux(s, bs)
 
         # these data are obtained from `boozer` branch of pyplamsaopt
         tf_target = 0.41431152
@@ -54,12 +53,11 @@ class QfmSurfaceTests(unittest.TestCase):
     def subtest_qfm_objective_gradient(self, surfacetype, stellsym, config):
         np.random.seed(1)
         base_curves, base_currents, ma, nfp, bs = get_data(config)
-        bs_tf = BiotSavart(bs.coils)
 
         s = get_surface(surfacetype, stellsym)
         s.fit_to_curve(ma, 0.1)
 
-        tf = ToroidalFlux(s, bs_tf)
+        tf = ToroidalFlux(s, bs)
 
         tf_target = 0.1
         qfm_surface = QfmSurface(bs, s, tf, tf_target)
@@ -96,12 +94,11 @@ class QfmSurfaceTests(unittest.TestCase):
     def subtest_qfm_label_constraint_gradient(self, surfacetype, stellsym):
         np.random.seed(1)
         base_curves, base_currents, ma, nfp, bs = get_data("ncsx")
-        bs_tf = BiotSavart(bs.coils)
 
         s = get_surface(surfacetype, stellsym)
         s.fit_to_curve(ma, 0.1)
 
-        tf = ToroidalFlux(s, bs_tf)
+        tf = ToroidalFlux(s, bs)
 
         tf_target = 0.1
         qfm_surface = QfmSurface(bs, s, tf, tf_target)
@@ -140,14 +137,13 @@ class QfmSurfaceTests(unittest.TestCase):
     def subtest_qfm_penalty_constraints_gradient(self, surfacetype, stellsym, config):
         np.random.seed(1)
         base_curves, base_currents, ma, nfp, bs = get_data(config)
-        bs_tf = BiotSavart(bs.coils)
 
         s = get_surface(surfacetype, stellsym)
         s.fit_to_curve(ma, 0.1)
 
         weight = 11.1232
 
-        tf = ToroidalFlux(s, bs_tf)
+        tf = ToroidalFlux(s, bs)
 
         tf_target = 0.1
         qfm_surface = QfmSurface(bs, s, tf, tf_target)


### PR DESCRIPTION
`QfmSurface` can take a `label`, which is an `Optimizable` that constrains the surface to a desired quantity. Often used are `Volume` and `ToroidalFlux`. 

There is an issue that surfaceobjectives `ToroidalFlux` and `QfmResidual` set the `BiotSavart`s evaluation points to differently shaped arrays; `QfmResidual` needs to evaluate on the entire surface, whereas `ToroidalFlux` only on a poloidal loop. 
The re-setting of the evaluation points was only done when the `recompute_bell` was rung, allowing re-use of intermediate results calculated in the BiotSavart object, if for example derivatives are requested. 

But when optimizing QFM surfaces for Toroidal flux, the points would still be set to the full surface from the b.n calculation, causing errors. 

In the `test_qfm.py` we used to create a separate `bs_tf` object for the `ToroidalFlux` evaluation to avoid this, but this was confusing: a single BiotSavart should be able to provide all the field-evaluation needs. 

# fix:
The surfaceobjectives now have an attribute `need_to_invalidate`, which is set when the recompute bell is rung. 
They also have an attribute `correct_shape` which is the shape of points the `BiotSavart` expects. 
At each evaluation the shape is tested against `correct_shape`, re-setting the points only if the shape is not correct.  

# why?
This should maintain the speed, as the cache is not invalidated at every evaluation (Evaluations of the derivatives of A and B can reuse previous computations). 

MWE of previously-failing code: 
```python
from simsopt.geo import SurfaceRZFourier
from simsopt.geo.qfmsurface import QfmSurface
from simsopt.geo.surfaceobjectives import QfmResidual, ToroidalFlux
from simsopt.configs import get_data


base_curves, base_currents, ma, nfp, bs = get_data('w7x')

s = SurfaceRZFourier.from_nphi_ntheta(mpol=8, ntor=8, stellsym=True, nfp=nfp, range='half period')

s.fit_to_curve(ma, 0.15, flip_theta=True)

label=ToroidalFlux(s, bs)
toroidal_flux_target=20
qfm_surface = QfmSurface(bs, s, label, toroidal_flux_target)

qfm_surface.minimize_qfm_penalty_constraints_LBFGS(tol=1e-20, maxiter=50,
                                                   constraint_weight=1e-3)
```