### PR TITLE
Add finite-beta Boozer surface workflow

### DIFF
--- a/docs/source/example_boozer_finitebeta.rst
+++ b/docs/source/example_boozer_finitebeta.rst
@@ -1,0 +1,139 @@
+.. _example_boozer_finitebeta:
+
+Finite-Beta Boozer Surfaces
+===========================
+
+This tutorial documents the finite-beta Boozer-surface workflow introduced
+alongside the existing vacuum :simsopt_file:`examples/2_Intermediate/boozerQA.py`
+example. The corresponding script is
+:simsopt_file:`examples/2_Intermediate/boozerQA_finitebeta.py`.
+
+The current implementation is intentionally staged. It already supports a
+finite-beta least-squares solve on a given surface for
+
+- the rotational transform ``iota``,
+- the Boozer-current parameter ``G``,
+- the internal current ``I``, and
+- a single-valued surface-current potential ``Phi``.
+
+The example script is intentionally kept close to the structure of
+:simsopt_file:`examples/2_Intermediate/boozerQA.py`: a flat top-level flow with
+the prescribed-field QA path as the default branch, plus two explicit alternate
+modes for fixed-field and VMEC-backed runs.
+
+The residual blocks enforced in this solve are
+
+.. math::
+
+   (G + \iota I) B_{\mathrm{in}} - |B_{\mathrm{in}}|^2 (x_\varphi + \iota x_\theta) = 0,
+
+.. math::
+
+   B_{\mathrm{out}} \cdot \hat{n} = 0,
+
+.. math::
+
+   |B_{\mathrm{out}}|^2 - |B_{\mathrm{in}}|^2 - 2 \mu_0 \Delta p = 0,
+
+.. math::
+
+   \mu_0 K - \hat{n} \times (B_{\mathrm{out}} - B_{\mathrm{in}}) = 0,
+
+with
+
+.. math::
+
+   K = \hat{n} \times \nabla \Phi.
+
+Three modes are presently exposed in the example script.
+
+Prescribed-field QA mode
+------------------------
+
+The default example path is a self-contained prescribed-field problem. In this
+mode the magnetic fields are provided by callables that can be reevaluated when
+the surface moves, so the script can perform an actual surface-optimization
+loop around :obj:`~simsopt.geo.FiniteBetaBoozerSurface` without any ideal-MHD
+solver in the optimization loop.
+
+One validation command is
+
+.. code-block:: bash
+
+   SIMSOPT_FINITE_BETA_MODE=prescribed \
+   SIMSOPT_FINITE_BETA_NPHI=8 \
+   SIMSOPT_FINITE_BETA_NTHETA=8 \
+   SIMSOPT_FINITE_BETA_MAX_NFEV=20 \
+   SIMSOPT_FINITE_BETA_QA_MAXITER=5 \
+   python examples/2_Intermediate/boozerQA_finitebeta.py
+
+This prescribed-field branch is the current end-to-end moving-surface QA
+demonstration.
+The ``SIMSOPT_FINITE_BETA_QA_MAXITER`` variable controls the outer L-BFGS-B
+iterations, while ``SIMSOPT_FINITE_BETA_MAX_NFEV`` controls the inner
+finite-beta least-squares solves.
+
+Prescribed fixed-field solve mode
+---------------------------------
+
+Set ``SIMSOPT_FINITE_BETA_MODE=prescribed-fixed`` to run the same prescribed
+surface-field setup with explicit ``B_in`` and ``B_out`` arrays held fixed on
+the surface quadrature grid. In this mode the example exercises the analytic
+surface-dof Jacobian inside :obj:`~simsopt.geo.FiniteBetaBoozerSurface.run_code`.
+
+One validation command is
+
+.. code-block:: bash
+
+   SIMSOPT_FINITE_BETA_MODE=prescribed-fixed \
+   SIMSOPT_FINITE_BETA_NPHI=8 \
+   SIMSOPT_FINITE_BETA_NTHETA=8 \
+   SIMSOPT_FINITE_BETA_MAX_NFEV=20 \
+   python examples/2_Intermediate/boozerQA_finitebeta.py
+
+This mode is useful when the surface fields are the given optimization data and
+no field reevaluation is needed when the surface moves.
+
+Auxiliary VMEC-backed mode
+--------------------------
+
+Set ``SIMSOPT_FINITE_BETA_MODE=vmec`` to load a VMEC equilibrium and
+virtual-casing data, fit a :obj:`~simsopt.geo.SurfaceXYZTensorFourier`
+representation to the VMEC boundary, and solve the finite-beta residual system
+on that fixed surface.
+
+This VMEC-backed branch is an auxiliary validation and diagnostics workflow,
+not the main optimization path. It is useful when an external equilibrium is
+available and you want to generate or compare surface field data.
+
+One VMEC-backed validation command is
+
+.. code-block:: bash
+
+   SIMSOPT_FINITE_BETA_MODE=vmec \
+   SIMSOPT_FINITE_BETA_NPHI=8 \
+   SIMSOPT_FINITE_BETA_NTHETA=8 \
+   SIMSOPT_FINITE_BETA_MAX_NFEV=20 \
+   python examples/2_Intermediate/boozerQA_finitebeta.py
+
+With such reduced smoke-test settings, this branch may stop because the maximum
+number of function evaluations is reached before convergence. That is expected
+for a quick validation run. Increase ``SIMSOPT_FINITE_BETA_MAX_NFEV`` when you
+want a tighter fixed-surface solve from VMEC-backed data.
+
+You can override the equilibrium with ``SIMSOPT_FINITE_BETA_VMEC=/path/to/input.file``
+and set a constant pressure jump using ``SIMSOPT_FINITE_BETA_PRESSURE_JUMP=value``.
+If you already have cached virtual-casing data, set
+``SIMSOPT_FINITE_BETA_VCASING=/path/to/vcasing_*.nc`` to use that file directly.
+For backward compatibility, ``SIMSOPT_FINITE_BETA_SYNTHETIC=1`` still selects
+the prescribed-field QA mode.
+
+Relevant APIs
+-------------
+
+- :obj:`~simsopt.geo.FiniteBetaBoozerSurface`
+- :obj:`~simsopt.geo.finite_beta_boozer_residual`
+- :obj:`~simsopt.geo.finite_beta_sheet_current`
+- :obj:`~simsopt.geo.surface_field_nonquasisymmetric_ratio`
+
+For the public geometry and API reference, see :doc:`geo` and :doc:`simsopt.geo`.

--- a/docs/source/geo.rst
+++ b/docs/source/geo.rst
@@ -164,6 +164,13 @@ A number of objective functions related to surfaces are available in :obj:`simso
 - :obj:`~simsopt.geo.ToroidalFlux`: computes the flux through a toroidal cross section of a :obj:`~simsopt.geo.Surface`.
 - :obj:`~simsopt.geo.PrincipalCurvature`: computes a metric which penalizes large values of the principal curvatures of a given :obj:`~simsopt.geo.Surface`.
 
+For Boozer-surface workflows, Simsopt provides both the established vacuum
+:obj:`~simsopt.geo.BoozerSurface` class and the staged finite-beta
+:obj:`~simsopt.geo.FiniteBetaBoozerSurface` class. The finite-beta path adds
+pressure-balance and jump-condition residuals together with a surface-current
+potential solve. A tutorial for this workflow is available in
+:doc:`example_boozer_finitebeta`.
+
 The value of the quantity and its derivative with respect to the surface dofs can be obtained by calling e.g., :obj:`ToroidalFlux.J() <simsopt.geo.ToroidalFlux.J>` and :obj:`ToroidalFlux.dJ_by_dsurfacecoefficients() <simsopt.geo.ToroidalFlux.dJ_by_dsurfacecoefficients>`.
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -86,6 +86,7 @@ optimization.  Others include `STELLOPT
    example_vmec
    example_vmec_only
    example_quasisymmetry
+  example_boozer_finitebeta
    example_islands
    example_coils
    example_single_stage

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -40,6 +40,9 @@ Also,
       properties of existing ``wout`` output files.
 - For computing Boozer coordinates:
     * `booz_xform <https://hiddensymmetries.github.io/booz_xform/>`_
+- For geometry self-intersection checks used by some surface and Boozer tests:
+    * `ground <https://pypi.org/project/ground/>`_
+    * `bentley-ottmann <https://pypi.org/project/bentley-ottmann/>`_
 - For SPEC support:
     * `py_spec <https://github.com/PrincetonUniversity/SPEC/tree/master/Utilities/pythontools>`_
     * `pyoculus <https://github.com/zhisong/pyoculus>`_

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -43,6 +43,10 @@ processors.
 
 The tests make use of data files in the :simsopt:`tests/test_files` directory.
 
+Some geometry-related tests, including the Boozer surface regression tests,
+also require the optional ``ground`` and ``bentley-ottmann`` python packages
+for self-intersection checks.
+
 Modular testing
 ***************
 
@@ -76,6 +80,29 @@ Parallel Testing
     pytest -n <NUMBER_OF_CORES>
 
 from the ``tests`` directory, where ``<NUMBER_OF_CORES>`` is the number of CPU cores of the machine.
+
+
+Targeted Boozer validation
+**************************
+
+When working on Boozer surface functionality, it is useful to first verify
+that your editable install points at the repository you are modifying:
+
+.. code-block::
+
+    python -c "import pathlib, simsopt; print(pathlib.Path(simsopt.__file__).resolve())"
+
+The printed path should point into your local checkout under ``src/simsopt``.
+
+After that, two targeted regression commands that are useful during development are
+
+.. code-block::
+
+    python -m pytest tests/geo/test_boozersurface.py -q
+    python -m pytest tests/geo/test_finitebeta_boozersurface.py -q
+
+The first command exercises the legacy Boozer surface regression coverage, and the
+second focuses on the finite-beta Boozer surface workflow.
 
 
 Longer examples

--- a/examples/2_Intermediate/boozerQA_finitebeta.py
+++ b/examples/2_Intermediate/boozerQA_finitebeta.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+
+import os
+from pathlib import Path
+
+import numpy as np
+from scipy.optimize import minimize
+
+from simsopt.configs import get_data
+from simsopt.geo import SurfaceRZFourier, SurfaceXYZTensorFourier, FiniteBetaBoozerSurface, Volume
+from simsopt.geo.surfaceobjectives import surface_field_nonquasisymmetric_ratio
+from simsopt.mhd import Vmec, VirtualCasing
+from simsopt.util import in_github_actions
+
+r"""
+This example is the finite-beta counterpart to boozerQA.py.
+
+The main workflow is a single-surface prescribed-field QA optimization.  The
+interior and exterior magnetic fields are specified on the surface, and
+FiniteBetaBoozerSurface solves the finite-beta Boozer residual system on that
+surface without any ideal-MHD solver in the optimization loop.
+
+An auxiliary VMEC-backed mode is available to generate or validate surface field
+data, but it is not the primary optimization path.
+"""
+
+
+OUT_DIR = "./output/"
+os.makedirs(OUT_DIR, exist_ok=True)
+
+print("Running 2_Intermediate/boozerQA_finitebeta.py")
+print("==============================================")
+
+legacy_synthetic_mode = os.environ.get("SIMSOPT_FINITE_BETA_SYNTHETIC")
+default_mode = "prescribed" if legacy_synthetic_mode in (None, "1") else "vmec"
+mode = os.environ.get("SIMSOPT_FINITE_BETA_MODE", default_mode).strip().lower()
+
+nphi_default = 12 if in_github_actions else 24
+ntheta_default = 12 if in_github_actions else 24
+nphi = int(os.environ.get("SIMSOPT_FINITE_BETA_NPHI", str(nphi_default)))
+ntheta = int(os.environ.get("SIMSOPT_FINITE_BETA_NTHETA", str(ntheta_default)))
+ls_max_nfev = int(os.environ.get("SIMSOPT_FINITE_BETA_MAX_NFEV", "40"))
+qa_maxiter_default = 10 if in_github_actions else 30
+qa_maxiter = int(os.environ.get("SIMSOPT_FINITE_BETA_QA_MAXITER", str(qa_maxiter_default)))
+
+
+def print_blocks(title, result):
+    print(title)
+    for name, values in result["blocks"].items():
+        print(f"{name:>13s} residual norm = {np.linalg.norm(values):.6e}")
+
+
+def write_residual_vtk(surface, result):
+    extra_data = {
+        "B_out_normal": result["blocks"]["normal"][:, :, None],
+        "pressure_balance": result["blocks"]["pressure"][:, :, None],
+        "jump_x": result["blocks"]["jump"][:, :, [0]],
+        "jump_y": result["blocks"]["jump"][:, :, [1]],
+        "jump_z": result["blocks"]["jump"][:, :, [2]],
+    }
+    surface.to_vtk(OUT_DIR + "boozerQA_finitebeta_boundary", extra_data=extra_data)
+
+
+if mode in ("prescribed", "prescribed-fixed", "fixed"):
+    print("Using prescribed-field finite-beta test case")
+    print(
+        f"Mode={mode}, grid: nphi={nphi}, ntheta={ntheta}, "
+        f"ls_max_nfev={ls_max_nfev}, qa_maxiter={qa_maxiter}"
+    )
+
+    _, _, ma, nfp, _ = get_data("ncsx")
+    phis = np.linspace(0, 1 / nfp, nphi, endpoint=False)
+    thetas = np.linspace(0, 1, ntheta, endpoint=False)
+    surface = SurfaceXYZTensorFourier(
+        mpol=3,
+        ntor=3,
+        stellsym=True,
+        nfp=nfp,
+        quadpoints_phi=phis,
+        quadpoints_theta=thetas,
+    )
+    surface.fit_to_curve(ma, 0.1, flip_theta=True)
+
+    iota_target = -0.31
+    G_target = 1.4
+    pressure_jump = 0.0
+    vol = Volume(surface)
+    vol_target = vol.J()
+
+    def B_in(surface):
+        tang = surface.gammadash1() + iota_target * surface.gammadash2()
+        tang_norm_sq = np.sum(tang**2, axis=2)
+        return (G_target / tang_norm_sq)[:, :, None] * tang
+
+    def B_out(surface):
+        return B_in(surface)
+
+    B_in0 = B_in(surface)
+    B_out0 = B_out(surface)
+
+    boozer_surface = FiniteBetaBoozerSurface(
+        None,
+        surface,
+        vol,
+        vol_target,
+        pressure_jump=pressure_jump,
+        options={'verbose': True, 'ls_max_nfev': ls_max_nfev},
+    )
+
+    initial = boozer_surface.residual_blocks(iota=-0.1, G=G_target, I=0.0, B_in=B_in0, B_out=B_out0)
+    print_blocks("Initial residual norms:", initial)
+
+    if mode in ("prescribed-fixed", "fixed"):
+        res = boozer_surface.run_code(iota=-0.1, G=G_target, I=0.0, B_in=B_in0, B_out=B_out0, optimize_G=False)
+        solved = boozer_surface.residual_blocks(
+            iota=res["iota"],
+            G=res["G"],
+            I=res["I"],
+            current_potential=res["current_potential"],
+            B_in=B_in0,
+            B_out=B_out0,
+        )
+        print_blocks("Solved residual norms:", solved)
+        print(
+            f"Solved parameters: success={res['success']}, iota={res['iota']:.6e}, "
+            f"G={res['G']:.6e}, I={res['I']:.6e}, ||r||={res['residual_norm']:.6e}"
+        )
+
+        surface.x = surface.x + 1e-3 * np.random.default_rng(7).standard_normal(surface.x.shape)
+        res = boozer_surface.run_code(
+            iota=res["iota"],
+            G=res["G"],
+            I=res["I"],
+            current_potential=res["current_potential"],
+            B_in=B_in0,
+            B_out=B_out0,
+            optimize_G=False,
+            optimize_surface=True,
+        )
+        solved = boozer_surface.residual_blocks(
+            iota=res["iota"],
+            G=res["G"],
+            I=res["I"],
+            current_potential=res["current_potential"],
+            B_in=B_in0,
+            B_out=B_out0,
+        )
+        print_blocks("Analytic fixed-field surface solve residual norms:", solved)
+        print(
+            f"Fixed-field surface solve: success={res['success']}, iota={res['iota']:.6e}, "
+            f"mr={surface.major_radius():.6e}, ||r||={res['residual_norm']:.6e}"
+        )
+        write_residual_vtk(surface, solved)
+        print("Prescribed fixed-field finite-beta solve complete.")
+
+    else:
+        res = boozer_surface.run_code(iota=-0.1, G=G_target, I=0.0, B_in=B_in, B_out=B_out, optimize_G=False)
+        solved = boozer_surface.residual_blocks(
+            iota=res["iota"],
+            G=res["G"],
+            I=res["I"],
+            current_potential=res["current_potential"],
+            B_in=B_in,
+            B_out=B_out,
+        )
+        print_blocks("Solved residual norms:", solved)
+        print(
+            f"Solved parameters: success={res['success']}, iota={res['iota']:.6e}, "
+            f"G={res['G']:.6e}, I={res['I']:.6e}, ||r||={res['residual_norm']:.6e}"
+        )
+
+        iota0 = res["iota"]
+        mr0 = surface.major_radius()
+
+        def fun(dofs):
+            surface.x = dofs
+            res_local = boozer_surface.run_code(
+                iota=boozer_surface.res["iota"],
+                G=G_target,
+                I=boozer_surface.res["I"],
+                current_potential=boozer_surface.res["current_potential"],
+                B_in=B_in,
+                B_out=B_out,
+                optimize_G=False,
+            )
+            field = B_in(surface)
+            J_nonqs = surface_field_nonquasisymmetric_ratio(surface, field)
+            J_iota = 0.5 * (res_local["iota"] - iota0)**2
+            J_mr = 0.5 * (surface.major_radius() - mr0)**2
+            J = J_nonqs + J_iota + J_mr
+            print(
+                f"J={J:.3e}, J_nonqs={J_nonqs:.3e}, iota={res_local['iota']:.3e}, "
+                f"mr={surface.major_radius():.3e}, ||r||={res_local['residual_norm']:.3e}"
+            )
+            return J
+
+        print("Running prescribed-field finite-beta QA optimization")
+        minimize(fun, surface.x, method="L-BFGS-B", options={"maxiter": qa_maxiter})
+
+        res = boozer_surface.run_code(
+            iota=boozer_surface.res["iota"],
+            G=G_target,
+            I=boozer_surface.res["I"],
+            current_potential=boozer_surface.res["current_potential"],
+            B_in=B_in,
+            B_out=B_out,
+            optimize_G=False,
+        )
+        field = B_in(surface)
+        solved = boozer_surface.residual_blocks(
+            iota=res["iota"],
+            G=res["G"],
+            I=res["I"],
+            current_potential=res["current_potential"],
+            B_in=B_in,
+            B_out=B_out,
+        )
+        print(
+            f"Final QA ratio={surface_field_nonquasisymmetric_ratio(surface, field):.6e}, "
+            f"iota={res['iota']:.6e}, mr={surface.major_radius():.6e}"
+        )
+        write_residual_vtk(surface, solved)
+        print("Prescribed-field finite-beta QA solve complete.")
+
+elif mode == "vmec":
+    print("Using auxiliary VMEC-backed finite-beta case")
+    test_dir = (Path(__file__).parent / ".." / ".." / "tests" / "test_files").resolve()
+    default_vmec_input = test_dir / "input.W7-X_without_coil_ripple_beta0p05_d23p4_tm"
+    vmec_filename = Path(os.environ.get("SIMSOPT_FINITE_BETA_VMEC", str(default_vmec_input))).resolve()
+    if not vmec_filename.exists():
+        raise FileNotFoundError(
+            f"VMEC input or wout file not found: {vmec_filename}. Set SIMSOPT_FINITE_BETA_VMEC to a valid path."
+        )
+
+    pressure_jump = float(os.environ.get("SIMSOPT_FINITE_BETA_PRESSURE_JUMP", "0.0"))
+    print(f"VMEC file: {vmec_filename}")
+    print(f"Grid: nphi={nphi}, ntheta={ntheta}, ls_max_nfev={ls_max_nfev}, pressure_jump={pressure_jump}")
+
+    vmec = Vmec(str(vmec_filename))
+    vmec.run()
+
+    vc_override = os.environ.get("SIMSOPT_FINITE_BETA_VCASING")
+    if vc_override:
+        vc_filename = Path(vc_override).resolve()
+    else:
+        vc_filename = vmec_filename.with_name(vmec_filename.name.replace("input.", "vcasing_") + ".nc")
+
+    if vc_filename.exists():
+        print(f"Loading saved virtual casing result from {vc_filename}")
+        vc = VirtualCasing.load(str(vc_filename))
+    else:
+        print("Running virtual casing calculation")
+        try:
+            vc = VirtualCasing.from_vmec(
+                vmec,
+                src_nphi=nphi,
+                src_ntheta=ntheta,
+                trgt_nphi=nphi,
+                trgt_ntheta=ntheta,
+                filename=str(vc_filename),
+            )
+        except ModuleNotFoundError as err:
+            if err.name == "virtual_casing":
+                raise ModuleNotFoundError(
+                    "The auxiliary VMEC-backed mode needs the optional virtual_casing package when no cached vcasing file is available. "
+                    "Install virtual_casing or set SIMSOPT_FINITE_BETA_VCASING to an existing vcasing_*.nc file."
+                ) from err
+            raise
+
+    boundary_rz = SurfaceRZFourier.from_nphi_ntheta(
+        mpol=vmec.wout.mpol,
+        ntor=vmec.wout.ntor,
+        nfp=vmec.wout.nfp,
+        stellsym=not bool(vmec.wout.lasym),
+        nphi=nphi,
+        ntheta=ntheta,
+        range="half period",
+    )
+    boundary_rz.x = vmec.boundary.x
+
+    surface = SurfaceXYZTensorFourier(
+        mpol=vmec.wout.mpol,
+        ntor=vmec.wout.ntor,
+        nfp=vmec.wout.nfp,
+        stellsym=not bool(vmec.wout.lasym),
+        quadpoints_phi=boundary_rz.quadpoints_phi,
+        quadpoints_theta=boundary_rz.quadpoints_theta,
+    )
+    surface.least_squares_fit(boundary_rz.gamma())
+    vol = Volume(surface)
+    vol_target = vol.J()
+
+    boozer_surface = FiniteBetaBoozerSurface(
+        None,
+        surface,
+        vol,
+        vol_target,
+        pressure_jump=pressure_jump,
+        options={'verbose': True, 'ls_max_nfev': ls_max_nfev},
+    )
+
+    B_in = vc.B_total - vc.B_external
+    B_out = vc.B_external
+    initial = boozer_surface.residual_blocks(iota=vmec.iota_edge(), G=0.0, I=0.0, B_in=B_in, B_out=B_out)
+    print_blocks("Initial residual norms:", initial)
+
+    res = boozer_surface.run_code(iota=vmec.iota_edge(), G=0.0, I=0.0, B_in=B_in, B_out=B_out, optimize_G=False)
+    solved = boozer_surface.residual_blocks(
+        iota=res["iota"],
+        G=res["G"],
+        I=res["I"],
+        current_potential=res["current_potential"],
+        B_in=B_in,
+        B_out=B_out,
+    )
+    print_blocks("Solved residual norms:", solved)
+    print(
+        f"Solved parameters: success={res['success']}, iota={res['iota']:.6e}, "
+        f"G={res['G']:.6e}, I={res['I']:.6e}, ||r||={res['residual_norm']:.6e}"
+    )
+    write_residual_vtk(surface, solved)
+    if res["success"]:
+        print("Auxiliary VMEC-backed finite-beta solve converged.")
+    else:
+        print("Auxiliary VMEC-backed finite-beta run finished without convergence; increase SIMSOPT_FINITE_BETA_MAX_NFEV for a tighter solve.")
+
+else:
+    raise ValueError("SIMSOPT_FINITE_BETA_MODE must be one of 'prescribed', 'prescribed-fixed', or 'vmec'.")
+
+print("End of 2_Intermediate/boozerQA_finitebeta.py")
+print("=============================================")

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,124 @@
+# Finite-Beta Boozer QA Plan
+
+## Goal
+
+Add a new finite-beta Boozer workflow beside the current vacuum Boozer workflow, keeping the existing vacuum path unchanged. The finite-beta path should be implemented as a single-surface least-squares residual system with explicit sheet-current closure, prescribed interior and exterior magnetic fields on the surface, analytic derivatives, tests at several levels, and matching documentation. Ideal-MHD equilibrium solvers may be used to generate validation data, but they are not part of the optimization loop.
+
+## Status
+
+1. Completed: Python finite-beta residual blocks, fixed-surface least-squares solve, analytic derivatives for the parameter block, and targeted finite-beta tests.
+2. Completed: analytic surface-dof derivatives for the fixed-field finite-beta residual blocks, together with a directional finite-difference regression test.
+3. Completed: `FiniteBetaBoozerSurface.run_code()` supports analytic surface optimization for fixed prescribed fields, while reevaluable field providers use numerical surface differentiation.
+4. Completed: a synthetic moving-surface QA example exercises the finite-beta solve inside a surface optimization loop without VMEC in the loop.
+5. Completed: VMEC plus virtual-casing remains available as an auxiliary field-data generation and validation path, while the primary framework is the single-surface prescribed-field problem.
+6. Completed: documentation and regression coverage were added in the same branch as the feature work.
+
+## Closeout
+
+1. Primary workflow: single-surface finite-beta Boozer solve with prescribed `B_in` and `B_out` on one surface.
+2. Auxiliary workflow: VMEC plus virtual-casing can generate or validate surface field data, but is not in the optimization loop.
+3. Legacy coverage preserved: the existing vacuum Boozer regression path remains green alongside the new finite-beta tests.
+4. Branch outcome: the implementation is ready to land as one final PR from the dedicated working branch.
+
+## Phases
+
+### 1. Freeze the physics model
+
+1. Write the governing-model note that defines the exact unknowns, equations, conventions, and limits for the finite-beta Boozer solve.
+2. Freeze the unknown set for the first merge: surface dofs, `iota`, `G`, internal current `I`, and sheet-current potential coefficients `Phi_mn` on the target surface.
+3. Freeze the gauge choice for `Phi`: remove the constant mode or impose zero mean on the single-valued part of `Phi`.
+4. Freeze the finite-beta interface interpretation and its sign conventions.
+5. Freeze the fact that the first finite-beta path is least-squares only.
+
+### 2. Freeze the equations
+
+1. Generalized Boozer tangential relation:
+   `(G + iota I) B_in - |B_in|^2 (x_phi + iota x_theta) = 0`
+2. Normal-field condition:
+   `B_out · n = 0`
+3. Pressure-balance jump condition:
+   `|B_out|^2 - |B_in|^2 - 2 mu0 Delta p = 0`
+4. Tangential jump / sheet-current closure:
+   `mu0 K - n x (B_out - B_in) = 0`
+5. Surface-current representation:
+   `K = n x grad Phi`
+6. Retain the surface label constraint.
+7. Retain the geometric anchor or symmetry-fixing constraint where needed.
+8. Freeze the vacuum limit: when `Delta p = 0`, `I = 0`, and `Phi_mn = 0`, the new path must reduce to the current vacuum behavior.
+
+### 3. Source-code architecture
+
+1. Keep the current vacuum Boozer implementation unchanged.
+2. Add a new finite-beta driver class, preferably `FiniteBetaBoozerSurface`, as a sibling to `BoozerSurface`.
+3. Add the finite-beta residual builder and differentiated residual helpers in `src/simsopt/geo/surfaceobjectives.py`.
+4. Add minimal surface-current field support under `src/simsopt/field` if needed.
+5. Treat prescribed `B_in` and `B_out` on the surface as the primary finite-beta interface. Reuse `src/simsopt/mhd/virtual_casing.py` only as an optional data-generation path when helpful.
+6. Delay compiled-kernel work until the Python equations and derivative tests are stable.
+
+### 4. Python-first implementation
+
+1. Build the finite-beta residual assembly in Python first.
+2. Keep the residual blocks separable: generalized Boozer residual, normal-field residual, pressure-balance residual, jump residual, label residual, and `Phi` gauge residual.
+3. Expose both the full stacked residual and per-block diagnostics.
+4. Keep the primary solve path on a single target surface with prescribed field data, and only use VMEC-backed cases as optional validation inputs.
+
+### 5. Analytic derivatives
+
+1. Require analytic derivatives from the start.
+2. Differentiate each residual block with respect to surface dofs, `iota`, `G`, `I`, and `Phi_mn`.
+3. Reuse the existing Biot-Savart derivative and adjoint patterns where possible.
+4. Add compiled derivative parity only after the Python derivatives pass Taylor tests.
+
+### 6. Validation and testing
+
+1. Algebraic validation on manufactured limits.
+2. Physics validation on fixed prescribed-field cases, with optional VMEC plus virtual-casing validation when available.
+3. Cross-limit validation back to vacuum.
+4. Solver validation that every residual block decreases.
+5. Unit tests for residual assembly, gauge handling, and derivatives.
+6. Physics tests for vacuum limit, pressure-balance sign, jump response, and gauge invariance.
+7. Regression tests for the existing vacuum Boozer path.
+8. Example smoke tests in CI-scale settings.
+
+### 7. Example work
+
+1. Create `examples/2_Intermediate/boozerQA_finitebeta.py` as a near-copy of `examples/2_Intermediate/boozerQA.py`.
+2. Keep the script layout parallel to the vacuum example.
+3. Make the single-surface prescribed-field workflow the primary example path, with optional VMEC-backed data loading only as an auxiliary mode.
+4. Add a CI-scale mode using `in_github_actions` or similar.
+
+### 8. Documentation
+
+1. Add user-facing documentation for the new finite-beta Boozer example.
+2. Document the new example script, required dependencies, and runtime expectations.
+3. Add API documentation for the new finite-beta Boozer driver class.
+4. Add API documentation for any new surface-current field representation.
+5. Update `docs/source/fields.rst` if a new field type is added.
+6. Update `docs/source/geo.rst` if a new Boozer or geometry API is added.
+7. Keep documentation in the same PR as the feature.
+
+### 9. PR and branch plan
+
+1. Keep all remaining work on the implementation branch from upstream `master`.
+2. Working branch: `feature/finite-beta-boozer-surface`.
+3. Land the feature as one final PR once the single-surface finite-beta framework, validation, and documentation are complete.
+4. In the final PR description, include motivation, governing equations, unknown set, solver choice, validation matrix, runtime impact, regression coverage, and documentation changes.
+
+## Verification checklist
+
+1. Done: governing equations and sign conventions are frozen in writing.
+2. Done: Python finite-beta residual assembly is implemented and block diagnostics are available.
+3. Done: first-derivative Taylor tests pass for the implemented new unknown groups.
+4. Done: physics tests cover the vacuum limit, pressure-balance sign, jump-condition response, and gauge handling.
+5. Done: existing vacuum Boozer tests remain green.
+6. Done: the new example runs in CI-scale prescribed mode, with auxiliary VMEC-backed validation available.
+7. Done: documentation for the new example and the new geometry API is included.
+8. Deferred by design: compiled performance parity work was kept out of scope for the first implementation.
+
+## Out of scope for the first implementation
+
+1. Multi-surface finite-beta Boozer QA.
+2. A broad free-boundary equilibrium refactor inside simsopt.
+3. Replacing the virtual-casing package or redesigning its global API.
+4. General-purpose surface-current infrastructure beyond what the finite-beta Boozer path strictly needs.
+5. Aggressive performance optimization before correctness and tests are complete.

--- a/src/simsopt/geo/boozersurface.py
+++ b/src/simsopt/geo/boozersurface.py
@@ -3,11 +3,502 @@ from scipy.linalg import lu
 from scipy.optimize import minimize, least_squares
 import simsoptpp as sopp
 
-from .surfaceobjectives import boozer_surface_residual, boozer_surface_dexactresidual_dcoils_dcurrents_vjp, boozer_surface_dlsqgrad_dcoils_vjp
+from .surfaceobjectives import boozer_surface_residual, boozer_surface_dexactresidual_dcoils_dcurrents_vjp, boozer_surface_dlsqgrad_dcoils_vjp, finite_beta_boozer_residual, finite_beta_boozer_residual_dsurface, finite_beta_boozer_residual_dparameters
 from .._core.optimizable import Optimizable
 from functools import partial
 
-__all__ = ['BoozerSurface']
+__all__ = ['BoozerSurface', 'FiniteBetaBoozerSurface']
+
+
+class FiniteBetaBoozerSurface(Optimizable):
+    r"""
+    Entry point for the upcoming finite-beta Boozer-surface workflow.
+
+    The finite-beta formulation extends the vacuum Boozer-surface solve with a
+    pressure-jump model, an internal current scalar ``I``, and a sheet-current
+    potential ``Phi`` on the target surface. The full residual assembly and solve
+    are introduced incrementally, so this class presently provides the validated
+    constructor-level API, option handling, and pressure-jump resolution logic
+    needed by the later implementation phases.
+
+    Args:
+        biotsavart (:obj:`~simsopt.field.BiotSavart`): Coil field used to seed the
+            finite-beta solve.
+        surface (:obj:`~simsopt.geo.SurfaceXYZFourier`,
+            :obj:`~simsopt.geo.SurfaceXYZTensorFourier`): Target surface.
+        label (:obj:`~simsopt._core.optimizable.Optimizable`): Surface label
+            evaluator, e.g. :obj:`~simsopt.geo.Volume` or
+            :obj:`~simsopt.geo.Area`.
+        targetlabel (float): Target value of the label on the surface.
+        pressure_jump (float or callable, optional): Pressure jump on the target
+            surface. If callable, it may accept either no arguments or the
+            surface object and must return a scalar.
+        virtual_casing (optional): Virtual-casing helper or cached data object to
+            be consumed by the finite-beta solve.
+        constraint_weight (float, optional): Residual weight used by the planned
+            least-squares solve.
+        options (dict, optional): Solver options for the finite-beta workflow.
+    """
+
+    def __init__(self, biotsavart, surface, label, targetlabel,
+                 pressure_jump=None, virtual_casing=None,
+                 constraint_weight=1.0, options=None):
+        depends_on = [biotsavart] if biotsavart is not None else []
+        super().__init__(depends_on=depends_on)
+
+        from simsopt.geo import SurfaceXYZFourier, SurfaceXYZTensorFourier
+        if not isinstance(surface, SurfaceXYZTensorFourier) and not isinstance(surface, SurfaceXYZFourier):
+            raise Exception("The input surface must be a SurfaceXYZTensorFourier or SurfaceXYZFourier.")
+
+        self.biotsavart = biotsavart
+        self.surface = surface
+        self.label = label
+        self.targetlabel = targetlabel
+        self.pressure_jump = pressure_jump
+        self.virtual_casing = virtual_casing
+        self.constraint_weight = constraint_weight
+        self.solve_type = 'ls'
+        self.need_to_run_code = True
+        self.res = None
+
+        if options is None:
+            options = {}
+        if 'verbose' not in options:
+            options['verbose'] = True
+        if 'newton_tol' not in options:
+            options['newton_tol'] = 1e-11
+        if 'newton_maxiter' not in options:
+            options['newton_maxiter'] = 40
+        if 'weight_inv_modB' not in options:
+            options['weight_inv_modB'] = True
+        self.options = options
+
+    def _default_G(self):
+        if self.biotsavart is None:
+            return 0.0
+        return 2. * np.pi * np.sum([np.abs(c.current.get_value()) for c in self.biotsavart.coils]) * (4 * np.pi * 10**(-7) / (2 * np.pi))
+
+    def _normalize_current_potential(self, current_potential=None):
+        shape = self.surface.gamma().shape[:2]
+        if current_potential is None:
+            potential = np.zeros(shape)
+        else:
+            potential = np.asarray(current_potential, dtype=float)
+            if potential.shape != shape:
+                raise ValueError(f"current_potential must have shape {shape}.")
+            potential = potential.copy()
+        potential -= potential[0, 0]
+        return potential
+
+    def _pack_state(self, iota, G, I, current_potential,
+                    optimize_iota, optimize_G, optimize_I, optimize_current_potential,
+                    optimize_surface=False, surface_dofs=None):
+        x0 = []
+        if optimize_surface:
+            x0.extend(surface_dofs)
+        if optimize_iota:
+            x0.append(float(iota))
+        if optimize_G:
+            x0.append(float(G))
+        if optimize_I:
+            x0.append(float(I))
+        if optimize_current_potential:
+            x0.extend(current_potential.reshape((-1,))[1:])
+        return np.asarray(x0, dtype=float)
+
+    def _unpack_state(self, vector, iota, G, I, current_potential,
+                      optimize_iota, optimize_G, optimize_I, optimize_current_potential,
+                      optimize_surface=False, nsurfdofs=0):
+        cursor = 0
+        surface_dofs_val = None
+        iota_val = float(iota)
+        G_val = float(G)
+        I_val = float(I)
+        current_potential_val = current_potential.copy()
+
+        if optimize_surface:
+            surface_dofs_val = np.asarray(vector[cursor:cursor + nsurfdofs], dtype=float)
+            cursor += nsurfdofs
+
+        if optimize_iota:
+            iota_val = float(vector[cursor])
+            cursor += 1
+        if optimize_G:
+            G_val = float(vector[cursor])
+            cursor += 1
+        if optimize_I:
+            I_val = float(vector[cursor])
+            cursor += 1
+        if optimize_current_potential:
+            flattened = current_potential_val.reshape((-1,))
+            flattened[1:] = vector[cursor:cursor + flattened.size - 1]
+            cursor += flattened.size - 1
+            current_potential_val = flattened.reshape(current_potential_val.shape)
+        current_potential_val -= current_potential_val[0, 0]
+
+        return surface_dofs_val, iota_val, G_val, I_val, current_potential_val
+
+    def _weighted_residual_vector(self, blocks):
+        weights = self.options.get('block_weights', {})
+        return np.concatenate([
+            weights.get('boozer', 1.0) * blocks['boozer'].reshape((-1,)),
+            weights.get('normal', 1.0) * blocks['normal'].reshape((-1,)),
+            weights.get('pressure', 1.0) * blocks['pressure'].reshape((-1,)),
+            weights.get('jump', 1.0) * blocks['jump'].reshape((-1,)),
+        ])
+
+    def _weighted_parameter_jacobian(self, jacobian):
+        weights = self.options.get('block_weights', {})
+        nphi, ntheta = self.surface.gamma().shape[:2]
+        row_sizes = [
+            ('boozer', nphi * ntheta * 3),
+            ('normal', nphi * ntheta),
+            ('pressure', nphi * ntheta),
+            ('jump', nphi * ntheta * 3),
+        ]
+        pieces = []
+        cursor = 0
+        for name, size in row_sizes:
+            pieces.append(weights.get(name, 1.0) * jacobian[cursor:cursor + size, :])
+            cursor += size
+        return np.concatenate(pieces, axis=0)
+
+    def _weighted_surface_jacobian(self, jacobian):
+        return self._weighted_parameter_jacobian(jacobian)
+
+    def recompute_bell(self, parent=None):
+        self.need_to_run_code = True
+
+    def resolve_pressure_jump(self):
+        """
+        Evaluate the configured pressure jump as a finite scalar.
+        """
+        if self.pressure_jump is None:
+            return None
+
+        if callable(self.pressure_jump):
+            try:
+                value = self.pressure_jump(self.surface)
+            except TypeError:
+                value = self.pressure_jump()
+        else:
+            value = self.pressure_jump
+
+        value = float(value)
+        if not np.isfinite(value):
+            raise ValueError("pressure_jump must evaluate to a finite scalar.")
+        return value
+
+    def resolve_field_components(self, B_in=None, B_out=None):
+        """
+        Return interior and exterior magnetic fields on the surface grid.
+
+        Explicit arrays take precedence. If they are omitted and a virtual casing
+        object with ``B_total`` and ``B_external`` is attached, those arrays are
+        used. Otherwise, the Biot-Savart field is used on both sides, giving the
+        vacuum limit.
+        """
+        if (B_in is None) != (B_out is None):
+            raise ValueError("B_in and B_out must be provided together.")
+
+        expected_shape = self.surface.gamma().shape
+        if callable(B_in) or callable(B_out):
+            if not callable(B_in) or not callable(B_out):
+                raise ValueError("B_in and B_out must either both be callables or both be arrays.")
+            B_in = np.asarray(B_in(self.surface))
+            B_out = np.asarray(B_out(self.surface))
+            if B_in.shape != expected_shape or B_out.shape != expected_shape:
+                raise ValueError(f"Callable B_in and B_out must return arrays with shape {expected_shape}.")
+            return B_in, B_out
+
+        if B_in is not None:
+            B_in = np.asarray(B_in)
+            B_out = np.asarray(B_out)
+            if B_in.shape != expected_shape or B_out.shape != expected_shape:
+                raise ValueError(f"B_in and B_out must have shape {expected_shape}.")
+            return B_in, B_out
+
+        vc = self.virtual_casing
+        if vc is not None and hasattr(vc, 'B_total') and hasattr(vc, 'B_external'):
+            B_total = np.asarray(vc.B_total)
+            B_external = np.asarray(vc.B_external)
+            if B_total.shape != expected_shape or B_external.shape != expected_shape:
+                raise ValueError(
+                    f"virtual_casing.B_total and virtual_casing.B_external must have shape {expected_shape}."
+                )
+            return B_total - B_external, B_external
+
+        if self.biotsavart is None:
+            raise ValueError("biotsavart is required when explicit fields or virtual_casing data are not provided.")
+
+        x = self.surface.gamma().reshape((-1, 3))
+        self.biotsavart.set_points(x)
+        self.biotsavart.compute(0)
+        B = self.biotsavart.B().reshape(expected_shape)
+        return B, B
+
+    def residual_blocks(self, iota, G, I=0.0, pressure_jump=None,
+                        current_potential=None, current_potential_derivatives=None,
+                        B_in=None, B_out=None):
+        resolved_pressure_jump = self.resolve_pressure_jump() if pressure_jump is None else pressure_jump
+        if resolved_pressure_jump is None:
+            resolved_pressure_jump = 0.0
+
+        resolved_B_in, resolved_B_out = self.resolve_field_components(B_in=B_in, B_out=B_out)
+        return finite_beta_boozer_residual(
+            self.surface,
+            iota,
+            G,
+            resolved_B_in,
+            resolved_B_out,
+            I=I,
+            pressure_jump=resolved_pressure_jump,
+            current_potential=current_potential,
+            current_potential_derivatives=current_potential_derivatives,
+        )
+
+    def residual_parameter_jacobian(self, iota, G, I=0.0,
+                                    B_in=None, B_out=None,
+                                    optimize_iota=True, optimize_G=False,
+                                    optimize_I=True, optimize_current_potential=True):
+        resolved_B_in, resolved_B_out = self.resolve_field_components(B_in=B_in, B_out=B_out)
+        derivatives = finite_beta_boozer_residual_dparameters(
+            self.surface,
+            iota,
+            G,
+            resolved_B_in,
+            resolved_B_out,
+            I=I,
+        )
+
+        columns = []
+        if optimize_iota:
+            columns.append(derivatives['iota'][:, None])
+        if optimize_G:
+            columns.append(derivatives['G'][:, None])
+        if optimize_I:
+            columns.append(derivatives['I'][:, None])
+        if optimize_current_potential:
+            columns.append(derivatives['current_potential'][:, 1:])
+
+        if len(columns) == 0:
+            reference = self.residual_blocks(iota=iota, G=G, I=I, B_in=resolved_B_in, B_out=resolved_B_out)
+            return np.zeros((self._weighted_residual_vector(reference['blocks']).size, 0))
+
+        return self._weighted_parameter_jacobian(np.concatenate(columns, axis=1))
+
+    def residual_surface_jacobian(self, iota, G, I=0.0,
+                                  current_potential=None,
+                                  current_potential_derivatives=None,
+                                  B_in=None, B_out=None):
+        resolved_B_in, resolved_B_out = self.resolve_field_components(B_in=B_in, B_out=B_out)
+        derivatives = finite_beta_boozer_residual_dsurface(
+            self.surface,
+            iota,
+            G,
+            resolved_B_in,
+            resolved_B_out,
+            I=I,
+            current_potential=current_potential,
+            current_potential_derivatives=current_potential_derivatives,
+        )
+        return self._weighted_surface_jacobian(derivatives['residual'])
+
+    def _surface_constraint_residual(self):
+        label_residual = float(self.constraint_weight) * (self.label.J() - self.targetlabel)
+        anchor_residual = self.surface.gamma()[0, 0, 2]
+        return np.asarray([label_residual, anchor_residual])
+
+    def _surface_constraint_jacobian(self):
+        label_jacobian = float(self.constraint_weight) * self.label.dJ(partials=True)(self.surface)
+        anchor_jacobian = self.surface.dgamma_by_dcoeff()[0, 0, 2, :]
+        return np.vstack([label_jacobian, anchor_jacobian])
+
+    def run_code(self, iota, G=None, I=0.0, current_potential=None,
+                 B_in=None, B_out=None, optimize_iota=True,
+                 optimize_G=False, optimize_I=True,
+                 optimize_current_potential=True, optimize_surface=False):
+        """
+        Run a finite-beta least-squares solve.
+
+        The current implementation optimizes Boozer parameters and the
+        sheet-current potential on the existing surface quadrature grid. Surface
+        geometry can also be optimized when either fixed field samples are
+        supplied on that grid or the field providers can be reevaluated on the
+        moved surface.
+        """
+        if G is None:
+            G = self._default_G()
+
+        surface_dofs0 = self.surface.x.copy()
+        vc = self.virtual_casing
+        explicit_fields = (B_in is not None and B_out is not None and not callable(B_in) and not callable(B_out))
+        callable_fields = callable(B_in) and callable(B_out)
+        virtual_casing_fields = (
+            B_in is None and B_out is None and vc is not None
+            and hasattr(vc, 'B_total') and hasattr(vc, 'B_external')
+        )
+        biotsavart_fields = B_in is None and B_out is None and not virtual_casing_fields and self.biotsavart is not None
+        analytic_surface_jacobian = optimize_surface and (explicit_fields or virtual_casing_fields)
+
+        if optimize_surface and not (explicit_fields or callable_fields or virtual_casing_fields or biotsavart_fields):
+            raise ValueError(
+                "optimize_surface requires explicit fixed fields, virtual_casing data, callable B_in/B_out providers, or a biotsavart object."
+            )
+
+        if optimize_surface and not analytic_surface_jacobian:
+            resolved_B_in = None
+            resolved_B_out = None
+        else:
+            resolved_B_in, resolved_B_out = self.resolve_field_components(B_in=B_in, B_out=B_out)
+        current_potential0 = self._normalize_current_potential(current_potential)
+        x0 = self._pack_state(iota, G, I, current_potential0,
+                              optimize_iota, optimize_G, optimize_I, optimize_current_potential,
+                              optimize_surface=optimize_surface, surface_dofs=surface_dofs0)
+
+        if x0.size == 0:
+            result = self.residual_blocks(iota=iota, G=G, I=I,
+                                          current_potential=current_potential0,
+                                          B_in=resolved_B_in, B_out=resolved_B_out)
+            residual = self._weighted_residual_vector(result['blocks'])
+            self.res = {
+                'success': True,
+                'iter': 0,
+                'iota': float(iota),
+                'G': float(G),
+                'I': float(I),
+                'current_potential': current_potential0,
+                'residual': residual,
+                'residual_norm': np.linalg.norm(residual),
+                'block_norms': {name: np.linalg.norm(values) for name, values in result['blocks'].items()},
+                'message': 'No free variables selected.',
+            }
+            self.need_to_run_code = False
+            return self.res
+
+        def objective(vector):
+            surface_dofs_val, iota_val, G_val, I_val, current_potential_val = self._unpack_state(
+                vector, iota, G, I, current_potential0,
+                optimize_iota, optimize_G, optimize_I, optimize_current_potential,
+                optimize_surface=optimize_surface, nsurfdofs=surface_dofs0.size,
+            )
+            if optimize_surface:
+                self.surface.x = surface_dofs_val
+                if analytic_surface_jacobian:
+                    resolved_B_in_local = resolved_B_in
+                    resolved_B_out_local = resolved_B_out
+                else:
+                    resolved_B_in_local, resolved_B_out_local = self.resolve_field_components(B_in=B_in, B_out=B_out)
+            else:
+                resolved_B_in_local = resolved_B_in
+                resolved_B_out_local = resolved_B_out
+            result = self.residual_blocks(
+                iota=iota_val,
+                G=G_val,
+                I=I_val,
+                current_potential=current_potential_val,
+                B_in=resolved_B_in_local,
+                B_out=resolved_B_out_local,
+            )
+            residual = self._weighted_residual_vector(result['blocks'])
+            if optimize_surface:
+                residual = np.concatenate([residual, self._surface_constraint_residual()])
+            return residual
+
+        def jacobian(vector):
+            surface_dofs_val, iota_val, G_val, I_val, current_potential_val = self._unpack_state(
+                vector, iota, G, I, current_potential0,
+                optimize_iota, optimize_G, optimize_I, optimize_current_potential,
+                optimize_surface=optimize_surface, nsurfdofs=surface_dofs0.size,
+            )
+            if optimize_surface:
+                self.surface.x = surface_dofs_val
+
+            parameter_jacobian = self.residual_parameter_jacobian(
+                iota=iota_val,
+                G=G_val,
+                I=I_val,
+                B_in=resolved_B_in,
+                B_out=resolved_B_out,
+                optimize_iota=optimize_iota,
+                optimize_G=optimize_G,
+                optimize_I=optimize_I,
+                optimize_current_potential=optimize_current_potential,
+            )
+
+            if not optimize_surface:
+                return parameter_jacobian
+
+            surface_jacobian = self.residual_surface_jacobian(
+                iota=iota_val,
+                G=G_val,
+                I=I_val,
+                current_potential=current_potential_val,
+                B_in=resolved_B_in,
+                B_out=resolved_B_out,
+            )
+            constraint_jacobian = self._surface_constraint_jacobian()
+
+            if parameter_jacobian.shape[1] == 0:
+                residual_jacobian = surface_jacobian
+                full_constraint_jacobian = constraint_jacobian
+            else:
+                residual_jacobian = np.concatenate([surface_jacobian, parameter_jacobian], axis=1)
+                full_constraint_jacobian = np.concatenate(
+                    [constraint_jacobian, np.zeros((constraint_jacobian.shape[0], parameter_jacobian.shape[1]))],
+                    axis=1,
+                )
+            return np.concatenate([residual_jacobian, full_constraint_jacobian], axis=0)
+
+        tol = self.options.get('ls_tol', self.options.get('newton_tol', 1e-11))
+        max_nfev = self.options.get('ls_max_nfev', 100)
+        lsq = least_squares(
+            objective,
+            x0,
+            jac=jacobian if (not optimize_surface or analytic_surface_jacobian) else '2-point',
+            method=self.options.get('ls_method', 'trf'),
+            ftol=tol,
+            xtol=tol,
+            gtol=tol,
+            max_nfev=max_nfev,
+            verbose=2 if self.options.get('verbose', True) else 0,
+        )
+
+        surface_dofs_val, iota_val, G_val, I_val, current_potential_val = self._unpack_state(
+            lsq.x, iota, G, I, current_potential0,
+            optimize_iota, optimize_G, optimize_I, optimize_current_potential,
+            optimize_surface=optimize_surface, nsurfdofs=surface_dofs0.size,
+        )
+        if optimize_surface:
+            self.surface.x = surface_dofs_val
+        result = self.residual_blocks(
+            iota=iota_val,
+            G=G_val,
+            I=I_val,
+            current_potential=current_potential_val,
+            B_in=B_in if optimize_surface else resolved_B_in,
+            B_out=B_out if optimize_surface else resolved_B_out,
+        )
+        residual = self._weighted_residual_vector(result['blocks'])
+        if optimize_surface:
+            residual = np.concatenate([residual, self._surface_constraint_residual()])
+
+        self.res = {
+            'success': bool(lsq.success),
+            'iter': int(lsq.nfev),
+            'surface': self.surface,
+            'iota': iota_val,
+            'G': G_val,
+            'I': I_val,
+            'current_potential': current_potential_val,
+            'residual': residual,
+            'residual_norm': np.linalg.norm(residual),
+            'block_norms': {name: np.linalg.norm(values) for name, values in result['blocks'].items()},
+            'message': lsq.message,
+            'least_squares_result': lsq,
+        }
+        self.need_to_run_code = False
+        return self.res
 
 
 class BoozerSurface(Optimizable):

--- a/src/simsopt/geo/surface.py
+++ b/src/simsopt/geo/surface.py
@@ -1,4 +1,5 @@
 import abc
+import math
 
 import numpy as np
 from scipy import interpolate
@@ -11,7 +12,13 @@ except ImportError:
 try:
     from ground.base import get_context
 except ImportError:
-    get_context = None
+    try:
+        from ground.context import Context
+    except ImportError:
+        get_context = None
+    else:
+        def get_context():
+            return Context(coordinate_factory=float, sqrt=math.sqrt)
 
 try:
     from bentley_ottmann.planar import contour_self_intersects
@@ -463,7 +470,10 @@ class Surface(Optimizable):
         context = get_context()
         Point, Contour = context.point_cls, context.contour_cls
         contour = Contour([Point(R[i], Z[i]) for i in range(cs.shape[0])])
-        return contour_self_intersects(contour)
+        try:
+            return contour_self_intersects(contour, context=context)
+        except TypeError:
+            return contour_self_intersects(contour)
 
     def aspect_ratio(self):
         r"""

--- a/src/simsopt/geo/surfaceobjectives.py
+++ b/src/simsopt/geo/surfaceobjectives.py
@@ -9,9 +9,321 @@ from .surfacexyztensorfourier import SurfaceXYZTensorFourier
 from ..objectives.utilities import forward_backward
 
 __all__ = ['Area', 'Volume', 'ToroidalFlux', 'PrincipalCurvature',
-           'QfmResidual', 'boozer_surface_residual', 'Iotas',
-           'MajorRadius', 'NonQuasiSymmetricRatio', 'BoozerResidual',
-           'AspectRatio']
+           'QfmResidual', 'boozer_surface_residual', 'finite_beta_sheet_current',
+           'finite_beta_boozer_residual', 'finite_beta_boozer_residual_dsurface', 'finite_beta_boozer_residual_dparameters', 'surface_field_nonquasisymmetric_ratio', 'Iotas', 'MajorRadius',
+           'NonQuasiSymmetricRatio', 'BoozerResidual', 'AspectRatio']
+
+
+MU0 = 4 * np.pi * 1e-7
+
+
+def _as_surface_field_array(surface, values, name, trailing_shape):
+    array = np.asarray(values)
+    expected_shape = surface.gamma().shape[:2] + trailing_shape
+    if array.shape != expected_shape:
+        raise ValueError(f"{name} must have shape {expected_shape}, got {array.shape}.")
+    return array
+
+
+def _periodic_spacing(points, period=None):
+    points = np.asarray(points, dtype=float)
+    if points.ndim != 1 or points.size < 2:
+        raise ValueError("Periodic derivatives require at least 2 quadrature points.")
+
+    diffs = np.diff(points)
+    if period is None:
+        period = points[-1] - points[0] + diffs[0]
+    if not np.allclose(diffs, diffs[0]):
+        raise ValueError("Only uniformly spaced quadrature grids are supported for current-potential finite differences.")
+    return float(diffs[0]), float(period)
+
+
+def _periodic_central_difference(values, spacing, axis):
+    return (np.roll(values, -1, axis=axis) - np.roll(values, 1, axis=axis)) / (2 * spacing)
+
+
+def _periodic_central_difference_matrix(length, spacing):
+    identity = np.eye(length)
+    return (np.roll(identity, -1, axis=0) - np.roll(identity, 1, axis=0)) / (2 * spacing)
+
+
+def _surface_potential_derivatives(surface, current_potential):
+    potential = _as_surface_field_array(surface, current_potential, 'current_potential', tuple())
+    dphi, _ = _periodic_spacing(surface.quadpoints_phi)
+    dtheta, _ = _periodic_spacing(surface.quadpoints_theta, period=1.0)
+    return (
+        _periodic_central_difference(potential, dphi, axis=0),
+        _periodic_central_difference(potential, dtheta, axis=1),
+    )
+
+
+def _surface_unitnormal_derivatives(surface):
+    normal = surface.normal()
+    dnormal_dc = surface.dnormal_by_dcoeff()
+    norm_normal = np.linalg.norm(normal, axis=2)
+    dnorm_normal_dc = np.sum(normal[:, :, :, None] * dnormal_dc, axis=2) / norm_normal[:, :, None]
+    dunitnormal_dc = dnormal_dc / norm_normal[:, :, None, None] - \
+        normal[:, :, :, None] * dnorm_normal_dc[:, :, None, :] / norm_normal[:, :, None, None]**2
+    return normal, norm_normal, dnormal_dc, dnorm_normal_dc, dunitnormal_dc
+
+
+def finite_beta_sheet_current(surface, current_potential=None, current_potential_derivatives=None):
+    r"""
+    Compute the surface sheet current
+
+    .. math::
+        \mathbf K = \hat{\mathbf n} \times \nabla \Phi
+
+    on the quadrature grid of ``surface``.
+
+    The sheet-current potential can be supplied either directly as values on the
+    surface quadrature grid, or as a pair of derivatives
+    ``(dPhi_dvarphi, dPhi_dtheta)`` on that same grid. If neither is supplied, a
+    zero sheet current is returned.
+    """
+    x = surface.gamma()
+    xphi = surface.gammadash1()
+    xtheta = surface.gammadash2()
+    normal = surface.normal()
+    norm_normal = np.linalg.norm(normal, axis=2)
+
+    if current_potential is None and current_potential_derivatives is None:
+        return np.zeros_like(x)
+
+    if current_potential_derivatives is None:
+        dphi_potential, dtheta_potential = _surface_potential_derivatives(surface, current_potential)
+    else:
+        if len(current_potential_derivatives) != 2:
+            raise ValueError("current_potential_derivatives must be a pair (dPhi_dvarphi, dPhi_dtheta).")
+        dphi_potential = _as_surface_field_array(surface, current_potential_derivatives[0], 'dPhi_dvarphi', tuple())
+        dtheta_potential = _as_surface_field_array(surface, current_potential_derivatives[1], 'dPhi_dtheta', tuple())
+
+    return (dphi_potential[:, :, None] * xtheta - dtheta_potential[:, :, None] * xphi) / norm_normal[:, :, None]
+
+
+def finite_beta_boozer_residual(surface, iota, G, B_in, B_out, I=0.0,
+                                pressure_jump=0.0, current_potential=None,
+                                current_potential_derivatives=None, mu0=MU0):
+    r"""
+    Assemble the finite-beta Boozer residual blocks on a surface grid.
+
+    The returned dictionary contains the flattened stacked residual and each
+    individual residual block:
+
+    .. math::
+        (G + \iota I) B_\text{in} - |B_\text{in}|^2 (x_\varphi + \iota x_\theta)
+
+    .. math::
+        B_\text{out} \cdot \hat{n}
+
+    .. math::
+        |B_\text{out}|^2 - |B_\text{in}|^2 - 2 \mu_0 \Delta p
+
+    .. math::
+        \mu_0 K - \hat{n} \times (B_\text{out} - B_\text{in})
+    """
+    B_in = _as_surface_field_array(surface, B_in, 'B_in', (3,))
+    B_out = _as_surface_field_array(surface, B_out, 'B_out', (3,))
+
+    xphi = surface.gammadash1()
+    xtheta = surface.gammadash2()
+    unit_normal = surface.unitnormal()
+    tang = xphi + iota * xtheta
+
+    B_in_sq = np.sum(B_in**2, axis=2)
+    B_out_sq = np.sum(B_out**2, axis=2)
+    sheet_current = finite_beta_sheet_current(
+        surface,
+        current_potential=current_potential,
+        current_potential_derivatives=current_potential_derivatives,
+    )
+
+    boozer = (G + iota * I) * B_in - B_in_sq[:, :, None] * tang
+    normal = np.sum(B_out * unit_normal, axis=2)
+    pressure = B_out_sq - B_in_sq - 2.0 * mu0 * float(pressure_jump)
+    jump = mu0 * sheet_current - np.cross(unit_normal, B_out - B_in)
+
+    blocks = {
+        'boozer': boozer,
+        'normal': normal,
+        'pressure': pressure,
+        'jump': jump,
+        'sheet_current': sheet_current,
+    }
+    residual = np.concatenate([
+        boozer.reshape((-1,)),
+        normal.reshape((-1,)),
+        pressure.reshape((-1,)),
+        jump.reshape((-1,)),
+    ])
+    return {
+        'residual': residual,
+        'blocks': blocks,
+    }
+
+
+def finite_beta_boozer_residual_dsurface(surface, iota, G, B_in, B_out, I=0.0,
+                                         current_potential=None,
+                                         current_potential_derivatives=None,
+                                         mu0=MU0):
+    r"""
+    Derivatives of the finite-beta residual with respect to the surface dofs.
+
+    The field samples ``B_in`` and ``B_out`` are treated as fixed values on the
+    current surface quadrature grid. This covers the fixed-field residual
+    assembly used by the staged finite-beta workflow. Field-provider shape
+    derivatives are intentionally out of scope here.
+    """
+    B_in = _as_surface_field_array(surface, B_in, 'B_in', (3,))
+    B_out = _as_surface_field_array(surface, B_out, 'B_out', (3,))
+
+    xphi = surface.gammadash1()
+    xtheta = surface.gammadash2()
+    dxphi_dc = surface.dgammadash1_by_dcoeff()
+    dxtheta_dc = surface.dgammadash2_by_dcoeff()
+    _, norm_normal, _, dnorm_normal_dc, dunitnormal_dc = _surface_unitnormal_derivatives(surface)
+
+    if current_potential is None and current_potential_derivatives is None:
+        dphi_potential = np.zeros(surface.gamma().shape[:2])
+        dtheta_potential = np.zeros(surface.gamma().shape[:2])
+    elif current_potential_derivatives is None:
+        dphi_potential, dtheta_potential = _surface_potential_derivatives(surface, current_potential)
+    else:
+        if len(current_potential_derivatives) != 2:
+            raise ValueError("current_potential_derivatives must be a pair (dPhi_dvarphi, dPhi_dtheta).")
+        dphi_potential = _as_surface_field_array(surface, current_potential_derivatives[0], 'dPhi_dvarphi', tuple())
+        dtheta_potential = _as_surface_field_array(surface, current_potential_derivatives[1], 'dPhi_dtheta', tuple())
+
+    B_in_sq = np.sum(B_in**2, axis=2)
+    delta_B = B_out - B_in
+    sheet_current_numerator = dphi_potential[:, :, None] * xtheta - dtheta_potential[:, :, None] * xphi
+
+    dboozer_dc = -B_in_sq[:, :, None, None] * (dxphi_dc + iota * dxtheta_dc)
+    dnormal_dc = np.sum(B_out[:, :, :, None] * dunitnormal_dc, axis=2)
+    dpressure_dc = np.zeros(dnormal_dc.shape)
+    dsheet_current_dc = (dphi_potential[:, :, None, None] * dxtheta_dc - dtheta_potential[:, :, None, None] * dxphi_dc) / norm_normal[:, :, None, None] - \
+        sheet_current_numerator[:, :, :, None] * dnorm_normal_dc[:, :, None, :] / norm_normal[:, :, None, None]**2
+
+    dunitnormal_dc_moved = np.moveaxis(dunitnormal_dc, -1, 2)
+    djump_dc = mu0 * dsheet_current_dc - np.moveaxis(
+        np.cross(dunitnormal_dc_moved, delta_B[:, :, None, :]),
+        2,
+        -1,
+    )
+
+    residual = np.concatenate([
+        dboozer_dc.reshape((-1, dboozer_dc.shape[-1])),
+        dnormal_dc.reshape((-1, dnormal_dc.shape[-1])),
+        dpressure_dc.reshape((-1, dpressure_dc.shape[-1])),
+        djump_dc.reshape((-1, djump_dc.shape[-1])),
+    ], axis=0)
+    return {
+        'residual': residual,
+        'blocks': {
+            'boozer': dboozer_dc,
+            'normal': dnormal_dc,
+            'pressure': dpressure_dc,
+            'jump': djump_dc,
+            'sheet_current': dsheet_current_dc,
+        },
+    }
+
+
+def finite_beta_boozer_residual_dparameters(surface, iota, G, B_in, B_out, I=0.0,
+                                            mu0=MU0):
+    r"""
+    Derivatives of the fixed-surface finite-beta residual with respect to the
+    scalar parameters ``iota``, ``G``, ``I``, and the current-potential values
+    on the surface grid.
+    """
+    B_in = _as_surface_field_array(surface, B_in, 'B_in', (3,))
+    B_out = _as_surface_field_array(surface, B_out, 'B_out', (3,))
+
+    xphi = surface.gammadash1()
+    xtheta = surface.gammadash2()
+    normal = surface.normal()
+    norm_normal = np.linalg.norm(normal, axis=2)
+    nphi, ntheta = B_in.shape[:2]
+    npts = nphi * ntheta
+
+    B_in_sq = np.sum(B_in**2, axis=2)
+    zeros_scalar = np.zeros((nphi, ntheta))
+    zeros_vector = np.zeros((nphi, ntheta, 3))
+
+    dboozer_diota = I * B_in - B_in_sq[:, :, None] * xtheta
+    dboozer_dG = B_in
+    dboozer_dI = iota * B_in
+
+    dresidual_diota = np.concatenate([
+        dboozer_diota.reshape((-1,)),
+        zeros_scalar.reshape((-1,)),
+        zeros_scalar.reshape((-1,)),
+        zeros_vector.reshape((-1,)),
+    ])
+    dresidual_dG = np.concatenate([
+        dboozer_dG.reshape((-1,)),
+        zeros_scalar.reshape((-1,)),
+        zeros_scalar.reshape((-1,)),
+        zeros_vector.reshape((-1,)),
+    ])
+    dresidual_dI = np.concatenate([
+        dboozer_dI.reshape((-1,)),
+        zeros_scalar.reshape((-1,)),
+        zeros_scalar.reshape((-1,)),
+        zeros_vector.reshape((-1,)),
+    ])
+
+    dphi_spacing, _ = _periodic_spacing(surface.quadpoints_phi)
+    dtheta_spacing, _ = _periodic_spacing(surface.quadpoints_theta, period=1.0)
+    dphi_matrix = np.kron(_periodic_central_difference_matrix(nphi, dphi_spacing), np.eye(ntheta))
+    dtheta_matrix = np.kron(np.eye(nphi), _periodic_central_difference_matrix(ntheta, dtheta_spacing))
+
+    xphi_flat = xphi.reshape((npts, 3))
+    xtheta_flat = xtheta.reshape((npts, 3))
+    norm_normal_flat = norm_normal.reshape((npts,))
+
+    dsheet_current_dpotential = (
+        dphi_matrix[:, None, :] * xtheta_flat[:, :, None]
+        - dtheta_matrix[:, None, :] * xphi_flat[:, :, None]
+    ) / norm_normal_flat[:, None, None]
+    djump_dpotential = mu0 * dsheet_current_dpotential
+
+    jacobian_potential = np.concatenate([
+        np.zeros((npts * 3, npts)),
+        np.zeros((npts, npts)),
+        np.zeros((npts, npts)),
+        djump_dpotential.reshape((npts * 3, npts)),
+    ], axis=0)
+
+    return {
+        'iota': dresidual_diota,
+        'G': dresidual_dG,
+        'I': dresidual_dI,
+        'current_potential': jacobian_potential,
+    }
+
+
+def surface_field_nonquasisymmetric_ratio(surface, field, quasi_poloidal=False):
+    r"""
+    Compute the non-quasisymmetric ratio for a magnetic field sampled on a surface grid.
+
+    Args:
+        surface: Surface carrying the quadrature grid and area element.
+        field: Array of shape ``surface.gamma().shape`` containing the magnetic field.
+        quasi_poloidal: If ``True``, compute the quasi-poloidal variant; otherwise
+            compute the quasi-axisymmetric variant.
+    """
+    field = _as_surface_field_array(surface, field, 'field', (3,))
+    axis = 1 if quasi_poloidal else 0
+
+    modB = np.linalg.norm(field, axis=2)
+    dS = np.linalg.norm(surface.normal(), axis=2)
+    B_qs = np.mean(modB * dS, axis=axis) / np.mean(dS, axis=axis)
+    if axis == 0:
+        B_qs = B_qs[None, :]
+    else:
+        B_qs = B_qs[:, None]
+    return np.mean(dS * (modB - B_qs)**2) / np.mean(dS * B_qs**2)
 
 
 class AspectRatio(Optimizable):
@@ -757,20 +1069,7 @@ class NonQuasiSymmetricRatio(Optimizable):
 
         B = self.biotsavart.B()
         B = B.reshape((nphi, ntheta, 3))
-        modB = np.sqrt(B[:, :, 0]**2 + B[:, :, 1]**2 + B[:, :, 2]**2)
-
-        nor = surface.normal()
-        dS = np.sqrt(nor[:, :, 0]**2 + nor[:, :, 1]**2 + nor[:, :, 2]**2)
-
-        B_QS = np.mean(modB * dS, axis=axis) / np.mean(dS, axis=axis)
-
-        if axis == 0:
-            B_QS = B_QS[None, :]
-        else:
-            B_QS = B_QS[:, None]
-
-        B_nonQS = modB - B_QS
-        self._J = np.mean(dS * B_nonQS**2) / np.mean(dS * B_QS**2)
+        self._J = surface_field_nonquasisymmetric_ratio(surface, B, quasi_poloidal=(axis == 1))
 
         booz_surf = self.boozer_surface
         iota = booz_surf.res['iota']

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,6 +24,24 @@ In this fashion, we can run only a single unit test: `python -m unittest geo.tes
 See the [python unittest documentation](https://docs.python.org/3/library/unittest.html) for more options.
 
 
+### Optional geometry dependencies
+
+Some geometry-related tests, including the Boozer surface regression tests, require the optional `ground` and `bentley-ottmann` packages for self-intersection checks.
+
+
+### Targeted Boozer validation
+
+If you are working from an editable install, first confirm that Python imports `simsopt` from the checkout you intend to test:
+
+`python -c "import pathlib, simsopt; print(pathlib.Path(simsopt.__file__).resolve())"`
+
+Then two useful targeted regression commands from the repository root are:
+
+`python -m pytest tests/geo/test_boozersurface.py -q`
+
+`python -m pytest tests/geo/test_finitebeta_boozersurface.py -q`
+
+
 ### Parallel testing with pytest
 
 Requires installing pytest along with pytest-xdist or pytest-parallel.  Install either of them with pip. With pytest-xdist, run `pytest -n <N> geo` to run all tests in the `geo` folder in parallel. For pytest-parallel, use `pytest --workers <N> geo`. Here <N> is the number of cores you want to use. In place of a specific number for <N>, use `auto` to automatically use all the avaialable cores in the machine.

--- a/tests/geo/test_finitebeta_boozersurface.py
+++ b/tests/geo/test_finitebeta_boozersurface.py
@@ -1,0 +1,539 @@
+import unittest
+from types import SimpleNamespace
+from pathlib import Path
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from simsopt.geo import FiniteBetaBoozerSurface, Volume
+from simsopt.geo.surfaceobjectives import MU0, finite_beta_sheet_current, surface_field_nonquasisymmetric_ratio
+
+from .surface_test_helpers import get_boozer_surface
+
+try:
+    import vmec as vmec_mod
+except ImportError:
+    vmec_mod = None
+
+try:
+    import virtual_casing as virtual_casing_mod
+except ImportError:
+    virtual_casing_mod = None
+
+from simsopt.mhd import Vmec, VirtualCasing
+
+
+class FiniteBetaBoozerSurfaceTests(unittest.TestCase):
+    def test_init_with_scalar_pressure_jump(self):
+        bs, boozer_surface = get_boozer_surface(converge=False)
+        finite_beta = FiniteBetaBoozerSurface(
+            bs,
+            boozer_surface.surface,
+            boozer_surface.label,
+            boozer_surface.targetlabel,
+            pressure_jump=123.4,
+        )
+
+        self.assertEqual(finite_beta.resolve_pressure_jump(), 123.4)
+        self.assertTrue(finite_beta.need_to_run_code)
+        self.assertEqual(finite_beta.solve_type, 'ls')
+
+    def test_init_with_callable_pressure_jump(self):
+        bs, boozer_surface = get_boozer_surface(converge=False)
+        finite_beta = FiniteBetaBoozerSurface(
+            bs,
+            boozer_surface.surface,
+            boozer_surface.label,
+            boozer_surface.targetlabel,
+            pressure_jump=lambda surface: 10.0,
+        )
+
+        self.assertAlmostEqual(finite_beta.resolve_pressure_jump(), 10.0)
+
+    def test_invalid_pressure_jump_raises(self):
+        bs, boozer_surface = get_boozer_surface(converge=False)
+        finite_beta = FiniteBetaBoozerSurface(
+            bs,
+            boozer_surface.surface,
+            boozer_surface.label,
+            boozer_surface.targetlabel,
+            pressure_jump=float('nan'),
+        )
+
+        with self.assertRaises(ValueError):
+            finite_beta.resolve_pressure_jump()
+
+    def test_run_code_solves_synthetic_fixed_surface_problem(self):
+        _, boozer_surface = get_boozer_surface(converge=False)
+        surface = boozer_surface.surface
+        iota_true = -0.31
+        G_fixed = 1.4
+        tang = surface.gammadash1() + iota_true * surface.gammadash2()
+        tang_norm_sq = np.sum(tang**2, axis=2)
+        B_in = (G_fixed / tang_norm_sq)[:, :, None] * tang
+        B_out = B_in.copy()
+
+        finite_beta = FiniteBetaBoozerSurface(
+            None,
+            surface,
+            boozer_surface.label,
+            boozer_surface.targetlabel,
+            pressure_jump=0.0,
+            options={'verbose': False, 'ls_tol': 1e-12, 'ls_max_nfev': 80},
+        )
+
+        initial = finite_beta.residual_blocks(iota=-0.1, G=G_fixed, I=0.0, B_in=B_in, B_out=B_out)
+        initial_norm = np.linalg.norm(initial['residual'])
+        result = finite_beta.run_code(iota=-0.1, G=G_fixed, I=0.0, B_in=B_in, B_out=B_out, optimize_G=False)
+
+        self.assertTrue(result['success'])
+        self.assertLess(result['residual_norm'], 1e-8)
+        self.assertLess(result['residual_norm'], initial_norm)
+        self.assertAlmostEqual(result['iota'], iota_true, places=8)
+        self.assertAlmostEqual(result['current_potential'][0, 0], 0.0)
+        self.assertIsNotNone(result['least_squares_result'].jac)
+
+    def test_parameter_jacobian_matches_finite_difference(self):
+        _, boozer_surface = get_boozer_surface(converge=False)
+        surface = boozer_surface.surface
+        shape = surface.gamma().shape
+        B_in = np.zeros(shape)
+        B_out = np.zeros(shape)
+        B_in[:, :, 0] = 0.7
+        B_in[:, :, 2] = 0.2
+        B_out[:, :, 1] = 0.4
+
+        finite_beta = FiniteBetaBoozerSurface(
+            None,
+            surface,
+            boozer_surface.label,
+            boozer_surface.targetlabel,
+            pressure_jump=0.0,
+            options={'verbose': False},
+        )
+
+        iota0 = -0.17
+        G0 = 1.3
+        I0 = 0.08
+        potential0 = np.zeros(shape[:2])
+        x0 = finite_beta._pack_state(iota0, G0, I0, potential0, True, True, True, True)
+
+        def residual_from_state(state):
+            _, iota, G, I, potential = finite_beta._unpack_state(state, iota0, G0, I0, potential0, True, True, True, True)
+            result = finite_beta.residual_blocks(iota=iota, G=G, I=I, current_potential=potential, B_in=B_in, B_out=B_out)
+            return finite_beta._weighted_residual_vector(result['blocks'])
+
+        analytic = finite_beta.residual_parameter_jacobian(
+            iota=iota0,
+            G=G0,
+            I=I0,
+            B_in=B_in,
+            B_out=B_out,
+            optimize_iota=True,
+            optimize_G=True,
+            optimize_I=True,
+            optimize_current_potential=True,
+        )
+
+        np.random.seed(2)
+        direction = np.random.standard_normal(x0.shape)
+        direction /= np.linalg.norm(direction)
+        eps = 1e-7
+        fd = (residual_from_state(x0 + eps * direction) - residual_from_state(x0 - eps * direction)) / (2 * eps)
+        linearized = analytic @ direction
+        assert_allclose(linearized, fd, rtol=5e-5, atol=5e-7)
+
+    def test_surface_jacobian_matches_finite_difference_for_fixed_fields(self):
+        _, boozer_surface = get_boozer_surface(converge=False)
+        surface = boozer_surface.surface
+        shape = surface.gamma().shape
+        B_in = np.zeros(shape)
+        B_out = np.zeros(shape)
+        B_in[:, :, 0] = 0.7
+        B_in[:, :, 1] = -0.2
+        B_in[:, :, 2] = 0.15
+        B_out[:, :, 0] = 0.1
+        B_out[:, :, 1] = 0.45
+        B_out[:, :, 2] = -0.35
+        phi = surface.quadpoints_phi[:, None]
+        theta = surface.quadpoints_theta[None, :]
+        potential0 = 1e-3 * (np.sin(2 * np.pi * phi) + 0.6 * np.cos(2 * np.pi * theta))
+
+        finite_beta = FiniteBetaBoozerSurface(
+            None,
+            surface,
+            boozer_surface.label,
+            boozer_surface.targetlabel,
+            pressure_jump=0.0,
+            options={'verbose': False},
+        )
+
+        iota0 = -0.17
+        G0 = 1.3
+        I0 = 0.08
+        x0 = surface.x.copy()
+
+        def residual_from_dofs(dofs):
+            surface.x = dofs
+            result = finite_beta.residual_blocks(
+                iota=iota0,
+                G=G0,
+                I=I0,
+                current_potential=potential0,
+                B_in=B_in,
+                B_out=B_out,
+            )
+            return finite_beta._weighted_residual_vector(result['blocks'])
+
+        try:
+            analytic = finite_beta.residual_surface_jacobian(
+                iota=iota0,
+                G=G0,
+                I=I0,
+                current_potential=potential0,
+                B_in=B_in,
+                B_out=B_out,
+            )
+
+            rng = np.random.default_rng(4)
+            direction = rng.standard_normal(x0.shape)
+            direction /= np.linalg.norm(direction)
+            eps = 1e-7
+            fd = (residual_from_dofs(x0 + eps * direction) - residual_from_dofs(x0 - eps * direction)) / (2 * eps)
+            linearized = analytic @ direction
+            assert_allclose(linearized, fd, rtol=1e-4, atol=2e-6)
+        finally:
+            surface.x = x0
+
+    def test_pressure_jump_case_has_nontrivial_current_potential_residuals(self):
+        _, boozer_surface = get_boozer_surface(converge=False)
+        surface = boozer_surface.surface
+        iota_true = -0.25
+        G_fixed = 1.1
+        tang = surface.gammadash1() + iota_true * surface.gammadash2()
+        tang_norm_sq = np.sum(tang**2, axis=2)
+        B_in = (G_fixed / tang_norm_sq)[:, :, None] * tang
+
+        theta = surface.quadpoints_theta[None, :]
+        potential_target = 1e-3 * np.sin(2 * np.pi * theta) * np.ones(surface.gamma().shape[:2])
+        dphi = np.zeros_like(potential_target)
+        dtheta = 1e-3 * 2 * np.pi * np.cos(2 * np.pi * theta) * np.ones(surface.gamma().shape[:2])
+        sheet_current_target = finite_beta_sheet_current(
+            surface,
+            current_potential_derivatives=(dphi, dtheta),
+        )
+        B_out = B_in - MU0 * np.cross(surface.unitnormal(), sheet_current_target)
+        pressure_jump = np.mean(np.sum(B_out**2, axis=2) - np.sum(B_in**2, axis=2)) / (2 * MU0)
+
+        finite_beta = FiniteBetaBoozerSurface(
+            None,
+            surface,
+            boozer_surface.label,
+            boozer_surface.targetlabel,
+            pressure_jump=pressure_jump,
+            options={'verbose': False},
+        )
+
+        zero_potential = finite_beta.residual_blocks(
+            iota=iota_true,
+            G=G_fixed,
+            I=0.0,
+            B_in=B_in,
+            B_out=B_out,
+        )
+        with_potential = finite_beta.residual_blocks(
+            iota=iota_true,
+            G=G_fixed,
+            I=0.0,
+            current_potential=potential_target,
+            B_in=B_in,
+            B_out=B_out,
+        )
+
+        self.assertGreater(abs(pressure_jump), 0.0)
+        self.assertGreater(np.linalg.norm(potential_target), 1e-6)
+        self.assertGreater(np.linalg.norm(with_potential['blocks']['sheet_current']), 0.0)
+        self.assertLess(
+            np.linalg.norm(with_potential['blocks']['jump']),
+            np.linalg.norm(zero_potential['blocks']['jump']),
+        )
+        self.assertGreater(np.linalg.norm(with_potential['blocks']['pressure']), 0.0)
+
+    def test_run_code_can_optimize_surface_with_callable_fields(self):
+        _, boozer_surface = get_boozer_surface(converge=False)
+        target_label = boozer_surface.label.J()
+        iota_target = -0.22
+        G_target = 1.05
+
+        def B_in_provider(surface):
+            tang = surface.gammadash1() + iota_target * surface.gammadash2()
+            tang_norm_sq = np.sum(tang**2, axis=2)
+            return (G_target / tang_norm_sq)[:, :, None] * tang
+
+        def B_out_provider(surface):
+            return B_in_provider(surface)
+
+        perturbed_surface = boozer_surface.surface.__class__(
+            mpol=boozer_surface.surface.mpol,
+            ntor=boozer_surface.surface.ntor,
+            stellsym=boozer_surface.surface.stellsym,
+            nfp=boozer_surface.surface.nfp,
+            quadpoints_phi=boozer_surface.surface.quadpoints_phi,
+            quadpoints_theta=boozer_surface.surface.quadpoints_theta,
+            dofs=boozer_surface.surface.dofs,
+        )
+        perturbed_surface.x = perturbed_surface.x + 1e-3 * np.random.default_rng(3).standard_normal(perturbed_surface.x.shape)
+        finite_beta = FiniteBetaBoozerSurface(
+            None,
+            perturbed_surface,
+            Volume(perturbed_surface),
+            target_label,
+            pressure_jump=0.0,
+            options={'verbose': False, 'ls_tol': 1e-10, 'ls_max_nfev': 60},
+        )
+
+        label_before = abs(finite_beta.label.J() - target_label)
+        result = finite_beta.run_code(
+            iota=iota_target,
+            G=G_target,
+            I=0.0,
+            B_in=B_in_provider,
+            B_out=B_out_provider,
+            optimize_iota=False,
+            optimize_G=False,
+            optimize_I=False,
+            optimize_current_potential=False,
+            optimize_surface=True,
+        )
+
+        self.assertTrue(result['success'])
+        self.assertLess(abs(finite_beta.label.J() - target_label), label_before)
+        self.assertAlmostEqual(finite_beta.surface.gamma()[0, 0, 2], 0.0, places=6)
+
+    def test_run_code_can_optimize_surface_with_fixed_fields(self):
+        _, boozer_surface = get_boozer_surface(converge=False)
+        target_label = boozer_surface.label.J()
+        perturbed_surface = boozer_surface.surface.__class__(
+            mpol=boozer_surface.surface.mpol,
+            ntor=boozer_surface.surface.ntor,
+            stellsym=boozer_surface.surface.stellsym,
+            nfp=boozer_surface.surface.nfp,
+            quadpoints_phi=boozer_surface.surface.quadpoints_phi,
+            quadpoints_theta=boozer_surface.surface.quadpoints_theta,
+            dofs=boozer_surface.surface.dofs,
+        )
+        perturbed_surface.x = perturbed_surface.x + 1e-3 * np.random.default_rng(5).standard_normal(perturbed_surface.x.shape)
+        finite_beta = FiniteBetaBoozerSurface(
+            None,
+            perturbed_surface,
+            Volume(perturbed_surface),
+            target_label,
+            pressure_jump=0.0,
+            options={'verbose': False, 'ls_tol': 1e-10, 'ls_max_nfev': 60},
+        )
+
+        zeros = np.zeros(perturbed_surface.gamma().shape)
+        label_before = abs(finite_beta.label.J() - target_label)
+        result = finite_beta.run_code(
+            iota=0.0,
+            G=0.0,
+            I=0.0,
+            B_in=zeros,
+            B_out=zeros,
+            optimize_iota=False,
+            optimize_G=False,
+            optimize_I=False,
+            optimize_current_potential=False,
+            optimize_surface=True,
+        )
+
+        self.assertTrue(result['success'])
+        self.assertLess(abs(finite_beta.label.J() - target_label), label_before)
+        self.assertAlmostEqual(finite_beta.surface.gamma()[0, 0, 2], 0.0, places=6)
+        self.assertEqual(result['least_squares_result'].jac.shape[1], perturbed_surface.x.size)
+
+    def test_surface_field_nonquasisymmetric_ratio_detects_qs_and_nonqs_content(self):
+        _, boozer_surface = get_boozer_surface(converge=False)
+        surface = boozer_surface.surface
+        theta = surface.quadpoints_theta[None, :]
+        phi = surface.quadpoints_phi[:, None]
+
+        qs_field = np.zeros(surface.gamma().shape)
+        qs_field[:, :, 0] = 1.0 + 0.2 * np.cos(2 * np.pi * theta)
+        nonqs_field = qs_field.copy()
+        nonqs_field[:, :, 0] += 0.1 * np.cos(2 * np.pi * phi)
+
+        qs_ratio = surface_field_nonquasisymmetric_ratio(surface, qs_field)
+        nonqs_ratio = surface_field_nonquasisymmetric_ratio(surface, nonqs_field)
+
+        self.assertLess(qs_ratio, 1e-12)
+        self.assertGreater(nonqs_ratio, 1e-6)
+
+    def test_resolve_field_components_from_virtual_casing(self):
+        bs, boozer_surface = get_boozer_surface(converge=False)
+        shape = boozer_surface.surface.gamma().shape
+        B_total = np.full(shape, 3.0)
+        B_external = np.full(shape, 1.25)
+        finite_beta = FiniteBetaBoozerSurface(
+            bs,
+            boozer_surface.surface,
+            boozer_surface.label,
+            boozer_surface.targetlabel,
+            pressure_jump=0.0,
+            virtual_casing=SimpleNamespace(B_total=B_total, B_external=B_external),
+        )
+
+        B_in, B_out = finite_beta.resolve_field_components()
+        assert_allclose(B_in, B_total - B_external)
+        assert_allclose(B_out, B_external)
+
+    def test_explicit_fields_do_not_require_biotsavart(self):
+        _, boozer_surface = get_boozer_surface(converge=False)
+        shape = boozer_surface.surface.gamma().shape
+        B_in = np.zeros(shape)
+        B_out = np.zeros(shape)
+        finite_beta = FiniteBetaBoozerSurface(
+            None,
+            boozer_surface.surface,
+            boozer_surface.label,
+            boozer_surface.targetlabel,
+            pressure_jump=0.0,
+        )
+
+        resolved_B_in, resolved_B_out = finite_beta.resolve_field_components(B_in=B_in, B_out=B_out)
+        assert_allclose(resolved_B_in, B_in)
+        assert_allclose(resolved_B_out, B_out)
+
+    def test_sheet_current_zero_without_potential(self):
+        _, boozer_surface = get_boozer_surface(converge=False)
+        current = finite_beta_sheet_current(boozer_surface.surface)
+        assert_allclose(current, 0.0)
+
+    def test_residual_blocks_match_vacuum_limit_with_explicit_fields(self):
+        bs, boozer_surface = get_boozer_surface(converge=False)
+        finite_beta = FiniteBetaBoozerSurface(
+            bs,
+            boozer_surface.surface,
+            boozer_surface.label,
+            boozer_surface.targetlabel,
+            pressure_jump=0.0,
+        )
+
+        surface = boozer_surface.surface
+        shape = surface.gamma().shape
+        constant_B = np.zeros(shape)
+        constant_B[:, :, 2] = 1.0
+        result = finite_beta.residual_blocks(
+            iota=-0.4,
+            G=1.2,
+            I=0.0,
+            B_in=constant_B,
+            B_out=constant_B,
+        )
+
+        expected_boozer = 1.2 * constant_B - np.sum(constant_B**2, axis=2)[:, :, None] * (
+            surface.gammadash1() - 0.4 * surface.gammadash2()
+        )
+        assert_allclose(result['blocks']['boozer'], expected_boozer)
+        assert_allclose(result['blocks']['normal'], np.sum(constant_B * surface.unitnormal(), axis=2))
+        assert_allclose(result['blocks']['pressure'], 0.0)
+        assert_allclose(result['blocks']['jump'], 0.0)
+
+    def test_residual_blocks_include_pressure_and_jump_terms(self):
+        bs, boozer_surface = get_boozer_surface(converge=False)
+        finite_beta = FiniteBetaBoozerSurface(
+            bs,
+            boozer_surface.surface,
+            boozer_surface.label,
+            boozer_surface.targetlabel,
+            pressure_jump=5.0,
+        )
+
+        surface = boozer_surface.surface
+        shape = surface.gamma().shape
+        B_in = np.zeros(shape)
+        B_out = np.zeros(shape)
+        B_out[:, :, 0] = 1.0
+        dphi = np.ones(shape[:2])
+        dtheta = np.zeros(shape[:2])
+
+        result = finite_beta.residual_blocks(
+            iota=0.0,
+            G=0.0,
+            I=0.0,
+            B_in=B_in,
+            B_out=B_out,
+            current_potential_derivatives=(dphi, dtheta),
+        )
+
+        expected_sheet_current = finite_beta_sheet_current(
+            surface,
+            current_potential_derivatives=(dphi, dtheta),
+        )
+        assert_allclose(result['blocks']['sheet_current'], expected_sheet_current)
+        assert_allclose(result['blocks']['pressure'], 1.0 - 2.0 * MU0 * 5.0)
+        assert_allclose(
+            result['blocks']['jump'],
+            MU0 * expected_sheet_current - np.cross(surface.unitnormal(), B_out - B_in),
+        )
+
+    @unittest.skipIf(vmec_mod is None or virtual_casing_mod is None, "vmec and virtual_casing python packages are required")
+    def test_vmec_fixed_surface_smoke(self):
+        test_dir = Path(__file__).resolve().parents[1] / 'test_files'
+        vmec_filename = test_dir / 'input.W7-X_without_coil_ripple_beta0p05_d23p4_tm'
+        vc_filename = vmec_filename.with_name(vmec_filename.name.replace('input.', 'vcasing_') + '.nc')
+
+        vmec = Vmec(str(vmec_filename))
+        vmec.run()
+        if vc_filename.exists():
+            vc = VirtualCasing.load(str(vc_filename))
+        else:
+            vc = VirtualCasing.from_vmec(vmec, src_nphi=8, src_ntheta=8, trgt_nphi=8, trgt_ntheta=8, filename=str(vc_filename))
+
+        boundary_rz = vmec.boundary.__class__.from_nphi_ntheta(
+            mpol=vmec.wout.mpol,
+            ntor=vmec.wout.ntor,
+            nfp=vmec.wout.nfp,
+            stellsym=not bool(vmec.wout.lasym),
+            nphi=8,
+            ntheta=8,
+            range='half period',
+        )
+        boundary_rz.x = vmec.boundary.x
+        surface = get_boozer_surface(converge=False)[1].surface.__class__(
+            mpol=vmec.wout.mpol,
+            ntor=vmec.wout.ntor,
+            nfp=vmec.wout.nfp,
+            stellsym=not bool(vmec.wout.lasym),
+            quadpoints_phi=boundary_rz.quadpoints_phi,
+            quadpoints_theta=boundary_rz.quadpoints_theta,
+        )
+        surface.least_squares_fit(boundary_rz.gamma())
+        vol = Volume(surface)
+        finite_beta = FiniteBetaBoozerSurface(
+            None,
+            surface,
+            vol,
+            vol.J(),
+            pressure_jump=0.0,
+            options={'verbose': False, 'ls_max_nfev': 200},
+        )
+
+        initial = finite_beta.residual_blocks(
+            iota=vmec.iota_edge(),
+            G=0.0,
+            I=0.0,
+            B_in=vc.B_total - vc.B_external,
+            B_out=vc.B_external,
+        )
+        result = finite_beta.run_code(
+            iota=vmec.iota_edge(),
+            G=0.0,
+            I=0.0,
+            B_in=vc.B_total - vc.B_external,
+            B_out=vc.B_external,
+            optimize_G=False,
+        )
+
+        self.assertTrue(result['success'])
+        self.assertLess(result['residual_norm'], np.linalg.norm(initial['residual']))


### PR DESCRIPTION
## Summary
- add `FiniteBetaBoozerSurface` as a staged single-surface finite-beta Boozer solve alongside the existing vacuum path
- add finite-beta residual assembly plus parameter and fixed-field surface Jacobians in `surfaceobjectives.py`
- add the `boozerQA_finitebeta.py` example and matching documentation for prescribed, prescribed-fixed, and auxiliary VMEC-backed modes
- add targeted finite-beta regression coverage and compatibility fallbacks for current `ground` and `bentley_ottmann` geometry-package APIs

## Notes
- the primary workflow is prescribed `B_in` and `B_out` on one surface, without an ideal-MHD solver in the optimization loop
- VMEC plus virtual casing remains available only as an auxiliary data-generation and validation path

## Validation
- `python -m pytest tests/geo/test_boozersurface.py -q`
- `python -m pytest tests/geo/test_finitebeta_boozersurface.py -q`
