### PR TITLE
Pyoculus migration

### DIFF
--- a/.github/workflows/extensive_test.yml
+++ b/.github/workflows/extensive_test.yml
@@ -182,7 +182,7 @@ jobs:
       run: |
         python -m pip install -v .
         python -m pip install --no-binary=mpi4py mpi4py
-        # python -m pip install -v git+https://github.com/zhisong/pyoculus
+        # python -m pip install -v git+https://github.com/pyoculus/pyoculus
         # python -m pip install py_spec h5py
 
     - name: Run examples as part of integrated tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,7 @@ jobs:
         pip install numpy cmake scikit-build f90nml ninja wheel setuptools sympy qsc pyevtk matplotlib plotly networkx pygraphviz mpi4py h5py ground==9 bentley_ottmann==8 f90wrap
 
     # - name: Install pyoculus
-    #   run: pip install -v git+https://github.com/zhisong/pyoculus
+    #   run: pip install -v git+https://github.com/pyoculus/pyoculus
 
     - name: Install booz_xform
       run: pip install -v git+https://github.com/hiddenSymmetries/booz_xform

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -60,7 +60,7 @@ RUN git clone --depth 1 https://github.com/hiddenSymmetries/VMEC2000.git /src/VM
     cp cmake/machines/ubuntu.json cmake_config_file.json && \
     /venv/bin/pip install -v . 2>&1 | tee vmec_build.log
 
-RUN /venv/bin/pip install git+https://github.com/zhisong/pyoculus
+RUN /venv/bin/pip install git+https://github.com/pyoculus/pyoculus
 RUN /venv/bin/pip install vtk==9.2.6 pyqt5 matplotlib pyevtk plotly
 RUN /venv/bin/pip install mayavi==4.8.3 --no-build-isolation
 RUN /venv/bin/pip install ground==9 bentley_ottmann==8

--- a/ci/singularity.def
+++ b/ci/singularity.def
@@ -74,7 +74,7 @@ Stage: devel
     cd .. && \
     rm -rf VMEC2000
 
-    # /venv/bin/pip install git+https://github.com/zhisong/pyoculus
+    # /venv/bin/pip install git+https://github.com/pyoculus/pyoculus
     /venv/bin/pip install vtk==9.2.6 pyqt5 matplotlib pyevtk plotly
     /venv/bin/pip install mayavi==4.8.3 --no-build-isolation
     /venv/bin/pip install ground==9 bentley_ottmann==8

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -42,7 +42,7 @@ Also,
     * `booz_xform <https://hiddensymmetries.github.io/booz_xform/>`_
 - For SPEC support:
     * `py_spec <https://github.com/PrincetonUniversity/SPEC/tree/master/Utilities/pythontools>`_
-    * `pyoculus <https://github.com/zhisong/pyoculus>`_
+    * `pyoculus <https://github.com/pyoculus/pyoculus>`_
     * `h5py <https://github.com/h5py/h5py>`_
 
 For requirements of separate physics modules like VMEC, see the


### PR DESCRIPTION
`pyoculus` repo moved from private ownership by @zhisong to github organization `pyoculus` for future maintainability.

Organization has owners @smiet  and @zhisong. 
Organization structure allows sharing and changing of ownership of repo and future maintainability, as well as automating pypi uploads (wip on pyoculus end)