### PR TITLE
WIP: benchmark and stabilize VMEC-JAX QH exact path

### DIFF
--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -178,15 +178,15 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
 
 ## Current constraints
 
-- The new backend is currently a reverse-mode (`custom_vjp`) path.
-- That means `jacfwd` is the wrong consumer for it; use reverse-mode gradients or
-  `jac="reverse"` in the outer least-squares solver.
-- The example now exposes that choice explicitly.
-- The current wrapper implementation uses a small Python payload cache in the
-  custom VJP backward pass so JAX does not need to treat the checkpoint tape as
-  a traceable value.
-- The reverse-Jacobian SciPy path should currently be treated as `jit=False`
-  only. The example forces that combination for the discrete-adjoint backend.
+- The new backend is now a forward-mode (`custom_jvp`) path because the QH
+  benchmark has `n=8` controls and `m ~ 4.4e4` residual components, so
+  forward Jacobian columns are the correct scaling.
+- The production SciPy consumer should therefore use `jac="jax"` /
+  `jacfwd`, not `jac="reverse"`.
+- `jit=False` remains the safe default on this path until the traced residual
+  solver is fully cleaned up. A traced `np.asarray(...)` precompute in the
+  VMEC residual path was identified as a concrete JIT blocker and is now being
+  removed incrementally.
 
 ## Activity log
 
@@ -203,3 +203,21 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
   - Small end-to-end script smoke no longer fails immediately on the old
     `TracerArrayConversionError`, but the full SciPy QH smoke is still too slow
     even at tiny inner budgets, so runtime policy is still unresolved.
+  - Measured the actual scaling mismatch for the first wrapper implementation:
+    reverse-mode scalar objective gradients were viable, but full residual
+    Jacobians were the wrong shape/cost for QH (`m >> n`).
+  - Switched the wrapper discrete-adjoint backend from `custom_vjp` to
+    `custom_jvp` and removed the Python payload-cache workaround.
+  - Added forward tape-JVP helpers in `vmec_jax` and confirmed the wrapper
+    exact-QH aspect directional-derivative gate still matches finite
+    differences after the switch.
+  - Revalidated that `jax.jacfwd(stage.residuals)` works on the new backend and
+    returns a finite `(44353, 8)` Jacobian on the QH microcase.
+  - Re-ran a small SciPy QH smoke on the new forward path
+    (`max_nfev=2`, `vmec_max_iter=1`, `jac='jax'`, discrete adjoint) and saw
+    real least-squares progress:
+    - total objective `1.901008100532871 -> 0.5052581847050714`,
+    - wall time about `23.18 s`.
+  - Identified the next concrete runtime blocker for the production path:
+    `jit=True` still fails in the traced residual solver due to NumPy-only
+    precompute code inside `vmec_jax.solve`.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -532,3 +532,41 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
     - that is materially better than the earlier full-inner moving-axis drift,
       but still leaves some headroom before calling the derivative issue fully
       closed at longer horizons / later accepted iterates.
+  - Exact callback RSS profiling on the benchmark QH wrapper path now shows:
+    - cold exact residual at `x0`: about `11.65 s`, RSS `+3.00 GB`
+    - cold exact Jacobian at `x0`: about `6.93 s`, RSS `+0.44 GB`
+    - warm exact residual at nearby `x1`: about `6.02 s`, RSS `+2.36 GB`
+    - warm exact Jacobian at nearby `x1`: about `5.15 s`, RSS `+0.14 GB`
+    - so the remaining large memory growth is dominated by the exact forward
+      solve path and executable retention, not by the replay Jacobian alone.
+  - The first lean exact-tape pass reduced runtime and peak RSS materially, but
+    it also exposed that the late-iteration Jacobian was still catastrophically
+    wrong whenever the tape contained even one restart step; SciPy optimality
+    blew up again there.
+  - Exact late-point audit on the benchmark QH final iterate before the mixed
+    replay fix gave objective-direction errors of order `1e19` on columns
+    `0..3`.
+  - After the mixed replay fix on the vmec_jax branch, the same final-point
+    audit now gives:
+    - column `0`: objective-direction relative error about `9.9e-3`
+    - column `1`: about `2.6e-2`
+    - column `2`: about `1.0e-5`
+    - column `3`: about `2.9e-2`
+    - so the late-iteration Jacobian blow-up is fixed.
+  - Exact `max_mode=1`, `max_nfev=3` benchmark on the current branch state:
+    - final total objective `0.26052325878767574`
+    - final QS objective `0.2596812636714725`
+    - final aspect `7.029017152103597`
+    - solve wall about `36.10 s`
+    - peak RSS about `17.48 GB`
+  - Exact `max_mode=1`, `max_nfev=10` benchmark on the current branch state:
+    - final total objective `0.24174600728278778`
+    - final QS objective `0.24061022810764002`
+    - final aspect `7.0337013230474374`
+    - solve wall about `138.55 s`
+    - peak RSS about `23.47 GB`
+    - first-order optimality now stays finite at about `6.62e-1`, which is a
+      major behavioral improvement over the earlier `~1e19` blow-up
+  - This branch state is now derivative-stable at late iterates, but runtime is
+    still not competitive with classic QH and the final objective is still
+    above the earlier best branch result and above the classic reference.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -165,9 +165,41 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
 - reaches objective quality in the same ballpark as the classic script,
 - is competitive enough in runtime to justify the JAX path.
 
-## Immediate next tasks
+## Current status
 
-- [ ] Identify the minimal donor file set from the previous `simsopt_qh` branch.
-- [ ] Defer porting until `vmec_jax` derivative Gate 4C is met.
-- [ ] Once the backend is ready, wire it into `VmecJax` with explicit backend
-  selection and benchmark reporting.
+- [x] Port the minimum consumer layer from the earlier `simsopt_qh` branch.
+- [x] Add an explicit `VmecJax` backend selector for the new residual
+  discrete-adjoint path.
+- [x] Add a first public wrapper derivative gate on the exact QH setup.
+- [x] Add explicit reverse-Jacobian support to `least_squares_jax_solve`.
+- [x] Expose backend / Jacobian mode in `QH_fixed_resolution_jax.py`.
+- [ ] Benchmark the new path on the exact apples-to-apples QH run.
+- [ ] Decide the production outer-solver policy for the discrete-adjoint backend.
+
+## Current constraints
+
+- The new backend is currently a reverse-mode (`custom_vjp`) path.
+- That means `jacfwd` is the wrong consumer for it; use reverse-mode gradients or
+  `jac="reverse"` in the outer least-squares solver.
+- The example now exposes that choice explicitly.
+- The current wrapper implementation uses a small Python payload cache in the
+  custom VJP backward pass so JAX does not need to treat the checkpoint tape as
+  a traceable value.
+- The reverse-Jacobian SciPy path should currently be treated as `jit=False`
+  only. The example forces that combination for the discrete-adjoint backend.
+
+## Activity log
+
+- 2026-04-14:
+  - Added `residual_derivative_backend` to `VmecJax` and wired a narrow
+    discrete-adjoint residual solve path into `_solve_state(...)`.
+  - The new wrapper path uses the validated `vmec_jax` checkpoint tape reverse
+    helper plus a frozen-axis initial-state VJP over SIMSOPT's free boundary DOFs.
+  - Added wrapper regressions covering backend selection and an exact QH aspect
+    directional derivative against finite differences.
+  - Added `jac="reverse"` / `jacrev` support to `least_squares_jax_solve`.
+  - Exposed `--jac` and `--residual-derivative-backend` in
+    `examples/2_Intermediate/QH_fixed_resolution_jax.py`.
+  - Small end-to-end script smoke no longer fails immediately on the old
+    `TracerArrayConversionError`, but the full SciPy QH smoke is still too slow
+    even at tiny inner budgets, so runtime policy is still unresolved.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -300,3 +300,13 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
       --residual-derivative-backend discrete_adjoint --jit`
     - total objective still `1.901008100532871 -> 0.505258184704556`,
     - solve wall time dropped again from about `16.93 s` to `5.14 s`.
+  - Cleaned up the example benchmark script itself to stop doing duplicate
+    forward solves just for reporting:
+    - before: solve state for QS/aspect reporting, then solve again through
+      `stage.residuals`/`scipy_residuals` to compute total objective,
+    - now: compute the total objective directly from the already-available
+      state using aspect + QS residuals.
+  - This does not change the numerical results, but it removes redundant shell
+    benchmark overhead at the start and end of the script, which matters on the
+    exact full-inner-solve QH benchmark because those extra forward solves are
+    expensive.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -485,3 +485,32 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
     `force_scale` vary every step with the residual history, while the replay
     Jacobian still treats those scalars as frozen trace data from the base
     trajectory.
+  - Full carry-aware replay landed on the vmec_jax branch and removed the
+    long-horizon QH Jacobian drift on the production exact path.
+  - Exact frozen-axis directional audit on the benchmark wrapper path now gives:
+    - `max_iter=1`: relative column error about `3.0e-8`
+    - `max_iter=10`: about `1.5e-6`
+    - `max_iter=20`: about `2.6e-5`
+    - `max_iter=50`: about `1.15e-3`
+  - Exact `max_mode=1`, `max_nfev=3` benchmark improved materially:
+    - final total objective `0.25541676622646603`
+    - final QS objective `0.2541757712576408`
+    - final aspect `7.035227758498451`
+    - solve wall about `41.99 s`
+  - Exact `max_mode=1`, `max_nfev=10` benchmark after the carry fix:
+    - final total objective `0.22719939587753907`
+    - final QS objective `0.22499609902383344`
+    - final aspect `7.046939289020027`
+    - solve wall about `129.20 s`
+    - this is much closer to the classic `0.21378863910867005`, though still
+      slower than the classic `24.75 s`.
+  - Exact `max_mode=2`, `max_nfev=3` benchmark is no longer stalled:
+    - final total objective `0.12191948331868585`
+    - final QS objective `0.11793999150722417`
+    - final aspect `7.063083213388838`
+    - solve wall about `51.55 s`
+    - compared with the local classic reference at about `0.102316`, this is
+      now qualitatively competitive in objective reduction, though still slower.
+  - Added a slow wrapper regression that locks the full-inner (`max_iter=20`)
+    QH frozen-axis Jacobian against central FD on the production
+    discrete-adjoint backend.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -324,9 +324,39 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
       --residual-derivative-backend discrete_adjoint --jit`
     - total objective `9.168100000000209 -> 5.205846451699488`,
     - solve wall time about `8.58 s`.
+  - Added a narrower runtime fix in the SciPy callback pair for the discrete
+    backend:
+    - residual and Jacobian callbacks now share the same exact
+      discrete-adjoint solve payload when SciPy evaluates both at the same
+      parameter vector,
+    - the Jacobian builder accepts an already-solved state/tape payload instead
+      of always rebuilding it.
+  - Added a wrapper regression that proves `scipy_residuals(x0)` followed by
+    `scipy_jacobian(x0)` only calls
+    `_solve_state_discrete_adjoint_residual(...)` once on the exact same point.
+  - Sequential microcase reruns on the new callback-reuse path:
+    - QH:
+      `QH_fixed_resolution_jax.py --max-mode 1 --max-nfev 2 --vmec-max-iter 1
+      --timings --method scipy --jac jax
+      --residual-derivative-backend discrete_adjoint --jit`
+      still gives total objective `1.901008100532871 -> 0.505258184704556`,
+      and solve wall time dropped again from about `5.14 s` to about `4.10 s`.
+    - QA:
+      `QA_fixed_resolution_jax.py --max-mode 1 --max-nfev 2 --vmec-max-iter 1
+      --timings --method scipy --jac jax
+      --residual-derivative-backend discrete_adjoint --jit`
+      still gives total objective `9.168100000000209 -> 5.205846451699488`,
+      and solve wall time dropped from about `8.58 s` to about `4.51 s`.
   - QA exact full-inner run on the same wrapper path is still heavy before the
     first SciPy iteration, so QA does not automatically bypass the current
     wrapper/Jacobian bottleneck.
+  - Re-probed the exact full-inner QH path after the callback reuse fix with:
+    - `QH_fixed_resolution_jax.py --max-mode 1 --max-nfev 1 --timings
+      --method scipy --jac jax --residual-derivative-backend discrete_adjoint
+      --jit`
+    - the run still exited before the first SciPy iteration completed, so this
+      fix materially improved the short compiled path but did not yet stabilize
+      the full-inner benchmark regime.
   - Built a fresh mainline comparison environment:
     - cloned `vmec_jax` main to `/Users/rogeriojorge/local/vmec_jax_main_fresh`,
     - installed it in an isolated venv with system site packages.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -235,3 +235,15 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
     depends on tracing the VMEC solve, and the 2-evaluation run improved to:
     - total objective `1.901008100532871 -> 0.5052581847050319`,
     - wall time about `18.26 s`.
+  - Split the production SciPy path again so residual values and Jacobians no
+    longer pay the same solver cost on the discrete backend:
+    - residual values now use a plain forward residual solve without building
+      the discrete-adjoint tape,
+    - Jacobians still use the concrete tape-column autodiff path.
+  - Revalidated the same wrapper and solver regressions after the split.
+  - Re-ran the same QH microcase with the split residual/Jacobian path:
+    - total objective `1.901008100532871 -> 0.5052581847050319`,
+    - wall time `17.7149871670008 s`.
+  - This confirms the next exact benchmark bottleneck is the plain forward
+    VMEC residual solve, not Jacobian tracing/plumbing in the outer SciPy
+    path.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -310,3 +310,38 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
     benchmark overhead at the start and end of the script, which matters on the
     exact full-inner-solve QH benchmark because those extra forward solves are
     expensive.
+  - Added a new QA-side experiment script,
+    `examples/2_Intermediate/QA_fixed_resolution_jax.py`, mirroring the
+    cleaned fixed-resolution JAX example structure but targeting:
+    - input `input.nfp2_QA`,
+    - max_mode `1`,
+    - QA helicity `(m, n) = (1, 0)`,
+    - objective tuples `(aspect, 2.0, 1.0)`,
+      `(mean_iota, 0.41, 1.0)`, `(qs, 0.0, 1.0)`.
+  - QA smoke result on the current discrete-adjoint `simsopt` path:
+    - `QA_fixed_resolution_jax.py --max-mode 1 --max-nfev 2 --vmec-max-iter 1
+      --timings --method scipy --jac jax
+      --residual-derivative-backend discrete_adjoint --jit`
+    - total objective `9.168100000000209 -> 5.205846451699488`,
+    - solve wall time about `8.58 s`.
+  - QA exact full-inner run on the same wrapper path is still heavy before the
+    first SciPy iteration, so QA does not automatically bypass the current
+    wrapper/Jacobian bottleneck.
+  - Built a fresh mainline comparison environment:
+    - cloned `vmec_jax` main to `/Users/rogeriojorge/local/vmec_jax_main_fresh`,
+    - installed it in an isolated venv with system site packages.
+  - Direct fixed-boundary forward solves on main vs the discrete-adjoint branch
+    are effectively identical, which rules out a low-level `vmec_jax` runtime
+    regression as the primary cause of the current slowdown. Measured parity:
+    - QA, `max_iter=1`: branch `2.454 s`, main `2.429 s`
+    - QA, `max_iter=20`: branch `0.334 s`, main `0.326 s`
+    - QH, `max_iter=1`: branch `1.963 s`, main `1.912 s`
+    - QH, `max_iter=20`: branch `0.238 s`, main `0.228 s`
+  - Full QA forward solve parity on main vs branch is also essentially exact:
+    - both converge in `113` iterations with `fsqz_last ≈ 4.39e-12`,
+    - branch `3.733 s`, main `3.622 s`.
+  - That shifts the current diagnosis again:
+    - the `vmec_jax` core forward solver is not the source of the major
+      regression,
+    - the remaining heaviness is in the higher-level `simsopt`
+      objective/Jacobian path used before the first SciPy iteration.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -460,3 +460,28 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
     mismatch in the initialization branch (`axis_override` refreshed at each
     perturbed point in the value callback versus frozen in the local Jacobian),
     not a corruption in the replay/tape linearization itself.
+  - Follow-up full-inner audit changed that diagnosis for the production path:
+    at the exact full-inner benchmark (`max_iter=1500`), moving-axis FD and
+    frozen-axis FD are nearly identical at both `x0` and the first accepted
+    SciPy point `x1`, and both disagree with the production Jacobian.
+  - On the exact benchmark path:
+    - at `x0`, direction `e0`: AD objective-direction about `-3.4527`, moving
+      and frozen FD both about `-1.03`;
+    - at `x1`, direction `e0`: AD about `-5.5086`, moving and frozen FD both
+      about `-2.964`;
+    - along the local GN direction, the same pattern holds.
+  - A frozen-axis iteration sweep then showed the replay Jacobian is good only
+    on short tapes and drifts progressively with tape length:
+    - `max_iter=1`: relative frozen-axis column error about `3.1e-4`
+    - `max_iter=10`: about `1.5e-2`
+    - `max_iter=20`: about `6.5e-2`
+    - `max_iter=50`: about `5.7e-1`
+    - `max_iter=100`: about `4.85`
+  - The exact QH `max_iter=100` step trace shows all 100 steps are still
+    `momentum_accept` with no restarts, so the drift is not caused by restart
+    branches.
+  - The remaining live hypothesis is now solver-control carry:
+    `time_step` itself stays fixed, but `dt_eff`, `b1`, `fac`, and
+    `force_scale` vary every step with the residual history, while the replay
+    Jacobian still treats those scalars as frozen trace data from the base
+    trajectory.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -418,3 +418,30 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
     - `x0a`: solve about `7.89 s`, jac about `4.14 s`
     - `x0b`: solve about `5.77 s`, jac about `3.32 s`
     - `x1`: solve about `5.65 s`, jac about `3.49 s`
+  - After the replay scan-runner cache landed in `vmec_jax`, reran the exact
+    full-inner apples-to-apples QH benchmark again:
+    - `QH_fixed_resolution_jax.py --max-mode 1 --max-nfev 10 --timings
+      --method scipy --jac jax --residual-derivative-backend discrete_adjoint
+      --jit`
+      now finishes with the same final objective
+      `0.25740827662357`, but solve wall improves again to about `97.79 s`
+      and shell real time to about `126.34 s`.
+  - Exact `max_mode=1`, `max_nfev=3` JAX benchmark on the same path:
+    - final total objective `0.2581125330463535`
+    - final QS objective `0.2565631893138016`
+    - final aspect `7.039361703882731`
+    - solve wall about `30.89 s`
+    - shell real about `55.97 s`
+  - Compared against the local classic reference at the same early-stop point:
+    - classic `max_mode=1`, `max_nfev=3` reaches cost `1.0803e-01`, so total
+      objective is already about `0.21606`;
+    - the current JAX exact path is still materially worse at `0.25811`.
+  - Exact `max_mode=2`, `max_nfev=3` JAX benchmark:
+    - final total objective `0.30024580360290376` (no improvement)
+    - solve wall about `97.98 s`
+    - shell real about `130.74 s`
+  - Compared against the local classic `max_mode=2`, `max_nfev=3` reference:
+    - classic reaches cost `5.1158e-02`, so total objective is already about
+      `0.102316`;
+    - the current JAX exact path is still far slower and does not move off the
+      starting point by 3 function evaluations.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -256,3 +256,21 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
     objective before optimization`, and `Total objective before optimization`
     quickly on the exact QH setup instead of stalling in a tape-building
     `_solve_state(...)` call before the solve begins.
+  - Reworked the concrete discrete-adjoint Jacobian builder so it no longer
+    retraces the same linear maps for each of the 8 control directions:
+    - linearize the frozen projected-initial-state map once,
+    - propagate all 8 packed-state tangents through the replay tape together,
+    - linearize the residuals-from-state map once and apply it to the packed
+      tangent block.
+  - Revalidated the simsopt wrapper/solver regressions after that batching
+    refactor, and revalidated the matching exact-QH batched tape-JVP gate in
+    `vmec_jax`.
+  - Measured the exact QH start-point split on the production path after the
+    batching refactor:
+    - concrete residual evaluation is about `12.27 s` in one run and
+      `13.57 s` in a rerun,
+    - the concrete 8-column Jacobian build still dominates wall time by a wide
+      margin and remains well above one minute.
+  - This changes the runtime diagnosis again: the outer Python loop over
+    columns is no longer the main cost. The next performance target is inside
+    the tape-column propagation / exact replay Jacobian path itself.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -1,0 +1,90 @@
+# QH VMEC-JAX Discrete-Adjoint Consumer Plan
+
+Last updated: 2026-04-14
+Repo: `simsopt`
+Branch: `codex/discrete-adjoint-2506`
+Coupled repo: `vmec_jax` on `codex/discrete-adjoint-2506`
+
+## Purpose
+
+This branch exists to consume a new solver-faithful discrete-adjoint derivative path
+from `vmec_jax`, and to use it in a clean `QH_fixed_resolution_jax.py` that mirrors
+the structure of the classic `QH_fixed_resolution.py`.
+
+The intent is not to add another layer of optimizer tuning around a weak derivative.
+The intent is to expose one correct and performant autodiff path to the existing
+SIMSOPT objective/solver machinery.
+
+## Paper-driven design decision
+
+The method in `arXiv:2506.14792` suggests that the right long-term structure is:
+
+- treat the equilibrium solve as the differentiated object,
+- use the solver's own accepted discrete path in reverse mode,
+- avoid dense finite-difference or dense Jacobian fallback paths,
+- keep the outer optimization code simple.
+
+For `simsopt`, that means the main work should stay small:
+
+- choose the right `VmecJax` derivative backend,
+- expose a clean QH example,
+- keep the benchmark apples-to-apples with the classic script.
+
+## Required benchmark
+
+- classic script: `examples/2_Intermediate/QH_fixed_resolution.py`
+- JAX script: `examples/2_Intermediate/QH_fixed_resolution_jax.py`
+- objective: `aspect + quasisymmetry`
+- no `mean_iota`
+- `max_mode = 1`
+- VMEC `mpol = ntor = 3`
+- 8 free boundary DOFs
+- `max_nfev = 10`
+
+## Planned changes
+
+### 1. Wrapper surface area
+
+- [ ] Add an explicit `VmecJax` derivative backend option for the new discrete-adjoint
+  residual path.
+- [ ] Keep wrapper defaults conservative until the new backend is validated.
+- [ ] Make backend selection explicit in the QH example output.
+
+### 2. QH example cleanup
+
+- [ ] Keep the script structure close to the classic example:
+  - setup,
+  - objective definition,
+  - before-solve reporting,
+  - solve,
+  - after-solve reporting.
+- [ ] Avoid branchy QA/QH scaffolding in the QH example itself.
+- [ ] Avoid hidden finite-difference Jacobian fallbacks.
+
+### 3. Solver choice
+
+- [ ] Re-test least-squares methods only after the new backend is correct.
+- [ ] Prefer a solver that does not need hand-tuned finite step sizes once the
+  Jacobian is trustworthy.
+- [ ] Keep `gradient_descent` as a diagnostic only, not the target path.
+
+### 4. Regression coverage
+
+- [ ] Add a wrapper-level regression confirming the QH start objective and finite
+  gradients on the new backend.
+- [ ] Add a small QH derivative smoke test from the public `VmecJax` API.
+
+## Acceptance
+
+This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
+
+- uses autodiff / adjoints only,
+- materially improves QH quasisymmetry,
+- reaches objective quality in the same ballpark as the classic script,
+- is competitive enough in runtime to justify the JAX path.
+
+## Immediate next tasks
+
+- [ ] Wait for the new `vmec_jax` backend interface to exist.
+- [ ] Wire it into `VmecJax`.
+- [ ] Replace the current QH example defaults with the new backend once validated.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -445,3 +445,18 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
       `0.102316`;
     - the current JAX exact path is still far slower and does not move off the
       starting point by 3 function evaluations.
+  - Ran a stricter derivative audit on the exact `max_mode=1`, `max_iter=1`
+    production path and isolated the earlier AD-vs-FD discrepancy:
+    - the discrete-adjoint Jacobian column does **not** match central FD of the
+      plain `scipy_residuals(x)` callback;
+    - but it **does** match central FD almost exactly when the residual is
+      finite-differenced through the same frozen-axis local map that the
+      discrete-adjoint path actually linearizes.
+  - On the benchmark QH start point, direction `e0`:
+    - plain residual callback FD gives objective-direction about `8.52594`;
+    - discrete-adjoint AD gives about `33.67235`;
+    - frozen-axis local residual FD gives about `33.67455`.
+  - This means the live production derivative gap is now understood as a model
+    mismatch in the initialization branch (`axis_override` refreshed at each
+    perturbed point in the value callback versus frozen in the local Jacobian),
+    not a corruption in the replay/tape linearization itself.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -30,6 +30,17 @@ For `simsopt`, that means the main work should stay small:
 - expose a clean QH example,
 - keep the benchmark apples-to-apples with the classic script.
 
+Important reality on this clean branch:
+
+- clean `simsopt` mainline does **not** yet contain:
+  - `src/simsopt/mhd/vmec_jax.py`,
+  - `src/simsopt/mhd/vmec_diagnostics_jax.py`,
+  - `src/simsopt/solve/jax_solve.py`,
+  - `examples/2_Intermediate/QH_fixed_resolution_jax.py`.
+
+So this branch is not just an example edit. It needs a staged reintroduction of
+the JAX consumer layer once the new backend in `vmec_jax` is trustworthy.
+
 ## Required benchmark
 
 - classic script: `examples/2_Intermediate/QH_fixed_resolution.py`
@@ -43,12 +54,33 @@ For `simsopt`, that means the main work should stay small:
 
 ## Planned changes
 
+### 0. Reintroduce the minimum JAX consumer surface
+
+- [ ] Port the minimum required files from the previous experimental branch, not
+  the whole branch history.
+- [ ] Keep the first port narrow:
+  - `src/simsopt/mhd/vmec_jax.py`
+  - `src/simsopt/mhd/vmec_diagnostics_jax.py`
+  - `src/simsopt/solve/jax_solve.py`
+  - exports / imports needed to surface them
+  - focused tests only
+- [ ] Do this only after `vmec_jax` reaches derivative Gate 4C.
+
+Acceptance:
+
+- clean `simsopt` can import the JAX wrapper and run a one-evaluation QH script.
+
 ### 1. Wrapper surface area
 
 - [ ] Add an explicit `VmecJax` derivative backend option for the new discrete-adjoint
   residual path.
 - [ ] Keep wrapper defaults conservative until the new backend is validated.
 - [ ] Make backend selection explicit in the QH example output.
+
+Acceptance:
+
+- backend selection is user-visible and test-covered,
+- the legacy implicit path is not silently selected by accident.
 
 ### 2. QH example cleanup
 
@@ -61,6 +93,12 @@ For `simsopt`, that means the main work should stay small:
 - [ ] Avoid branchy QA/QH scaffolding in the QH example itself.
 - [ ] Avoid hidden finite-difference Jacobian fallbacks.
 
+Acceptance:
+
+- the example reads like the classic QH script with a JAX-backed VMEC object
+  substituted for the classic VMEC object,
+- the derivative backend used is explicit in script output.
+
 ### 3. Solver choice
 
 - [ ] Re-test least-squares methods only after the new backend is correct.
@@ -68,11 +106,55 @@ For `simsopt`, that means the main work should stay small:
   Jacobian is trustworthy.
 - [ ] Keep `gradient_descent` as a diagnostic only, not the target path.
 
+Acceptance:
+
+- no production default depends on a hand-tuned finite step size,
+- the selected solver is justified by short benchmark data rather than guesswork.
+
 ### 4. Regression coverage
 
 - [ ] Add a wrapper-level regression confirming the QH start objective and finite
   gradients on the new backend.
 - [ ] Add a small QH derivative smoke test from the public `VmecJax` API.
+
+Acceptance:
+
+- wrapper regressions fail early if the backend becomes non-finite, changes the
+  QH start state, or silently regresses derivative quality.
+
+## Benchmarks and gates
+
+### Consumer-side gates
+
+- Gate S0: import and one-evaluation smoke test for the reintroduced wrapper.
+- Gate S1: exact QH start objective matches the intended converged forward path.
+- Gate S2: public-API directional derivative agrees with finite differences on
+  the exact QH start point.
+- Gate S3: `max_nfev=1` runtime and correctness benchmark.
+- Gate S4: `max_nfev=2` apples-to-apples QH benchmark.
+- Gate S5: `max_nfev=10` apples-to-apples QH benchmark.
+
+### Required runtime metrics
+
+For every benchmark script run, record:
+
+- total wall time,
+- solver method,
+- derivative backend,
+- objective/Jacobian call counts,
+- wall time per objective/Jacobian call,
+- final total objective,
+- final QS objective,
+- final aspect.
+
+### Required file-level benchmark targets
+
+- `src/simsopt/mhd/vmec_jax.py`
+  - wrapper overhead and caching overhead.
+- `src/simsopt/mhd/vmec_diagnostics_jax.py`
+  - QS residual evaluation cost and derivative smoke checks.
+- `src/simsopt/solve/jax_solve.py`
+  - solver bookkeeping overhead independent of VMEC solve cost.
 
 ## Acceptance
 
@@ -85,6 +167,7 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
 
 ## Immediate next tasks
 
-- [ ] Wait for the new `vmec_jax` backend interface to exist.
-- [ ] Wire it into `VmecJax`.
-- [ ] Replace the current QH example defaults with the new backend once validated.
+- [ ] Identify the minimal donor file set from the previous `simsopt_qh` branch.
+- [ ] Defer porting until `vmec_jax` derivative Gate 4C is met.
+- [ ] Once the backend is ready, wire it into `VmecJax` with explicit backend
+  selection and benchmark reporting.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -274,3 +274,29 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
   - This changes the runtime diagnosis again: the outer Python loop over
     columns is no longer the main cost. The next performance target is inside
     the tape-column propagation / exact replay Jacobian path itself.
+  - Re-measured the exact QH start-point concrete Jacobian path directly on the
+    current branch at `vmec_max_iter=1` and found a different dominant term:
+    - solve/tape build about `2.42 s`,
+    - frozen initial-state linearization about `2.10 s`,
+    - replay column propagation about `1.30 s`,
+    - residual-side linearization about `9.42 s`,
+    - total concrete Jacobian build about `15.24 s`.
+  - Based on that measurement, shifted the next optimization into the wrapper's
+    pure-JAX blocks rather than the replay tape itself.
+  - Added a cache of JIT-compiled helper functions inside
+    `VmecJax._discrete_adjoint_residual_jacobian(...)` for:
+    - frozen initial-state tangent columns,
+    - residual tangent columns.
+  - The residual-side JIT initially exposed a traced NumPy path in the
+    Boozer/QS diagnostics on the `vmec_jax` side; after that blocker was fixed,
+    the cached residual block became usable.
+  - With those cached helper blocks active, the repeated exact-QH concrete
+    Jacobian on the same start point dropped to about `1.17 s` for a
+    `(44353, 8)` Jacobian after the first compilation, with zero numerical
+    difference between repeated calls.
+  - Re-ran the same production QH microcase:
+    - `QH_fixed_resolution_jax.py --max-mode 1 --max-nfev 2 --vmec-max-iter 1
+      --timings --method scipy --jac jax
+      --residual-derivative-backend discrete_adjoint --jit`
+    - total objective still `1.901008100532871 -> 0.505258184704556`,
+    - solve wall time dropped again from about `16.93 s` to `5.14 s`.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -570,3 +570,30 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
   - This branch state is now derivative-stable at late iterates, but runtime is
     still not competitive with classic QH and the final objective is still
     above the earlier best branch result and above the classic reference.
+  - Stable direct comparison set generated on 2026-04-16 with the new
+    `tools/diagnostics/qh_classic_vs_jax_compare.py` harness and plots written
+    to `/Users/rogeriojorge/local/tests/qh_compare_outputs_ship`:
+    - classic `max_mode=1`, `max_nfev<=20`, 300 s cap:
+      final total `0.2137756193963573`, QS `0.21146713337229725`,
+      aspect `7.04804670669319`, elapsed `71.23 s`, peak RSS `0.49 GB`
+    - classic `max_mode=2`, `max_nfev<=20`, 300 s cap:
+      final total `0.005563975632258551`, QS `0.0055639710182783944`,
+      aspect `7.000067926284435`, elapsed `265.12 s`, peak RSS `0.49 GB`
+    - JAX exact `max_mode=1`, `max_nfev<=20`, 90 s cap:
+      final total `0.24902495986882436`, QS `0.24799228342758917`,
+      aspect `7.032135283431692`, elapsed `109.40 s`, peak RSS `14.93 GB`
+    - JAX exact `max_mode=2`, `max_nfev<=20`, 90 s cap:
+      final total `0.22622233073571194`, QS `0.22572926013411204`,
+      aspect `7.022205193122329`, elapsed `123.32 s`, peak RSS `16.91 GB`
+  - Interpretation of that stable comparison set:
+    - the forward exact JAX path is still the blocker, not the late-iterate
+      derivative catastrophe we already fixed;
+    - at both `max_mode=1` and `max_mode=2`, classic is still materially
+      ahead in both objective reduction and memory footprint within the first
+      90-120 seconds;
+    - mode 2 remains the clearest shipping blocker because classic reaches
+      `O(1e-3)` total objective while JAX is still at `O(1e-1)` in the same
+      broad runtime envelope.
+  - Next PR-facing step is no longer another derivative rewrite. It is a
+    forward-path/runtime pass aimed at executable retention and exact residual
+    solve cost, with the new comparison harness kept as the acceptance gate.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -597,3 +597,5 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
   - Next PR-facing step is no longer another derivative rewrite. It is a
     forward-path/runtime pass aimed at executable retention and exact residual
     solve cost, with the new comparison harness kept as the acceptance gate.
+  - Draft PR opened for the simsopt-side branch state:
+    https://github.com/hiddenSymmetries/simsopt/pull/621

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -514,3 +514,21 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
   - Added a slow wrapper regression that locks the full-inner (`max_iter=20`)
     QH frozen-axis Jacobian against central FD on the production
     discrete-adjoint backend.
+  - The production wrapper is no longer using the old frozen-axis
+    initial-state surrogate. After fixing the traced moving-axis
+    `initial_guess_from_boundary(...)` path in `vmec_jax`, the exact
+    discrete-adjoint backend now linearizes the true moving-axis initial-state
+    map on the user-facing QH objective path.
+  - The replay tangent transport is also no longer linearized around a drifting
+    replayed scan. It now composes the dynamic one-step map at the stored
+    primal carry of each accepted step, which materially tightened the exact
+    QH Jacobian audit on the real wrapper path.
+  - Updated slow wrapper gates now lock:
+    - exact QH start-point moving-axis Jacobian vs central FD at `max_iter=1`
+    - exact QH start-point moving-axis Jacobian vs central FD at `max_iter=20`
+  - Current exact full-inner start-point audit on the production path:
+    - moving-axis `max_iter=20` relative column error about `2.25e-3`
+    - objective-direction mismatch about `1.1e-2` relative
+    - that is materially better than the earlier full-inner moving-axis drift,
+      but still leaves some headroom before calling the derivative issue fully
+      closed at longer horizons / later accepted iterates.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -357,6 +357,27 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
     - the run still exited before the first SciPy iteration completed, so this
       fix materially improved the short compiled path but did not yet stabilize
       the full-inner benchmark regime.
+  - Switched the production discrete-adjoint wrapper off the replay-built tape
+    and onto a new direct full-solve tape path from `vmec_jax`, so the exact
+    Jacobian payload is built from one residual solve with full
+    `adjoint_step_trace` history instead of hundreds of `max_iter=1` replay
+    solves.
+  - On the exact full-inner QH benchmark path this removes the compile storm
+    that previously happened before SciPy iteration 0. The exact run now gets
+    through real SciPy iterations:
+    - `QH_fixed_resolution_jax.py --max-mode 1 --max-nfev 1 --timings
+      --method scipy --jac jax --residual-derivative-backend discrete_adjoint
+      --jit`
+      now reaches and completes iteration 0 with solve wall time about
+      `16.58 s`.
+    - `QH_fixed_resolution_jax.py --max-mode 1 --max-nfev 2 --timings
+      --method scipy --jac jax --residual-derivative-backend discrete_adjoint
+      --jit`
+      now completes two exact full-inner evaluations with:
+      - total objective `0.2983122217180416 -> 0.2651202937448159`,
+      - QS objective `0.24335963941459998`,
+      - aspect `7.147514929177409`,
+      - solve wall time about `29.73 s`.
   - Built a fresh mainline comparison environment:
     - cloned `vmec_jax` main to `/Users/rogeriojorge/local/vmec_jax_main_fresh`,
     - installed it in an isolated venv with system site packages.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -221,3 +221,17 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
   - Identified the next concrete runtime blocker for the production path:
     `jit=True` still fails in the traced residual solver due to NumPy-only
     precompute code inside `vmec_jax.solve`.
+  - Switched the production SciPy path away from traced `jacfwd(stage.residuals)`
+    and onto a concrete Jacobian callable built from the discrete-adjoint tape
+    columns in `VmecJax`.
+  - `build_vmec_objective_stage(...)` now attaches a discrete-backend
+    `scipy_jacobian` override, and `least_squares_jax_solve(...)` consumes it
+    when `jac='jax'`.
+  - That keeps the outer optimizer on an autodiff/adjoint Jacobian while
+    avoiding traced execution of the VMEC residual solver entirely.
+  - Revalidated the wrapper and solver regressions after this refactor.
+  - Re-ran the same QH microcase with `--jit` still enabled; because the
+    SciPy Jacobian now comes from the concrete tape-column path, it no longer
+    depends on tracing the VMEC solve, and the 2-evaluation run improved to:
+    - total objective `1.901008100532871 -> 0.5052581847050319`,
+    - wall time about `18.26 s`.

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -396,3 +396,25 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
       regression,
     - the remaining heaviness is in the higher-level `simsopt`
       objective/Jacobian path used before the first SciPy iteration.
+  - After the stacked-trace cache refactor landed in `vmec_jax`, reran the
+    exact full-inner apples-to-apples QH benchmark:
+    - `QH_fixed_resolution_jax.py --max-mode 1 --max-nfev 10 --timings
+      --method scipy --jac jax --residual-derivative-backend discrete_adjoint
+      --jit`
+      now finishes with the same final objective
+      `0.25740827662370214`, but solve wall time improves from about
+      `136.70 s` to about `103.92 s` and shell real time improves from about
+      `167.41 s` to about `133.02 s`.
+  - Probed exact callback compile churn on `x0`, repeated `x0`, and nearby
+    `x1`, and found one remaining avoidable `simsopt` helper-cache miss:
+    `_initial_tangent_columns` and `_residual_tangent_columns` were
+    recompiling when the tape length changed, even though those helpers do not
+    depend on step count.
+  - Removed `len(payload["tape"].step_traces)` from the helper-cache key in
+    `VmecJax._discrete_adjoint_residual_jacobian(...)`.
+  - After that change, compile logging shows each of
+    `_initial_tangent_columns` and `_residual_tangent_columns` compiles only
+    once across `x0/x0/x1`, while the nearby exact callback timings improve to:
+    - `x0a`: solve about `7.89 s`, jac about `4.14 s`
+    - `x0b`: solve about `5.77 s`, jac about `3.32 s`
+    - `x1`: solve about `5.65 s`, jac about `3.49 s`

--- a/discrete_adjoint_2506_plan.md
+++ b/discrete_adjoint_2506_plan.md
@@ -247,3 +247,12 @@ This branch is successful only if the resulting `QH_fixed_resolution_jax.py`:
   - This confirms the next exact benchmark bottleneck is the plain forward
     VMEC residual solve, not Jacobian tracing/plumbing in the outer SciPy
     path.
+  - Cleaned up `examples/2_Intermediate/QH_fixed_resolution_jax.py` so its
+    pre/post reporting path now uses the same concrete forward solve and
+    concrete residual callable as the production SciPy residual path when the
+    discrete backend is active.
+  - That removes a large amount of wasted work from the exact benchmark shell
+    runtime: the script now reaches `Solver settings`, `Quasisymmetry
+    objective before optimization`, and `Total objective before optimization`
+    quickly on the exact QH setup instead of stalling in a tape-building
+    `_solve_state(...)` call before the solve begins.

--- a/examples/2_Intermediate/QA_fixed_resolution_jax.py
+++ b/examples/2_Intermediate/QA_fixed_resolution_jax.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import time
+
+import numpy as np
+
+from simsopt.mhd import VmecJax
+from simsopt.solve import build_vmec_objective_stage, least_squares_jax_solve
+from simsopt.util import proc0_print
+
+"""
+Optimize a VMEC-JAX equilibrium for quasi-axisymmetry (M=1, N=0)
+throughout the volume, using autodiff and the VMEC-only quasisymmetry
+diagnostic.
+
+Run this example with:
+  python QA_fixed_resolution_jax.py
+"""
+
+DEFAULT_MAX_NFEV = 10
+DEFAULT_MAX_MODE = 1
+DEFAULT_METHOD = "scipy"
+DEFAULT_JAC = "jax"
+DEFAULT_RESIDUAL_DERIVATIVE_BACKEND = "discrete_adjoint"
+DEFAULT_JIT = True
+DEFAULT_STEP_SIZE = 1.0
+DEFAULT_ADJOINT_MODE = "lineax"
+DEFAULT_ASPECT_TARGET = 2.0
+DEFAULT_IOTA_TARGET = 0.41
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-nfev", type=int, default=DEFAULT_MAX_NFEV)
+    parser.add_argument("--max-mode", type=int, default=DEFAULT_MAX_MODE)
+    parser.add_argument(
+        "--method",
+        choices=[
+            "gradient_descent",
+            "scipy",
+            "gauss_newton",
+            "truncated_gauss_newton",
+            "trust_region",
+            "levenberg_marquardt",
+            "lbfgs",
+        ],
+        default=DEFAULT_METHOD,
+    )
+    parser.add_argument("--step-size", type=float, default=DEFAULT_STEP_SIZE)
+    parser.add_argument("--adjoint-mode", choices=["lineax", "auto", "chunked", "dense"], default=DEFAULT_ADJOINT_MODE)
+    parser.add_argument("--jac", choices=["jax", "reverse", "2-point", "3-point"], default=DEFAULT_JAC)
+    parser.add_argument(
+        "--residual-derivative-backend",
+        choices=["implicit", "discrete_adjoint"],
+        default=DEFAULT_RESIDUAL_DERIVATIVE_BACKEND,
+    )
+    parser.add_argument("--jit", action=argparse.BooleanOptionalAction, default=DEFAULT_JIT)
+    parser.add_argument("--stateless-evaluations", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--timings", action="store_true")
+    parser.add_argument("--profile", action="store_true")
+    parser.add_argument("--aspect-target", type=float, default=DEFAULT_ASPECT_TARGET)
+    parser.add_argument("--iota-target", type=float, default=DEFAULT_IOTA_TARGET)
+    parser.add_argument("--vmec-max-iter", type=int, default=None)
+    parser.add_argument("--vmec-grad-tol", type=float, default=None)
+    parser.add_argument("--implicit-cg-max-iter", type=int, default=None)
+    parser.add_argument("--implicit-cg-tol", type=float, default=None)
+    return parser.parse_args()
+
+
+def objective_value_from_state(vmec, qs, state, *, aspect_target, iota_target):
+    aspect_residual = np.asarray([vmec.aspect_equilibrium_from_state_jax(state) - float(aspect_target)], dtype=float)
+    iota_residual = np.asarray([vmec.mean_iota_from_state_jax(state) - float(iota_target)], dtype=float)
+    qs_residual = np.asarray(qs.residuals_from_state(state), dtype=float)
+    residual = np.concatenate((aspect_residual, iota_residual, qs_residual))
+    return float(np.dot(residual, residual))
+
+
+def solve_state_for_report(vmec, x):
+    if str(getattr(vmec, "_residual_derivative_backend", "")) == "discrete_adjoint":
+        step_size = (
+            float(vmec._step_size_override)
+            if getattr(vmec, "_step_size_override", None) is not None
+            else float(vmec._indata_raw.get_float("DELT", 1.0))
+        )
+        return vmec._solve_state_residual_forward(x, step_size=step_size)
+    return vmec._solve_state(x)
+
+
+def main():
+    args = parse_args()
+    max_mode = int(args.max_mode)
+    max_nfev = int(args.max_nfev)
+    method = str(args.method).strip().lower()
+    jac_mode = str(args.jac).strip().lower()
+    aspect_target = float(args.aspect_target)
+    iota_target = float(args.iota_target)
+
+    proc0_print("Running 2_Intermediate/QA_fixed_resolution_jax.py")
+    proc0_print("=================================================")
+
+    filename = os.path.join(os.path.dirname(__file__), "inputs", "input.nfp2_QA")
+    vmec = VmecJax(filename, verbose=False)
+    vmec.indata.mpol = max_mode + 2
+    vmec.indata.ntor = max_mode + 2
+    vmec.use_residual_autodiff_defaults(
+        outer_method=method,
+        residual_adjoint_mode=str(args.adjoint_mode).strip().lower(),
+        stateless_evaluations=bool(args.stateless_evaluations),
+    )
+    vmec.set_solver_options(
+        max_iter=args.vmec_max_iter,
+        grad_tol=args.vmec_grad_tol,
+        implicit_cg_max_iter=args.implicit_cg_max_iter,
+        implicit_cg_tol=args.implicit_cg_tol,
+        residual_derivative_backend=str(args.residual_derivative_backend).strip().lower(),
+    )
+
+    stage = build_vmec_objective_stage(
+        vmec,
+        max_mode=max_mode,
+        objective_tuples=[
+            ("aspect", aspect_target, 1.0),
+            ("mean_iota", iota_target, 1.0),
+            ("qs", 0.0, 1.0),
+        ],
+        surfaces=np.arange(0, 1.01, 0.1),
+        helicity_m=1,
+        helicity_n=0,
+        x_scale_alpha=1.2,
+        x_scale_min=1e-9,
+    )
+    surf = stage.extras["surf"]
+    qs = stage.extras["qs"]
+    solve_jit = bool(args.jit)
+    if (
+        method == "scipy"
+        and jac_mode in ("reverse", "rev", "jacrev")
+        and str(vmec._residual_derivative_backend) == "discrete_adjoint"
+    ):
+        solve_jit = False
+
+    initial_state = solve_state_for_report(vmec, stage.x0)
+
+    proc0_print("Parameter space:", stage.free_names)
+    proc0_print(
+        "Objective tuples:",
+        [("aspect", aspect_target, 1.0), ("mean_iota", iota_target, 1.0), ("qs", 0.0, 1.0)],
+    )
+    proc0_print(
+        "Reference setup:",
+        {
+            "reference": "QA",
+            "input": "input.nfp2_QA",
+            "helicity": (1, 0),
+            "max_mode": max_mode,
+            "vmec_mpol": max_mode + 2,
+            "vmec_ntor": max_mode + 2,
+        },
+    )
+    proc0_print(
+        "Solver settings:",
+        {
+            "method": method,
+            "jac": jac_mode,
+            "residual_derivative_backend": str(vmec._residual_derivative_backend),
+            "vmec_max_iter": int(vmec._max_iter),
+            "vmec_grad_tol": float(vmec._grad_tol),
+            "implicit_cg_max_iter": int(vmec._implicit_cg_max_iter),
+            "implicit_cg_tol": float(vmec._implicit_cg_tol),
+            "jit": solve_jit,
+            "adjoint_mode": str(vmec._residual_adjoint_mode),
+            "stateless_evaluations": bool(vmec._stateless_evaluations),
+        },
+    )
+
+    proc0_print("Quasisymmetry objective before optimization:", float(np.asarray(qs.total_from_state(initial_state))))
+    proc0_print("Initial aspect ratio:", float(np.asarray(vmec.aspect_equilibrium_from_state_jax(initial_state))))
+    proc0_print("Initial mean iota:", float(np.asarray(vmec.mean_iota_from_state_jax(initial_state))))
+    proc0_print(
+        "Total objective before optimization:",
+        objective_value_from_state(vmec, qs, initial_state, aspect_target=aspect_target, iota_target=iota_target),
+    )
+
+    solve_start = time.perf_counter()
+    result = least_squares_jax_solve(
+        stage.residuals,
+        stage.x0,
+        method=method,
+        max_nfev=max_nfev,
+        gtol=1e-7,
+        step_size=float(args.step_size),
+        x_scale=stage.x_scale,
+        jit=solve_jit,
+        verbose=1,
+        jac=jac_mode if method == "scipy" else None,
+        profile=bool(args.profile),
+    )
+    solve_elapsed = time.perf_counter() - solve_start
+
+    surf.set_free_params(result["x"])
+    state_opt = solve_state_for_report(vmec, result["x"])
+
+    proc0_print("Final aspect ratio:", float(np.asarray(vmec.aspect_equilibrium_from_state_jax(state_opt))))
+    proc0_print("Mean iota after optimization:", float(np.asarray(vmec.mean_iota_from_state_jax(state_opt))))
+    proc0_print("Quasisymmetry objective after optimization:", float(np.asarray(qs.total_from_state(state_opt))))
+    proc0_print(
+        "Total objective after optimization:",
+        objective_value_from_state(vmec, qs, state_opt, aspect_target=aspect_target, iota_target=iota_target),
+    )
+    proc0_print("Result summary:", {key: result.get(key) for key in ("success", "status", "nfev")})
+    if args.profile:
+        proc0_print("Solver profile:", result.get("profile"))
+    if args.timings:
+        proc0_print("Solve wall time [s]:", solve_elapsed)
+
+    proc0_print("End of 2_Intermediate/QA_fixed_resolution_jax.py")
+    proc0_print("===============================================")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/2_Intermediate/QH_fixed_resolution_jax.py
+++ b/examples/2_Intermediate/QH_fixed_resolution_jax.py
@@ -24,6 +24,8 @@ DEFAULT_METHOD = "gradient_descent"
 DEFAULT_STEP_SIZE = 5e-5
 DEFAULT_JIT = True
 DEFAULT_ADJOINT_MODE = "chunked"
+DEFAULT_JAC = "jax"
+DEFAULT_RESIDUAL_DERIVATIVE_BACKEND = "implicit"
 
 
 def parse_args():
@@ -45,6 +47,12 @@ def parse_args():
     )
     parser.add_argument("--step-size", type=float, default=DEFAULT_STEP_SIZE)
     parser.add_argument("--adjoint-mode", choices=["lineax", "auto", "chunked", "dense"], default=DEFAULT_ADJOINT_MODE)
+    parser.add_argument("--jac", choices=["jax", "reverse", "2-point", "3-point"], default=DEFAULT_JAC)
+    parser.add_argument(
+        "--residual-derivative-backend",
+        choices=["implicit", "discrete_adjoint"],
+        default=DEFAULT_RESIDUAL_DERIVATIVE_BACKEND,
+    )
     parser.add_argument("--jit", action=argparse.BooleanOptionalAction, default=DEFAULT_JIT)
     parser.add_argument("--stateless-evaluations", action=argparse.BooleanOptionalAction, default=False)
     parser.add_argument("--timings", action="store_true")
@@ -66,6 +74,7 @@ def main():
     max_mode = int(args.max_mode)
     max_nfev = int(args.max_nfev)
     method = str(args.method).strip().lower()
+    jac_mode = str(args.jac).strip().lower()
 
     proc0_print("Running 2_Intermediate/QH_fixed_resolution_jax.py")
     proc0_print("==================================================")
@@ -85,6 +94,7 @@ def main():
         grad_tol=args.vmec_grad_tol,
         implicit_cg_max_iter=args.implicit_cg_max_iter,
         implicit_cg_tol=args.implicit_cg_tol,
+        residual_derivative_backend=str(args.residual_derivative_backend).strip().lower(),
     )
 
     surf = vmec.boundary
@@ -103,6 +113,13 @@ def main():
         x_scale_min=1e-9,
     )
     qs = stage.extras["qs"]
+    solve_jit = bool(args.jit)
+    if (
+        method == "scipy"
+        and jac_mode in ("reverse", "rev", "jacrev")
+        and str(vmec._residual_derivative_backend) == "discrete_adjoint"
+    ):
+        solve_jit = False
 
     proc0_print("Parameter space:", stage.free_names)
     initial_state = vmec._solve_state(stage.x0)
@@ -116,7 +133,9 @@ def main():
             "vmec_grad_tol": float(vmec._grad_tol),
             "implicit_cg_max_iter": int(vmec._implicit_cg_max_iter),
             "implicit_cg_tol": float(vmec._implicit_cg_tol),
-            "jit": bool(args.jit),
+            "jit": solve_jit,
+            "jac": jac_mode,
+            "residual_derivative_backend": str(vmec._residual_derivative_backend),
             "adjoint_mode": str(vmec._residual_adjoint_mode),
             "stateless_evaluations": bool(vmec._stateless_evaluations),
         },
@@ -135,9 +154,9 @@ def main():
         gtol=1e-7,
         step_size=float(args.step_size),
         x_scale=stage.x_scale,
-        jit=bool(args.jit),
+        jit=solve_jit,
         verbose=1,
-        jac="jax" if method == "scipy" else None,
+        jac=jac_mode if method == "scipy" else None,
         profile=bool(args.profile),
     )
     solve_elapsed = time.perf_counter() - solve_start

--- a/examples/2_Intermediate/QH_fixed_resolution_jax.py
+++ b/examples/2_Intermediate/QH_fixed_resolution_jax.py
@@ -63,8 +63,23 @@ def parse_args():
 
 
 def objective_value(stage, x):
-    residual = np.asarray(stage.residuals(x), dtype=float)
+    scipy_residuals = getattr(stage.residuals, "scipy_residuals", None)
+    if callable(scipy_residuals):
+        residual = np.asarray(scipy_residuals(x), dtype=float)
+    else:
+        residual = np.asarray(stage.residuals(x), dtype=float)
     return float(np.dot(residual, residual))
+
+
+def solve_state_for_report(vmec, x):
+    if str(getattr(vmec, "_residual_derivative_backend", "")) == "discrete_adjoint":
+        step_size = (
+            float(vmec._step_size_override)
+            if getattr(vmec, "_step_size_override", None) is not None
+            else float(vmec._indata_raw.get_float("DELT", 1.0))
+        )
+        return vmec._solve_state_residual_forward(x, step_size=step_size)
+    return vmec._solve_state(x)
 
 
 def main():
@@ -123,7 +138,7 @@ def main():
     ):
         solve_jit = False
 
-    initial_state = vmec._solve_state(stage.x0)
+    initial_state = solve_state_for_report(vmec, stage.x0)
 
     proc0_print(
         "Solver settings:",
@@ -162,7 +177,7 @@ def main():
     solve_elapsed = time.perf_counter() - solve_start
 
     surf.set_free_params(result["x"])
-    state_opt = vmec._solve_state(result["x"])
+    state_opt = solve_state_for_report(vmec, result["x"])
 
     proc0_print("Final aspect ratio:", float(np.asarray(vmec.aspect_equilibrium_from_state_jax(state_opt))))
     proc0_print("Quasisymmetry objective after optimization:", float(np.asarray(qs.total_from_state(state_opt))))

--- a/examples/2_Intermediate/QH_fixed_resolution_jax.py
+++ b/examples/2_Intermediate/QH_fixed_resolution_jax.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import time
+
+import numpy as np
+
+from simsopt.mhd import VmecJax
+from simsopt.solve import build_vmec_objective_stage, least_squares_jax_solve
+from simsopt.util import proc0_print
+
+"""
+Optimize a VMEC-JAX equilibrium for quasi-helical symmetry (M=1, N=1)
+throughout the volume using autodiff through vmec_jax.
+
+Run this example with:
+  python QH_fixed_resolution_jax.py
+"""
+
+DEFAULT_MAX_NFEV = 10
+DEFAULT_MAX_MODE = 1
+DEFAULT_METHOD = "gradient_descent"
+DEFAULT_STEP_SIZE = 5e-5
+DEFAULT_JIT = True
+DEFAULT_ADJOINT_MODE = "chunked"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-nfev", type=int, default=DEFAULT_MAX_NFEV)
+    parser.add_argument("--max-mode", type=int, default=DEFAULT_MAX_MODE)
+    parser.add_argument(
+        "--method",
+        choices=[
+            "gradient_descent",
+            "scipy",
+            "gauss_newton",
+            "truncated_gauss_newton",
+            "trust_region",
+            "levenberg_marquardt",
+            "lbfgs",
+        ],
+        default=DEFAULT_METHOD,
+    )
+    parser.add_argument("--step-size", type=float, default=DEFAULT_STEP_SIZE)
+    parser.add_argument("--adjoint-mode", choices=["lineax", "auto", "chunked", "dense"], default=DEFAULT_ADJOINT_MODE)
+    parser.add_argument("--jit", action=argparse.BooleanOptionalAction, default=DEFAULT_JIT)
+    parser.add_argument("--stateless-evaluations", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--timings", action="store_true")
+    parser.add_argument("--profile", action="store_true")
+    parser.add_argument("--vmec-max-iter", type=int, default=None)
+    parser.add_argument("--vmec-grad-tol", type=float, default=None)
+    parser.add_argument("--implicit-cg-max-iter", type=int, default=None)
+    parser.add_argument("--implicit-cg-tol", type=float, default=None)
+    return parser.parse_args()
+
+
+def objective_value(stage, x):
+    residual = np.asarray(stage.residuals(x), dtype=float)
+    return float(np.dot(residual, residual))
+
+
+def main():
+    args = parse_args()
+    max_mode = int(args.max_mode)
+    max_nfev = int(args.max_nfev)
+    method = str(args.method).strip().lower()
+
+    proc0_print("Running 2_Intermediate/QH_fixed_resolution_jax.py")
+    proc0_print("==================================================")
+
+    filename = os.path.join(os.path.dirname(__file__), "inputs", "input.nfp4_QH_warm_start")
+    vmec = VmecJax(filename, verbose=False)
+    vmec.indata.mpol = max_mode + 2
+    vmec.indata.ntor = max_mode + 2
+    vmec.use_residual_autodiff_defaults(
+        outer_method=method,
+        residual_adjoint_mode=str(args.adjoint_mode).strip().lower(),
+        stateless_evaluations=bool(args.stateless_evaluations),
+        optimization_profile="qh",
+    )
+    vmec.set_solver_options(
+        max_iter=args.vmec_max_iter,
+        grad_tol=args.vmec_grad_tol,
+        implicit_cg_max_iter=args.implicit_cg_max_iter,
+        implicit_cg_tol=args.implicit_cg_tol,
+    )
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=max_mode, nmin=-max_mode, nmax=max_mode, fixed=False)
+    surf.fix("rc(0,0)")
+
+    stage = build_vmec_objective_stage(
+        vmec,
+        max_mode=max_mode,
+        objective_tuples=[("aspect", 7.0, 1.0), ("qs", 0.0, 1.0)],
+        surfaces=np.arange(0, 1.01, 0.1),
+        helicity_m=1,
+        helicity_n=-1,
+        x_scale_alpha=1.2,
+        x_scale_min=1e-9,
+    )
+    qs = stage.extras["qs"]
+
+    proc0_print("Parameter space:", stage.free_names)
+    initial_state = vmec._solve_state(stage.x0)
+
+    proc0_print(
+        "Solver settings:",
+        {
+            "method": method,
+            "step_size": float(args.step_size),
+            "vmec_max_iter": int(vmec._max_iter),
+            "vmec_grad_tol": float(vmec._grad_tol),
+            "implicit_cg_max_iter": int(vmec._implicit_cg_max_iter),
+            "implicit_cg_tol": float(vmec._implicit_cg_tol),
+            "jit": bool(args.jit),
+            "adjoint_mode": str(vmec._residual_adjoint_mode),
+            "stateless_evaluations": bool(vmec._stateless_evaluations),
+        },
+    )
+
+    proc0_print("Quasisymmetry objective before optimization:", float(np.asarray(qs.total_from_state(initial_state))))
+    proc0_print("Initial aspect ratio:", float(np.asarray(vmec.aspect_equilibrium_from_state_jax(initial_state))))
+    proc0_print("Total objective before optimization:", objective_value(stage, stage.x0))
+
+    solve_start = time.perf_counter()
+    result = least_squares_jax_solve(
+        stage.residuals,
+        stage.x0,
+        method=method,
+        max_nfev=max_nfev,
+        gtol=1e-7,
+        step_size=float(args.step_size),
+        x_scale=stage.x_scale,
+        jit=bool(args.jit),
+        verbose=1,
+        jac="jax" if method == "scipy" else None,
+        profile=bool(args.profile),
+    )
+    solve_elapsed = time.perf_counter() - solve_start
+
+    surf.set_free_params(result["x"])
+    state_opt = vmec._solve_state(result["x"])
+
+    proc0_print("Final aspect ratio:", float(np.asarray(vmec.aspect_equilibrium_from_state_jax(state_opt))))
+    proc0_print("Quasisymmetry objective after optimization:", float(np.asarray(qs.total_from_state(state_opt))))
+    proc0_print("Total objective after optimization:", objective_value(stage, result["x"]))
+    proc0_print("Result summary:", {key: result.get(key) for key in ("success", "status", "nfev")})
+    if args.profile:
+        proc0_print("Solver profile:", result.get("profile"))
+    if args.timings:
+        proc0_print("Solve wall time [s]:", solve_elapsed)
+
+    proc0_print("End of 2_Intermediate/QH_fixed_resolution_jax.py")
+    proc0_print("================================================")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/2_Intermediate/QH_fixed_resolution_jax.py
+++ b/examples/2_Intermediate/QH_fixed_resolution_jax.py
@@ -102,8 +102,6 @@ def main():
     surf.fixed_range(mmin=0, mmax=max_mode, nmin=-max_mode, nmax=max_mode, fixed=False)
     surf.fix("rc(0,0)")
 
-    proc0_print("Parameter space:", surf.dof_names)
-
     # Configure quasisymmetry objective:
     stage = build_vmec_objective_stage(
         vmec,
@@ -115,6 +113,7 @@ def main():
         x_scale_alpha=1.2,
         x_scale_min=1e-9,
     )
+    proc0_print("Parameter space:", stage.free_names)
     qs = stage.extras["qs"]
     solve_jit = bool(args.jit)
     if (

--- a/examples/2_Intermediate/QH_fixed_resolution_jax.py
+++ b/examples/2_Intermediate/QH_fixed_resolution_jax.py
@@ -12,20 +12,18 @@ from simsopt.util import proc0_print
 
 """
 Optimize a VMEC-JAX equilibrium for quasi-helical symmetry (M=1, N=1)
-throughout the volume using autodiff through vmec_jax.
-
-Run this example with:
-  python QH_fixed_resolution_jax.py
+throughout the volume.
+Run this example with python QH_fixed_resolution_jax.py
 """
 
 DEFAULT_MAX_NFEV = 10
 DEFAULT_MAX_MODE = 1
-DEFAULT_METHOD = "gradient_descent"
-DEFAULT_STEP_SIZE = 5e-5
-DEFAULT_JIT = True
-DEFAULT_ADJOINT_MODE = "chunked"
+DEFAULT_METHOD = "scipy"
 DEFAULT_JAC = "jax"
-DEFAULT_RESIDUAL_DERIVATIVE_BACKEND = "implicit"
+DEFAULT_RESIDUAL_DERIVATIVE_BACKEND = "discrete_adjoint"
+DEFAULT_JIT = False
+DEFAULT_STEP_SIZE = 5e-5
+DEFAULT_ADJOINT_MODE = "chunked"
 
 
 def parse_args():
@@ -77,8 +75,9 @@ def main():
     jac_mode = str(args.jac).strip().lower()
 
     proc0_print("Running 2_Intermediate/QH_fixed_resolution_jax.py")
-    proc0_print("==================================================")
+    proc0_print("=================================================")
 
+    # For forming filenames for VMEC, pathlib sometimes does not work, so use os.path.join instead.
     filename = os.path.join(os.path.dirname(__file__), "inputs", "input.nfp4_QH_warm_start")
     vmec = VmecJax(filename, verbose=False)
     vmec.indata.mpol = max_mode + 2
@@ -97,11 +96,15 @@ def main():
         residual_derivative_backend=str(args.residual_derivative_backend).strip().lower(),
     )
 
+    # Define parameter space:
     surf = vmec.boundary
     surf.fix_all()
     surf.fixed_range(mmin=0, mmax=max_mode, nmin=-max_mode, nmax=max_mode, fixed=False)
     surf.fix("rc(0,0)")
 
+    proc0_print("Parameter space:", surf.dof_names)
+
+    # Configure quasisymmetry objective:
     stage = build_vmec_objective_stage(
         vmec,
         max_mode=max_mode,
@@ -121,30 +124,28 @@ def main():
     ):
         solve_jit = False
 
-    proc0_print("Parameter space:", stage.free_names)
     initial_state = vmec._solve_state(stage.x0)
 
     proc0_print(
         "Solver settings:",
         {
             "method": method,
-            "step_size": float(args.step_size),
+            "jac": jac_mode,
+            "residual_derivative_backend": str(vmec._residual_derivative_backend),
             "vmec_max_iter": int(vmec._max_iter),
             "vmec_grad_tol": float(vmec._grad_tol),
             "implicit_cg_max_iter": int(vmec._implicit_cg_max_iter),
             "implicit_cg_tol": float(vmec._implicit_cg_tol),
             "jit": solve_jit,
-            "jac": jac_mode,
-            "residual_derivative_backend": str(vmec._residual_derivative_backend),
             "adjoint_mode": str(vmec._residual_adjoint_mode),
             "stateless_evaluations": bool(vmec._stateless_evaluations),
         },
     )
 
     proc0_print("Quasisymmetry objective before optimization:", float(np.asarray(qs.total_from_state(initial_state))))
-    proc0_print("Initial aspect ratio:", float(np.asarray(vmec.aspect_equilibrium_from_state_jax(initial_state))))
     proc0_print("Total objective before optimization:", objective_value(stage, stage.x0))
 
+    # To keep this example fast, we stop after max_nfev function evaluations.
     solve_start = time.perf_counter()
     result = least_squares_jax_solve(
         stage.residuals,
@@ -174,7 +175,7 @@ def main():
         proc0_print("Solve wall time [s]:", solve_elapsed)
 
     proc0_print("End of 2_Intermediate/QH_fixed_resolution_jax.py")
-    proc0_print("================================================")
+    proc0_print("===============================================")
 
 
 if __name__ == "__main__":

--- a/examples/2_Intermediate/QH_fixed_resolution_jax.py
+++ b/examples/2_Intermediate/QH_fixed_resolution_jax.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
-import argparse
 import os
-import time
 
 import numpy as np
 
@@ -16,188 +14,68 @@ throughout the volume.
 Run this example with python QH_fixed_resolution_jax.py
 """
 
-DEFAULT_MAX_NFEV = 10
-DEFAULT_MAX_MODE = 1
-DEFAULT_METHOD = "scipy"
-DEFAULT_JAC = "jax"
-DEFAULT_RESIDUAL_DERIVATIVE_BACKEND = "discrete_adjoint"
-DEFAULT_JIT = False
-DEFAULT_STEP_SIZE = 5e-5
-DEFAULT_ADJOINT_MODE = "chunked"
+max_nfev = 10  # Maximum number of function evaluations
+max_mode = 1  # Maximum poloidal and toroidal mode numbers to vary
 
+proc0_print("Running 2_Intermediate/QH_fixed_resolution_jax.py")
+proc0_print("=================================================")
 
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--max-nfev", type=int, default=DEFAULT_MAX_NFEV)
-    parser.add_argument("--max-mode", type=int, default=DEFAULT_MAX_MODE)
-    parser.add_argument(
-        "--method",
-        choices=[
-            "gradient_descent",
-            "scipy",
-            "gauss_newton",
-            "truncated_gauss_newton",
-            "trust_region",
-            "levenberg_marquardt",
-            "lbfgs",
-        ],
-        default=DEFAULT_METHOD,
-    )
-    parser.add_argument("--step-size", type=float, default=DEFAULT_STEP_SIZE)
-    parser.add_argument("--adjoint-mode", choices=["lineax", "auto", "chunked", "dense"], default=DEFAULT_ADJOINT_MODE)
-    parser.add_argument("--jac", choices=["jax", "reverse", "2-point", "3-point"], default=DEFAULT_JAC)
-    parser.add_argument(
-        "--residual-derivative-backend",
-        choices=["implicit", "discrete_adjoint"],
-        default=DEFAULT_RESIDUAL_DERIVATIVE_BACKEND,
-    )
-    parser.add_argument("--jit", action=argparse.BooleanOptionalAction, default=DEFAULT_JIT)
-    parser.add_argument("--stateless-evaluations", action=argparse.BooleanOptionalAction, default=False)
-    parser.add_argument("--timings", action="store_true")
-    parser.add_argument("--profile", action="store_true")
-    parser.add_argument("--vmec-max-iter", type=int, default=None)
-    parser.add_argument("--vmec-grad-tol", type=float, default=None)
-    parser.add_argument("--implicit-cg-max-iter", type=int, default=None)
-    parser.add_argument("--implicit-cg-tol", type=float, default=None)
-    return parser.parse_args()
+# For forming filenames for VMEC, pathlib sometimes does not work, so use os.path.join instead.
+filename = os.path.join(os.path.dirname(__file__), "inputs", "input.nfp4_QH_warm_start")
+vmec = VmecJax(filename, verbose=False)
+vmec.use_residual_autodiff_defaults(
+    outer_method="scipy",
+    residual_adjoint_mode="chunked",
+    stateless_evaluations=False,
+    optimization_profile="qh",
+)
+vmec.set_solver_options(residual_derivative_backend="discrete_adjoint")
 
+# Define objective function and parameter space:
+objective_tuples = [("aspect", 7.0, 1.0), ("qs", 0.0, 1.0)]
+stage = build_vmec_objective_stage(
+    vmec,
+    max_mode=max_mode,
+    objective_tuples=objective_tuples,
+    surfaces=np.arange(0, 1.01, 0.1),
+    helicity_m=1,
+    helicity_n=-1,
+    x_scale_alpha=1.2,
+    x_scale_min=1e-9,
+)
+surf = stage.extras["surf"]
+qs = stage.extras["qs"]
+residuals_from_state = stage.extras["residuals_from_state"]
 
-def objective_value(stage, x):
-    scipy_residuals = getattr(stage.residuals, "scipy_residuals", None)
-    if callable(scipy_residuals):
-        residual = np.asarray(scipy_residuals(x), dtype=float)
-    else:
-        residual = np.asarray(stage.residuals(x), dtype=float)
-    return float(np.dot(residual, residual))
+proc0_print("Parameter space:", stage.free_names)
 
+state = vmec.solve_state_for_objective(stage.x0)
+residual = np.asarray(residuals_from_state(state), dtype=float)
 
-def objective_value_from_state(vmec, qs, state):
-    aspect_residual = np.asarray([vmec.aspect_equilibrium_from_state_jax(state) - 7.0], dtype=float)
-    qs_residual = np.asarray(qs.residuals_from_state(state), dtype=float)
-    residual = np.concatenate((aspect_residual, qs_residual))
-    return float(np.dot(residual, residual))
+proc0_print("Quasisymmetry objective before optimization:", float(np.asarray(qs.total_from_state(state))))
+proc0_print("Total objective before optimization:", float(np.dot(residual, residual)))
 
+# Unlike the classic example, the Jacobian here comes from vmec_jax through
+# JAX autodiff / discrete adjoints instead of finite differences.
+result = least_squares_jax_solve(
+    stage.residuals,
+    stage.x0,
+    method="scipy",
+    jac="jax",
+    max_nfev=max_nfev,
+    gtol=1e-7,
+    x_scale=stage.x_scale,
+    jit=True,
+    verbose=1,
+)
 
-def solve_state_for_report(vmec, x):
-    if str(getattr(vmec, "_residual_derivative_backend", "")) == "discrete_adjoint":
-        step_size = (
-            float(vmec._step_size_override)
-            if getattr(vmec, "_step_size_override", None) is not None
-            else float(vmec._indata_raw.get_float("DELT", 1.0))
-        )
-        return vmec._solve_state_residual_forward(x, step_size=step_size)
-    return vmec._solve_state(x)
+surf.set_free_params(result["x"])
+state = vmec.solve_state_for_objective(result["x"])
+residual = np.asarray(residuals_from_state(state), dtype=float)
 
+proc0_print("Final aspect ratio:", float(np.asarray(vmec.aspect_equilibrium_from_state_jax(state))))
+proc0_print("Quasisymmetry objective after optimization:", float(np.asarray(qs.total_from_state(state))))
+proc0_print("Total objective after optimization:", float(np.dot(residual, residual)))
 
-def main():
-    args = parse_args()
-    max_mode = int(args.max_mode)
-    max_nfev = int(args.max_nfev)
-    method = str(args.method).strip().lower()
-    jac_mode = str(args.jac).strip().lower()
-
-    proc0_print("Running 2_Intermediate/QH_fixed_resolution_jax.py")
-    proc0_print("=================================================")
-
-    # For forming filenames for VMEC, pathlib sometimes does not work, so use os.path.join instead.
-    filename = os.path.join(os.path.dirname(__file__), "inputs", "input.nfp4_QH_warm_start")
-    vmec = VmecJax(filename, verbose=False)
-    vmec.indata.mpol = max_mode + 2
-    vmec.indata.ntor = max_mode + 2
-    vmec.use_residual_autodiff_defaults(
-        outer_method=method,
-        residual_adjoint_mode=str(args.adjoint_mode).strip().lower(),
-        stateless_evaluations=bool(args.stateless_evaluations),
-        optimization_profile="qh",
-    )
-    vmec.set_solver_options(
-        max_iter=args.vmec_max_iter,
-        grad_tol=args.vmec_grad_tol,
-        implicit_cg_max_iter=args.implicit_cg_max_iter,
-        implicit_cg_tol=args.implicit_cg_tol,
-        residual_derivative_backend=str(args.residual_derivative_backend).strip().lower(),
-    )
-
-    # Define parameter space:
-    surf = vmec.boundary
-    surf.fix_all()
-    surf.fixed_range(mmin=0, mmax=max_mode, nmin=-max_mode, nmax=max_mode, fixed=False)
-    surf.fix("rc(0,0)")
-
-    # Configure quasisymmetry objective:
-    stage = build_vmec_objective_stage(
-        vmec,
-        max_mode=max_mode,
-        objective_tuples=[("aspect", 7.0, 1.0), ("qs", 0.0, 1.0)],
-        surfaces=np.arange(0, 1.01, 0.1),
-        helicity_m=1,
-        helicity_n=-1,
-        x_scale_alpha=1.2,
-        x_scale_min=1e-9,
-    )
-    proc0_print("Parameter space:", stage.free_names)
-    qs = stage.extras["qs"]
-    solve_jit = bool(args.jit)
-    if (
-        method == "scipy"
-        and jac_mode in ("reverse", "rev", "jacrev")
-        and str(vmec._residual_derivative_backend) == "discrete_adjoint"
-    ):
-        solve_jit = False
-
-    initial_state = solve_state_for_report(vmec, stage.x0)
-
-    proc0_print(
-        "Solver settings:",
-        {
-            "method": method,
-            "jac": jac_mode,
-            "residual_derivative_backend": str(vmec._residual_derivative_backend),
-            "vmec_max_iter": int(vmec._max_iter),
-            "vmec_grad_tol": float(vmec._grad_tol),
-            "implicit_cg_max_iter": int(vmec._implicit_cg_max_iter),
-            "implicit_cg_tol": float(vmec._implicit_cg_tol),
-            "jit": solve_jit,
-            "adjoint_mode": str(vmec._residual_adjoint_mode),
-            "stateless_evaluations": bool(vmec._stateless_evaluations),
-        },
-    )
-
-    proc0_print("Quasisymmetry objective before optimization:", float(np.asarray(qs.total_from_state(initial_state))))
-    proc0_print("Total objective before optimization:", objective_value_from_state(vmec, qs, initial_state))
-
-    # To keep this example fast, we stop after max_nfev function evaluations.
-    solve_start = time.perf_counter()
-    result = least_squares_jax_solve(
-        stage.residuals,
-        stage.x0,
-        method=method,
-        max_nfev=max_nfev,
-        gtol=1e-7,
-        step_size=float(args.step_size),
-        x_scale=stage.x_scale,
-        jit=solve_jit,
-        verbose=1,
-        jac=jac_mode if method == "scipy" else None,
-        profile=bool(args.profile),
-    )
-    solve_elapsed = time.perf_counter() - solve_start
-
-    surf.set_free_params(result["x"])
-    state_opt = solve_state_for_report(vmec, result["x"])
-
-    proc0_print("Final aspect ratio:", float(np.asarray(vmec.aspect_equilibrium_from_state_jax(state_opt))))
-    proc0_print("Quasisymmetry objective after optimization:", float(np.asarray(qs.total_from_state(state_opt))))
-    proc0_print("Total objective after optimization:", objective_value_from_state(vmec, qs, state_opt))
-    proc0_print("Result summary:", {key: result.get(key) for key in ("success", "status", "nfev")})
-    if args.profile:
-        proc0_print("Solver profile:", result.get("profile"))
-    if args.timings:
-        proc0_print("Solve wall time [s]:", solve_elapsed)
-
-    proc0_print("End of 2_Intermediate/QH_fixed_resolution_jax.py")
-    proc0_print("===============================================")
-
-
-if __name__ == "__main__":
-    main()
+proc0_print("End of 2_Intermediate/QH_fixed_resolution_jax.py")
+proc0_print("===============================================")

--- a/examples/2_Intermediate/QH_fixed_resolution_jax.py
+++ b/examples/2_Intermediate/QH_fixed_resolution_jax.py
@@ -71,6 +71,13 @@ def objective_value(stage, x):
     return float(np.dot(residual, residual))
 
 
+def objective_value_from_state(vmec, qs, state):
+    aspect_residual = np.asarray([vmec.aspect_equilibrium_from_state_jax(state) - 7.0], dtype=float)
+    qs_residual = np.asarray(qs.residuals_from_state(state), dtype=float)
+    residual = np.concatenate((aspect_residual, qs_residual))
+    return float(np.dot(residual, residual))
+
+
 def solve_state_for_report(vmec, x):
     if str(getattr(vmec, "_residual_derivative_backend", "")) == "discrete_adjoint":
         step_size = (
@@ -157,7 +164,7 @@ def main():
     )
 
     proc0_print("Quasisymmetry objective before optimization:", float(np.asarray(qs.total_from_state(initial_state))))
-    proc0_print("Total objective before optimization:", objective_value(stage, stage.x0))
+    proc0_print("Total objective before optimization:", objective_value_from_state(vmec, qs, initial_state))
 
     # To keep this example fast, we stop after max_nfev function evaluations.
     solve_start = time.perf_counter()
@@ -181,7 +188,7 @@ def main():
 
     proc0_print("Final aspect ratio:", float(np.asarray(vmec.aspect_equilibrium_from_state_jax(state_opt))))
     proc0_print("Quasisymmetry objective after optimization:", float(np.asarray(qs.total_from_state(state_opt))))
-    proc0_print("Total objective after optimization:", objective_value(stage, result["x"]))
+    proc0_print("Total objective after optimization:", objective_value_from_state(vmec, qs, state_opt))
     proc0_print("Result summary:", {key: result.get(key) for key in ("success", "status", "nfev")})
     if args.profile:
         proc0_print("Solver profile:", result.get("profile"))

--- a/src/simsopt/mhd/__init__.py
+++ b/src/simsopt/mhd/__init__.py
@@ -5,10 +5,13 @@
 from .vmec import *
 from .virtual_casing import *
 from .vmec_diagnostics import *
+from .vmec_diagnostics_jax import *
 from .profiles import *
 from .bootstrap import *
 from .boozer import *
+from .vmec_jax import *
 from .spec import *
 
 __all__ = (vmec.__all__ + virtual_casing.__all__ + vmec_diagnostics.__all__ +
-           profiles.__all__ + bootstrap.__all__ + boozer.__all__ + spec.__all__)
+           vmec_diagnostics_jax.__all__ + profiles.__all__ + bootstrap.__all__ +
+           boozer.__all__ + vmec_jax.__all__ + spec.__all__)

--- a/src/simsopt/mhd/vmec_diagnostics_jax.py
+++ b/src/simsopt/mhd/vmec_diagnostics_jax.py
@@ -1,0 +1,381 @@
+# coding: utf-8
+# Copyright (c) HiddenSymmetries Development Team.
+# Distributed under the terms of the MIT License
+
+"""
+JAX-backed VMEC diagnostics.
+
+This module mirrors a small subset of :mod:`simsopt.mhd.vmec_diagnostics`
+without depending on the Fortran VMEC wrapper. The initial scope is a
+VMEC-only quasisymmetry metric that can be evaluated from a ``VmecJax``
+equilibrium or from a VMEC-style ``wout`` object.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+
+try:
+    import jax.numpy as jnp
+except Exception as exc:  # pragma: no cover - optional dependency
+    jnp = None
+    _import_error = exc
+else:
+    _import_error = None
+
+
+__all__ = [
+    "QuasisymmetryRatioResidualJax",
+    "quasisymmetry_ratio_residual_from_wout_jax",
+    "quasisymmetry_ratio_residual_from_state_jax",
+]
+
+
+def _require_jax():
+    """Raise a helpful error if the optional JAX dependency is unavailable."""
+    if jnp is None:
+        raise ImportError(
+            "vmec_diagnostics_jax requires JAX. "
+            "Install jax/jaxlib before using these helpers."
+        ) from _import_error
+
+
+def _as_surface_array(surfaces) -> jnp.ndarray:
+    """Normalize a scalar or iterable surface list into a 1D JAX array."""
+    try:
+        values = list(surfaces)  # type: ignore[arg-type]
+    except Exception:
+        values = [surfaces]
+    return jnp.asarray(values, dtype=jnp.float64)
+
+
+def _as_jax_array(values, *, dtype=None):
+    """Convert possibly big-endian VMEC arrays into native-endian JAX arrays."""
+    try:
+        arr = np.asarray(values)
+    except Exception:
+        return jnp.asarray(values, dtype=dtype)
+    if dtype is not None:
+        arr = arr.astype(dtype, copy=False)
+    elif arr.dtype.byteorder not in ("=", "|"):
+        arr = arr.astype(arr.dtype.newbyteorder("="), copy=False)
+    return jnp.asarray(arr)
+
+
+def _as_weight_array(weights, nsurf: int) -> jnp.ndarray:
+    """Return a 1D weight vector for the requested number of surfaces."""
+    if weights is None:
+        return jnp.ones((nsurf,), dtype=jnp.float64)
+    return jnp.asarray(list(weights), dtype=jnp.float64)
+
+
+def _half_grid(radial_count: int, dtype) -> jnp.ndarray:
+    """Construct the canonical VMEC half-grid for a given radial resolution."""
+    if radial_count < 2:
+        return jnp.zeros((0,), dtype=dtype)
+    s_full = jnp.linspace(0.0, 1.0, radial_count, dtype=dtype)
+    return 0.5 * (s_full[:-1] + s_full[1:])
+
+
+def _interp_half_grid(samples, surfaces, s_half):
+    """Linearly interpolate samples tabulated on the VMEC half grid."""
+    samples = jnp.asarray(samples)
+    surfaces = jnp.asarray(surfaces, dtype=samples.dtype)
+    s_half = jnp.asarray(s_half, dtype=samples.dtype)
+    if s_half.shape[0] == 0:
+        raise ValueError("half-grid interpolation requires at least one radial point")
+    if s_half.shape[0] == 1:
+        return jnp.broadcast_to(samples[:1], (surfaces.shape[0],) + samples.shape[1:])
+
+    idx_hi = jnp.searchsorted(s_half, surfaces, side="left")
+    idx_hi = jnp.clip(idx_hi, 1, s_half.shape[0] - 1)
+    idx_lo = idx_hi - 1
+    x0 = s_half[idx_lo]
+    x1 = s_half[idx_hi]
+    denom = jnp.where(x1 != x0, x1 - x0, jnp.ones_like(x1))
+    t = ((surfaces - x0) / denom).reshape((surfaces.shape[0],) + (1,) * (samples.ndim - 1))
+    y0 = samples[idx_lo]
+    y1 = samples[idx_hi]
+    return y0 + t * (y1 - y0)
+
+
+def _radial_mode_matrix(values, *, radial_count: int, mode_count: int) -> jnp.ndarray:
+    """Normalize VMEC coefficient storage to shape ``(radial, mode)``."""
+    arr = _as_jax_array(values, dtype=np.float64)
+    if arr.ndim != 2:
+        raise ValueError(f"expected a rank-2 coefficient array, got shape {arr.shape}")
+    if arr.shape == (radial_count, mode_count):
+        return arr
+    if arr.shape == (mode_count, radial_count):
+        return jnp.swapaxes(arr, 0, 1)
+    raise ValueError(
+        f"unexpected coefficient shape {arr.shape}; expected {(radial_count, mode_count)} "
+        f"or {(mode_count, radial_count)}"
+    )
+
+
+def quasisymmetry_ratio_residual_from_wout_jax(
+    wout,
+    *,
+    surfaces,
+    helicity_m: int = 1,
+    helicity_n: int = 0,
+    weights=None,
+    ntheta: int = 63,
+    nphi: int = 64,
+):
+    r"""Evaluate the VMEC-only quasisymmetry residual from a ``wout`` object.
+
+    This implements the same metric as
+    :class:`simsopt.mhd.vmec_diagnostics.QuasisymmetryRatioResidual`, but uses
+    JAX arrays and accepts coefficient storage from either the classic VMEC
+    Python wrapper or :class:`simsopt.mhd.VmecJax`.
+    """
+    _require_jax()
+
+    if bool(getattr(wout, "lasym", False)):
+        raise RuntimeError("QuasisymmetryRatioResidualJax does not yet support lasym=True")
+
+    surfaces = _as_surface_array(surfaces)
+    weights = _as_weight_array(weights, int(surfaces.shape[0]))
+    if weights.shape[0] != surfaces.shape[0]:
+        raise ValueError("weights must have the same length as surfaces")
+
+    ntheta = int(ntheta)
+    nphi = int(nphi)
+    nfp = int(getattr(wout, "nfp"))
+    helicity_m = int(helicity_m)
+    helicity_n = int(helicity_n)
+
+    iotas_full = _as_jax_array(getattr(wout, "iotas"), dtype=np.float64)
+    radial_count = int(iotas_full.shape[0])
+    s_half = _half_grid(radial_count, iotas_full.dtype)
+    half_count = int(s_half.shape[0])
+    mode_count = int(_as_jax_array(getattr(wout, "xm_nyq"), dtype=np.float64).shape[0])
+
+    iota = _interp_half_grid(iotas_full[1:], surfaces, s_half)
+    G = _interp_half_grid(_as_jax_array(getattr(wout, "bvco"), dtype=np.float64)[1:], surfaces, s_half)
+    I = _interp_half_grid(_as_jax_array(getattr(wout, "buco"), dtype=np.float64)[1:], surfaces, s_half)
+
+    gmnc = _interp_half_grid(
+        _radial_mode_matrix(getattr(wout, "gmnc"), radial_count=radial_count, mode_count=mode_count)[1:],
+        surfaces,
+        s_half,
+    )
+    bmnc = _interp_half_grid(
+        _radial_mode_matrix(getattr(wout, "bmnc"), radial_count=radial_count, mode_count=mode_count)[1:],
+        surfaces,
+        s_half,
+    )
+    bsubumnc = _interp_half_grid(
+        _radial_mode_matrix(getattr(wout, "bsubumnc"), radial_count=radial_count, mode_count=mode_count)[1:],
+        surfaces,
+        s_half,
+    )
+    bsubvmnc = _interp_half_grid(
+        _radial_mode_matrix(getattr(wout, "bsubvmnc"), radial_count=radial_count, mode_count=mode_count)[1:],
+        surfaces,
+        s_half,
+    )
+    bsupumnc = _interp_half_grid(
+        _radial_mode_matrix(getattr(wout, "bsupumnc"), radial_count=radial_count, mode_count=mode_count)[1:],
+        surfaces,
+        s_half,
+    )
+    bsupvmnc = _interp_half_grid(
+        _radial_mode_matrix(getattr(wout, "bsupvmnc"), radial_count=radial_count, mode_count=mode_count)[1:],
+        surfaces,
+        s_half,
+    )
+
+    theta1d = jnp.linspace(0.0, 2.0 * jnp.pi, ntheta, endpoint=False, dtype=jnp.float64)
+    phi1d = jnp.linspace(0.0, 2.0 * jnp.pi / nfp, nphi, endpoint=False, dtype=jnp.float64)
+    theta2d, phi2d = jnp.meshgrid(theta1d, phi1d, indexing="ij")
+
+    xm_nyq = _as_jax_array(getattr(wout, "xm_nyq"), dtype=np.float64)
+    xn_nyq = _as_jax_array(getattr(wout, "xn_nyq"), dtype=np.float64)
+    angle = theta2d[:, :, None] * xm_nyq[None, None, :] - phi2d[:, :, None] * xn_nyq[None, None, :]
+    cosangle = jnp.cos(angle)
+    sinangle = jnp.sin(angle)
+
+    modB = jnp.einsum("sm,tpm->stp", bmnc, cosangle)
+    d_B_d_theta = jnp.einsum("sm,tpm,m->stp", bmnc, -sinangle, xm_nyq)
+    d_B_d_phi = jnp.einsum("sm,tpm,m->stp", bmnc, sinangle, xn_nyq)
+    sqrtg = jnp.einsum("sm,tpm->stp", gmnc, cosangle)
+    bsubu = jnp.einsum("sm,tpm->stp", bsubumnc, cosangle)
+    bsubv = jnp.einsum("sm,tpm->stp", bsubvmnc, cosangle)
+    bsupu = jnp.einsum("sm,tpm->stp", bsupumnc, cosangle)
+    bsupv = jnp.einsum("sm,tpm->stp", bsupvmnc, cosangle)
+
+    d_psi_d_s = -_as_jax_array(getattr(wout, "phi"), dtype=np.float64)[-1] / (2.0 * jnp.pi)
+    sqrtg_safe = jnp.where(sqrtg != 0.0, sqrtg, jnp.ones_like(sqrtg))
+    B_dot_grad_B = bsupu * d_B_d_theta + bsupv * d_B_d_phi
+    B_cross_grad_B_dot_grad_psi = (
+        d_psi_d_s * (bsubu * d_B_d_phi - bsubv * d_B_d_theta) / sqrtg_safe
+    )
+
+    dtheta = theta1d[1] - theta1d[0]
+    dphi = phi1d[1] - phi1d[0]
+    sqrtg_abs = jnp.abs(sqrtg)
+    # The QS residual scales like sqrt(|sqrt(g)|). At the magnetic axis this can
+    # hit exactly zero, which makes reverse-mode sensitivities undefined even
+    # though the residual value itself is finite. Keep a tiny positive floor so
+    # the traced objective remains differentiable at the axis surface.
+    sqrtg_abs_safe = jnp.maximum(
+        sqrtg_abs,
+        jnp.asarray(jnp.finfo(sqrtg.dtype).tiny, dtype=sqrtg.dtype),
+    )
+    modB_safe = jnp.maximum(jnp.abs(modB), jnp.asarray(jnp.finfo(modB.dtype).tiny, dtype=modB.dtype))
+    V_prime = nfp * dtheta * dphi * jnp.sum(sqrtg_abs_safe, axis=(1, 2))
+
+    nn = helicity_n * nfp
+    prefactor = jnp.sqrt(
+        weights[:, None, None]
+        * nfp
+        * dtheta
+        * dphi
+        / V_prime[:, None, None]
+        * sqrtg_abs_safe
+    )
+    residuals3d = prefactor * (
+        B_cross_grad_B_dot_grad_psi * (nn - iota[:, None, None] * helicity_m)
+        - B_dot_grad_B * (helicity_m * G[:, None, None] + nn * I[:, None, None])
+    ) / (modB_safe**3)
+
+    residuals1d = jnp.ravel(residuals3d)
+    profile = jnp.sum(residuals3d * residuals3d, axis=(1, 2))
+    total = jnp.sum(residuals1d * residuals1d)
+
+    return {
+        "surfaces": surfaces,
+        "weights": weights,
+        "residuals3d": residuals3d,
+        "residuals1d": residuals1d,
+        "profile": profile,
+        "total": total,
+        "modB": modB,
+        "sqrtg": sqrtg,
+        "B_dot_grad_B": B_dot_grad_B,
+        "B_cross_grad_B_dot_grad_psi": B_cross_grad_B_dot_grad_psi,
+        "iota": iota,
+        "G": G,
+        "I": I,
+    }
+
+
+def quasisymmetry_ratio_residual_from_state_jax(
+    vmec,
+    state,
+    *,
+    surfaces,
+    helicity_m: int = 1,
+    helicity_n: int = 0,
+    weights=None,
+    ntheta: int = 63,
+    nphi: int = 64,
+):
+    """Evaluate the VMEC-only QS residual directly from a solved ``VmecJax`` state.
+
+    This path avoids constructing an intermediate Python ``wout`` object, so it
+    remains usable inside traced JAX optimization loops.
+    """
+    data = vmec.quasisymmetry_diagnostics_from_state_jax(state)
+    return quasisymmetry_ratio_residual_from_wout_jax(
+        data,
+        surfaces=surfaces,
+        helicity_m=helicity_m,
+        helicity_n=helicity_n,
+        weights=weights,
+        ntheta=ntheta,
+        nphi=nphi,
+    )
+
+
+class QuasisymmetryRatioResidualJax:
+    """JAX-backed VMEC-only quasisymmetry residual for :class:`VmecJax`."""
+
+    def __init__(
+        self,
+        vmec,
+        surfaces,
+        helicity_m: int = 1,
+        helicity_n: int = 0,
+        weights=None,
+        ntheta: int = 63,
+        nphi: int = 64,
+    ) -> None:
+        """Store the VMEC-JAX source and target surfaces for QS evaluation."""
+        self.vmec = vmec
+        self.surfaces = list(_as_surface_array(surfaces))
+        self.helicity_m = int(helicity_m)
+        self.helicity_n = int(helicity_n)
+        self.weights = None if weights is None else list(weights)
+        self.ntheta = int(ntheta)
+        self.nphi = int(nphi)
+
+    def compute_from_wout(self, wout):
+        """Evaluate all intermediate VMEC-only QS channels from a ``wout`` object."""
+        return quasisymmetry_ratio_residual_from_wout_jax(
+            wout,
+            surfaces=self.surfaces,
+            helicity_m=self.helicity_m,
+            helicity_n=self.helicity_n,
+            weights=self.weights,
+            ntheta=self.ntheta,
+            nphi=self.nphi,
+        )
+
+    def compute_from_state(self, state):
+        """Evaluate the QS metric from an already solved VMEC-JAX state."""
+        return quasisymmetry_ratio_residual_from_state_jax(
+            self.vmec,
+            state,
+            surfaces=self.surfaces,
+            helicity_m=self.helicity_m,
+            helicity_n=self.helicity_n,
+            weights=self.weights,
+            ntheta=self.ntheta,
+            nphi=self.nphi,
+        )
+
+    def compute(self, x_free):
+        """Evaluate the QS metric for a boundary parameter vector."""
+        return self.compute_from_wout(self.vmec.get_wout(x_free))
+
+    def residuals_from_wout(self, wout):
+        """Return the flattened least-squares residual vector."""
+        return self.compute_from_wout(wout)["residuals1d"]
+
+    def residuals_from_state(self, state):
+        """Return the flattened least-squares residual vector from a solved state."""
+        return self.compute_from_state(state)["residuals1d"]
+
+    def residuals(self, x_free):
+        """Return the flattened least-squares residual vector for ``x_free``."""
+        return self.compute(x_free)["residuals1d"]
+
+    def profile_from_wout(self, wout):
+        """Return the radial profile of squared QS residuals."""
+        return self.compute_from_wout(wout)["profile"]
+
+    def profile_from_state(self, state):
+        """Return the radial profile of squared QS residuals from a solved state."""
+        return self.compute_from_state(state)["profile"]
+
+    def profile(self, x_free):
+        """Return the radial profile of squared QS residuals for ``x_free``."""
+        return self.compute(x_free)["profile"]
+
+    def total_from_wout(self, wout):
+        """Return the scalar QS objective from a ``wout`` object."""
+        return self.compute_from_wout(wout)["total"]
+
+    def total_from_state(self, state):
+        """Return the scalar QS objective from a solved VMEC-JAX state."""
+        return self.compute_from_state(state)["total"]
+
+    def total(self, x_free):
+        """Return the scalar QS objective for ``x_free``."""
+        return self.compute(x_free)["total"]

--- a/src/simsopt/mhd/vmec_jax.py
+++ b/src/simsopt/mhd/vmec_jax.py
@@ -951,6 +951,29 @@ class VmecJax:
         )
         return _clone_state(res.state)
 
+    def solve_state_for_objective(self, x_free=None):
+        """Return a solved state for objective reporting on the current wrapper path.
+
+        For the discrete-adjoint residual backend, the optimization Jacobian is
+        built from a locally frozen replay model, but user-facing objective
+        reports should still evaluate the actual forward residual solve. For all
+        other modes we can report directly from ``_solve_state(...)``.
+        """
+        if x_free is None:
+            x_free = self.boundary.get_free_params()
+        x_free = jnp.asarray(x_free, dtype=jnp.float64)
+        if (
+            str(self._residual_derivative_backend) == "discrete_adjoint"
+            and str(self._solver).strip().lower() in ("residual", "vmec2000")
+        ):
+            residual_step_size = (
+                float(self._step_size_override)
+                if self._step_size_override is not None
+                else float(self._indata_raw.get_float("DELT", 1.0))
+            )
+            return self._solve_state_residual_forward(x_free, step_size=residual_step_size)
+        return self._solve_state(x_free)
+
     def _x_cache_key(self, x_free) -> tuple[float, ...]:
         """Return a hashable cache key for concrete parameter vectors."""
         try:

--- a/src/simsopt/mhd/vmec_jax.py
+++ b/src/simsopt/mhd/vmec_jax.py
@@ -789,6 +789,7 @@ class VmecJax:
                 step_size=float(step_size),
                 light_history=True,
                 store_trace=False,
+                store_full_step_traces=False,
             )
             packed_final = jnp.asarray(tape.final_packed_state, dtype=x0.dtype)
             return packed_final, {"tape": tape, "axis_override": axis_override}

--- a/src/simsopt/mhd/vmec_jax.py
+++ b/src/simsopt/mhd/vmec_jax.py
@@ -722,7 +722,7 @@ class VmecJax:
             **solver_options,
         )
 
-    def _solve_state_discrete_adjoint_residual(self, x_free: jnp.ndarray, *, step_size: float):
+    def _solve_state_discrete_adjoint_residual(self, x_free: jnp.ndarray, *, step_size: float, return_payload: bool = False):
         """Solve the residual iteration with a discrete-adjoint VJP over x_free."""
         self._ensure_context()
         static = self._static
@@ -822,8 +822,79 @@ class VmecJax:
             )
             return packed_final, packed_tangent
 
+        if return_payload:
+            packed_state, payload = _forward_payload(jnp.asarray(x_free))
+            return vj.unpack_state(packed_state, layout), payload
+
         packed_state = _packed_state_from_xfree(jnp.asarray(x_free))
         return vj.unpack_state(packed_state, layout)
+
+    def _discrete_adjoint_residual_jacobian(self, x_free, residuals_from_state):
+        self._ensure_context()
+        x_free = jnp.asarray(x_free, dtype=jnp.float64)
+        if self._residual_derivative_backend != "discrete_adjoint":
+            raise ValueError("Concrete discrete-adjoint Jacobian requested for a non-discrete backend.")
+
+        residual_step_size = (
+            float(self._step_size_override)
+            if self._step_size_override is not None
+            else float(self._indata_raw.get_float("DELT", 1.0))
+        )
+        state, payload = self._solve_state_discrete_adjoint_residual(
+            x_free,
+            step_size=residual_step_size,
+            return_payload=True,
+        )
+
+        static = self._static
+        boundary_wrapper = self.boundary
+        indata = self._indata_raw
+        base_full = jnp.asarray(boundary_wrapper._base)
+        specs = tuple(boundary_wrapper._specs)
+        modes = boundary_wrapper._modes
+        lasym = bool(self._cfg.lasym)
+        layout = state.layout
+        packed_final = jnp.asarray(vj.pack_state(state), dtype=jnp.float64)
+
+        def _initial_state_packed(xf, *, axis_override=None):
+            x_full = boundary_wrapper.expand_free(xf)
+            delta_full = jnp.asarray(x_full) - base_full
+            boundary_input = vj.apply_boundary_params(boundary_wrapper._boundary_input0, specs, delta_full)
+            boundary = boundary_from_input_convention(
+                boundary_input,
+                modes,
+                lasym=lasym,
+                apply_m1_constraint=False,
+            )
+            state0 = vj.initial_guess_from_boundary(
+                static,
+                boundary,
+                indata,
+                vmec_project=True,
+                axis_override=axis_override,
+            )
+            return jnp.asarray(vj.pack_state(state0), dtype=jnp.float64)
+
+        def _frozen_initial_state(x):
+            return _initial_state_packed(x, axis_override=payload["axis_override"])
+
+        def _residuals_from_packed(x):
+            return residuals_from_state(vj.unpack_state(x, layout))
+
+        eye = np.eye(int(x_free.size), dtype=float)
+        columns = []
+        for i in range(int(x_free.size)):
+            direction = jnp.asarray(eye[i], dtype=x_free.dtype)
+            _, packed_tangent0 = jax.jvp(_frozen_initial_state, (x_free,), (direction,))
+            packed_tangent = vj.checkpoint_tape_state_jvp(
+                tape=payload["tape"],
+                static=static,
+                initial_tangent=packed_tangent0,
+                rebuild_preconditioner=True,
+            )
+            col = jax.jvp(_residuals_from_packed, (packed_final,), (packed_tangent,))[1]
+            columns.append(np.asarray(col, dtype=float))
+        return np.stack(columns, axis=1)
 
     def _x_cache_key(self, x_free) -> tuple[float, ...]:
         """Return a hashable cache key for concrete parameter vectors."""

--- a/src/simsopt/mhd/vmec_jax.py
+++ b/src/simsopt/mhd/vmec_jax.py
@@ -475,6 +475,7 @@ class VmecJax:
         self._cached_state = None
         self._cached_wout = None
         self._cached_run = None
+        self._discrete_jacobian_helper_cache = {}
         if reset_warm_start and self._context is not None and self._context_seed_guess is not None:
             self._context.st_guess = _clone_state(self._context_seed_guess)
 
@@ -881,17 +882,46 @@ class VmecJax:
         def _residuals_from_packed(x):
             return residuals_from_state(vj.unpack_state(x, layout))
 
+        cache_key = (
+            id(residuals_from_state),
+            int(x_free.size),
+            int(layout.size),
+            int(len(payload["tape"].step_traces)),
+        )
+        helper_cache = self._discrete_jacobian_helper_cache.get(cache_key)
+        if helper_cache is None:
+            @jax.jit
+            def _initial_tangent_columns(xf, axis_override, directions):
+                _, initial_state_linear = jax.linearize(
+                    lambda x: _initial_state_packed(x, axis_override=axis_override),
+                    xf,
+                )
+                return jax.vmap(initial_state_linear)(directions)
+
+            @jax.jit
+            def _residual_tangent_columns(packed_state, packed_tangents):
+                _, residual_linear = jax.linearize(_residuals_from_packed, packed_state)
+                return jax.vmap(residual_linear)(packed_tangents)
+
+            helper_cache = {
+                "initial_tangent_columns": _initial_tangent_columns,
+                "residual_tangent_columns": _residual_tangent_columns,
+            }
+            self._discrete_jacobian_helper_cache[cache_key] = helper_cache
+
         directions = jnp.asarray(np.eye(int(x_free.size), dtype=float), dtype=x_free.dtype)
-        _, initial_state_linear = jax.linearize(_frozen_initial_state, x_free)
-        packed_tangents0 = jax.vmap(initial_state_linear)(directions)
+        packed_tangents0 = helper_cache["initial_tangent_columns"](
+            x_free,
+            payload["axis_override"],
+            directions,
+        )
         packed_tangents = vj.checkpoint_tape_state_jvp_columns(
             tape=payload["tape"],
             static=static,
             initial_tangents=packed_tangents0,
             rebuild_preconditioner=True,
         )
-        _, residual_linear = jax.linearize(_residuals_from_packed, packed_final)
-        columns = jax.vmap(residual_linear)(packed_tangents)
+        columns = helper_cache["residual_tangent_columns"](packed_final, packed_tangents)
         return np.asarray(columns, dtype=float).T
 
     def _solve_state_residual_forward(self, x_free, *, step_size: float):

--- a/src/simsopt/mhd/vmec_jax.py
+++ b/src/simsopt/mhd/vmec_jax.py
@@ -881,20 +881,18 @@ class VmecJax:
         def _residuals_from_packed(x):
             return residuals_from_state(vj.unpack_state(x, layout))
 
-        eye = np.eye(int(x_free.size), dtype=float)
-        columns = []
-        for i in range(int(x_free.size)):
-            direction = jnp.asarray(eye[i], dtype=x_free.dtype)
-            _, packed_tangent0 = jax.jvp(_frozen_initial_state, (x_free,), (direction,))
-            packed_tangent = vj.checkpoint_tape_state_jvp(
-                tape=payload["tape"],
-                static=static,
-                initial_tangent=packed_tangent0,
-                rebuild_preconditioner=True,
-            )
-            col = jax.jvp(_residuals_from_packed, (packed_final,), (packed_tangent,))[1]
-            columns.append(np.asarray(col, dtype=float))
-        return np.stack(columns, axis=1)
+        directions = jnp.asarray(np.eye(int(x_free.size), dtype=float), dtype=x_free.dtype)
+        _, initial_state_linear = jax.linearize(_frozen_initial_state, x_free)
+        packed_tangents0 = jax.vmap(initial_state_linear)(directions)
+        packed_tangents = vj.checkpoint_tape_state_jvp_columns(
+            tape=payload["tape"],
+            static=static,
+            initial_tangents=packed_tangents0,
+            rebuild_preconditioner=True,
+        )
+        _, residual_linear = jax.linearize(_residuals_from_packed, packed_final)
+        columns = jax.vmap(residual_linear)(packed_tangents)
+        return np.asarray(columns, dtype=float).T
 
     def _solve_state_residual_forward(self, x_free, *, step_size: float):
         from vmec_jax.solve import solve_fixed_boundary_residual_iter

--- a/src/simsopt/mhd/vmec_jax.py
+++ b/src/simsopt/mhd/vmec_jax.py
@@ -1,0 +1,1145 @@
+# coding: utf-8
+# Copyright (c) HiddenSymmetries Development Team.
+# Distributed under the terms of the MIT License
+
+"""
+JAX-backed VMEC wrapper for SIMSOPT workflows.
+
+This module provides a minimal interface that mirrors the parts of
+`simsopt.mhd.vmec.Vmec` used by the QH/Q A optimization examples, but
+implemented on top of `vmec_jax` with implicit differentiation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import re
+from typing import Sequence
+from types import SimpleNamespace
+
+import numpy as np
+
+try:
+    import vmec_jax as vj
+    from vmec_jax._compat import jax, jnp, has_jax
+    from vmec_jax.boundary import boundary_from_input_convention, boundary_input_from_indata
+except Exception as exc:  # pragma: no cover - optional dependency
+    vj = None
+    jax = None
+    jnp = None
+    has_jax = None
+    boundary_from_input_convention = None
+    boundary_input_from_indata = None
+    _import_error = exc
+else:
+    _import_error = None
+
+
+__all__ = ["VmecJax", "JaxBoundary"]
+
+
+_OUTER_OPTIMIZATION_PROFILES = {
+    "qh": {
+        "residual_adjoint_mode": "chunked",
+        "stateless_evaluations": False,
+    },
+}
+
+
+def _clone_state(state):
+    """Return a JAX-friendly copy of a VMEC-JAX state object."""
+    return vj.VMECState(
+        layout=state.layout,
+        Rcos=jnp.asarray(state.Rcos),
+        Rsin=jnp.asarray(state.Rsin),
+        Zcos=jnp.asarray(state.Zcos),
+        Zsin=jnp.asarray(state.Zsin),
+        Lcos=jnp.asarray(state.Lcos),
+        Lsin=jnp.asarray(state.Lsin),
+    )
+
+
+def _is_traced_value(value) -> bool:
+    return jax is not None and isinstance(value, jax.core.Tracer)
+
+
+def _require_vmec_jax():
+    """Validate that vmec_jax and JAX are available."""
+    if vj is None or has_jax is None or not has_jax():
+        raise ImportError(
+            "VmecJax requires vmec_jax and JAX. "
+            "Install vmec_jax (and jax/jaxlib) before importing VmecJax."
+        ) from _import_error
+
+
+def _format_name(kind: str, m: int, n: int) -> str:
+    """Format a boundary coefficient name in SurfaceRZFourier style."""
+    return f"{kind}({m},{n})"
+
+
+def _parse_name(name: str) -> tuple[str, int, int]:
+    """Parse a SurfaceRZFourier-style coefficient name into components."""
+    m = re.match(r"([a-zA-Z]+)\(([-\d]+),([-\d]+)\)", name.replace(" ", ""))
+    if not m:
+        raise ValueError(f"Unrecognized boundary dof name: {name}")
+    return m.group(1).lower(), int(m.group(2)), int(m.group(3))
+
+
+def _as_list_like(value):
+    """Normalize scalar or array-like VMEC input values into a Python list."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, np.ndarray):
+        return list(np.asarray(value).reshape(-1).tolist())
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        return [value]
+    try:
+        return list(value)
+    except Exception:
+        return None
+
+
+def _last_input_value(indata, *, array_key: str, scalar_key: str, default, cast):
+    """Return the last staged VMEC input value, falling back to the scalar key."""
+    values = _as_list_like(indata.get(array_key, None))
+    if values:
+        try:
+            return cast(values[-1])
+        except Exception:
+            pass
+    getter_name = "get_int" if cast is int else "get_float"
+    getter = getattr(indata, getter_name, None)
+    if callable(getter):
+        return cast(getter(scalar_key, default))
+    return cast(indata.get(scalar_key, default))
+
+
+def _surface_rzfourier_mode_is_valid(kind: str, m: int, n: int, *, lasym: bool) -> bool:
+    """Mirror the SurfaceRZFourier coefficient set used by SIMSOPT.
+
+    VMEC-JAX stores all four Fourier coefficient families on the boundary
+    object, but SIMSOPT's SurfaceRZFourier only exposes the structurally
+    valid subset:
+    - no negative-n modes for m=0,
+    - no sine coefficients at (m=0, n=0),
+    - `lasym=False` surfaces expose only rc/zs.
+    """
+    kind = str(kind).lower()
+    if m == 0 and n < 0:
+        return False
+    if (m == 0) and (n == 0) and kind in ("rs", "zs"):
+        return False
+    if not bool(lasym) and kind in ("rs", "zc"):
+        return False
+    return kind in ("rc", "rs", "zc", "zs")
+
+
+def _surface_rzfourier_spec_sort_key(spec, *, lasym: bool):
+    """Sort coefficients in the same order used by SurfaceRZFourier."""
+    kind_order = ("rc", "rs", "zc", "zs") if bool(lasym) else ("rc", "zs")
+    kind_rank = kind_order.index(str(spec.kind).lower())
+    m = int(spec.m)
+    n = int(spec.n)
+    if m == 0:
+        n_key = n
+    else:
+        n_key = n + 100000
+    return (kind_rank, m, n_key)
+
+
+def _vmec_wrout_nyquist_cos_coeffs_jax(*, f, modes, trig):
+    """Return wrout-style Nyquist cosine coefficients using JAX arrays.
+
+    This mirrors ``vmec_jax.wout._vmec_wrout_nyquist_cos_coeffs`` closely but
+    avoids NumPy conversions so it can be used inside traced optimization
+    loops.
+    """
+    f = jnp.asarray(f)
+    if f.ndim != 3:
+        raise ValueError(f"Expected f with shape (ns, ntheta, nzeta), got {f.shape}")
+
+    m = jnp.asarray(modes.m, dtype=jnp.int32)
+    n = jnp.asarray(modes.n, dtype=jnp.int32)
+    if int(m.shape[0]) == 0:
+        return jnp.zeros((int(f.shape[0]), 0), dtype=f.dtype)
+
+    nt2 = int(trig.ntheta2)
+    if int(f.shape[1]) < nt2:
+        raise ValueError("Input theta grid is smaller than VMEC ntheta2")
+    f = f[:, :nt2, :]
+
+    cosmui = jnp.asarray(trig.cosmui, dtype=f.dtype)[:nt2, :]
+    sinmui = jnp.asarray(trig.sinmui, dtype=f.dtype)[:nt2, :]
+    cosnv = jnp.asarray(trig.cosnv, dtype=f.dtype)
+    sinnv = jnp.asarray(trig.sinnv, dtype=f.dtype)
+
+    mnyq = int(cosmui.shape[1] - 1)
+    if mnyq > 0:
+        cosmui = cosmui.at[:, mnyq].multiply(jnp.asarray(0.5, dtype=f.dtype))
+    nnyq = int(cosnv.shape[1] - 1)
+    if nnyq > 0:
+        cosnv = cosnv.at[:, nnyq].multiply(jnp.asarray(0.5, dtype=f.dtype))
+
+    f_theta_cos = jnp.einsum("sik,im->smk", f, cosmui, optimize=True)
+    f_theta_sin = jnp.einsum("sik,im->smk", f, sinmui, optimize=True)
+    cos_zeta = jnp.einsum("smk,kn->smn", f_theta_cos, cosnv, optimize=True)
+    sin_zeta = jnp.einsum("smk,kn->smn", f_theta_sin, sinnv, optimize=True)
+
+    n_abs = jnp.abs(n)
+    sgn = jnp.where(n < 0, -1.0, 1.0).astype(f.dtype)
+    coeff = cos_zeta[:, m, n_abs] + sgn[None, :] * sin_zeta[:, m, n_abs]
+
+    mscale = jnp.asarray(trig.mscale, dtype=f.dtype)
+    nscale = jnp.asarray(trig.nscale, dtype=f.dtype)
+    dmult = mscale[m] * nscale[n_abs] * jnp.asarray(0.5 / float(getattr(trig, "r0scale", 1.0)) ** 2, dtype=f.dtype)
+    dmult = jnp.where((m == 0) | (n == 0), 2.0 * dmult, dmult)
+    return coeff * dmult[None, :]
+
+
+def _outer_optimization_profile(name: str | None) -> dict:
+    """Return a copy of a named wrapper preset for outer optimization."""
+    if name is None:
+        return {}
+    key = str(name).strip().lower()
+    if key in ("", "none"):
+        return {}
+    try:
+        return dict(_OUTER_OPTIMIZATION_PROFILES[key])
+    except KeyError as exc:
+        raise ValueError(f"Unknown VmecJax optimization profile: {name}") from exc
+
+
+class JaxBoundary:
+    """Boundary DOF wrapper mirroring the SurfaceRZFourier interface used by examples."""
+
+    def __init__(
+        self,
+        boundary,
+        boundary_input,
+        modes,
+        *,
+        lasym: bool,
+        include: Sequence[str] = ("rc", "zs", "rs", "zc"),
+    ) -> None:
+        """Wrap vmec_jax boundary coefficients with a SurfaceRZFourier-like API."""
+        _require_vmec_jax()
+        self._boundary0 = boundary
+        self._boundary_input0 = boundary_input
+        self._modes = modes
+        self._lasym = bool(lasym)
+        specs = vj.optimization.boundary_param_specs(
+            boundary_input,
+            modes,
+            max_mode=None,
+            min_coeff=0.0,
+            include=include,
+            fix=(),
+            include_axis=True,
+        )
+        self._specs = [
+            spec
+            for spec in specs
+            if _surface_rzfourier_mode_is_valid(spec.kind, int(spec.m), int(spec.n), lasym=bool(lasym))
+        ]
+        self._specs.sort(key=lambda spec: _surface_rzfourier_spec_sort_key(spec, lasym=bool(lasym)))
+        self._names = [_format_name(s.kind, s.m, s.n) for s in self._specs]
+        self._base = np.array([self._get_coeff(boundary_input, s) for s in self._specs], dtype=float)
+        self._x = self._base.copy()
+        self._free = np.ones_like(self._x, dtype=bool)
+
+    def _get_coeff(self, boundary, spec):
+        """Read one Fourier coefficient from a vmec_jax boundary object."""
+        if spec.kind == "rc":
+            return float(boundary.R_cos[spec.index])
+        if spec.kind == "rs":
+            return float(boundary.R_sin[spec.index])
+        if spec.kind == "zc":
+            return float(boundary.Z_cos[spec.index])
+        if spec.kind == "zs":
+            return float(boundary.Z_sin[spec.index])
+        raise ValueError(f"Unknown boundary coeff kind: {spec.kind}")
+
+    @property
+    def dof_names(self) -> list[str]:
+        """Return the ordered coefficient names exposed to SIMSOPT."""
+        return list(self._names)
+
+    @property
+    def x(self) -> np.ndarray:
+        """Return the full coefficient vector in input convention."""
+        return self._x.copy()
+
+    @property
+    def free(self) -> np.ndarray:
+        """Return a boolean mask marking active optimization variables."""
+        return self._free.copy()
+
+    def fix_all(self) -> None:
+        """Mark every boundary coefficient as fixed."""
+        self._free[:] = False
+
+    def unfix_all(self) -> None:
+        """Mark every boundary coefficient as free."""
+        self._free[:] = True
+
+    def fix(self, name: str) -> None:
+        """Fix a single coefficient by name."""
+        idx = self._names.index(name)
+        self._free[idx] = False
+
+    def unfix(self, name: str) -> None:
+        """Unfix a single coefficient by name."""
+        idx = self._names.index(name)
+        self._free[idx] = True
+
+    def fixed_range(
+        self,
+        *,
+        mmin: int,
+        mmax: int,
+        nmin: int,
+        nmax: int,
+        fixed: bool = True,
+    ) -> None:
+        """Apply a free/fixed setting over a rectangular Fourier mode window."""
+        for i, name in enumerate(self._names):
+            kind, m, n = _parse_name(name)
+            if mmin <= m <= mmax and nmin <= n <= nmax:
+                self._free[i] = not fixed
+
+    def set_full_params(self, x_full: np.ndarray) -> None:
+        """Replace the complete coefficient vector."""
+        if x_full.shape[0] != self._x.shape[0]:
+            raise ValueError("x_full has wrong length")
+        self._x[:] = np.asarray(x_full, dtype=float)
+
+    def get_free_params(self) -> np.ndarray:
+        """Return only the currently free parameters."""
+        return self._x[self._free]
+
+    def set_free_params(self, x_free: np.ndarray) -> None:
+        """Update the active optimization variables in-place."""
+        if x_free.shape[0] != int(np.sum(self._free)):
+            raise ValueError("x_free has wrong length")
+        self._x[self._free] = np.asarray(x_free, dtype=float)
+
+    def expand_free(self, x_free: jnp.ndarray) -> jnp.ndarray:
+        """Expand free parameters into the full coefficient vector."""
+        x_full = jnp.asarray(self._x)
+        if int(np.sum(self._free)) == 0:
+            return x_full
+        free_idx = jnp.asarray(np.nonzero(self._free)[0], dtype=jnp.int32)
+        return x_full.at[free_idx].set(jnp.asarray(x_free))
+
+    def apply_params(self, x_full: jnp.ndarray):
+        """Apply a full parameter vector and return vmec_jax solver coefficients."""
+        delta = jnp.asarray(x_full) - jnp.asarray(self._base)
+        boundary_input = vj.optimization.apply_boundary_params(self._boundary_input0, self._specs, delta)
+        return boundary_from_input_convention(
+            boundary_input,
+            self._modes,
+            lasym=self._lasym,
+            apply_m1_constraint=False,
+        )
+
+
+class _InDataProxy:
+    """Proxy exposing the small subset of VMEC indata used by SIMSOPT."""
+
+    def __init__(self, parent, cfg, indata):
+        """Create a mutable view that keeps the wrapper config in sync."""
+        self._parent = parent
+        self._cfg = cfg
+        self._indata = indata
+        self._mpol = int(cfg.mpol)
+        self._ntor = int(cfg.ntor)
+
+    @property
+    def mpol(self) -> int:
+        """Return the active poloidal truncation used by the wrapper."""
+        return self._mpol
+
+    @mpol.setter
+    def mpol(self, val: int) -> None:
+        """Update the active poloidal truncation and rebuild dependent state."""
+        self._mpol = int(val)
+        self._parent._update_cfg(mpol=self._mpol, ntor=self._ntor)
+
+    @property
+    def ntor(self) -> int:
+        """Return the active toroidal truncation used by the wrapper."""
+        return self._ntor
+
+    @ntor.setter
+    def ntor(self, val: int) -> None:
+        """Update the active toroidal truncation and rebuild dependent state."""
+        self._ntor = int(val)
+        self._parent._update_cfg(mpol=self._mpol, ntor=self._ntor)
+
+    def get_int(self, key: str, default=None):
+        """Delegate integer lookups to the underlying indata object."""
+        return self._indata.get_int(key, default)
+
+    def get_float(self, key: str, default=None):
+        """Delegate float lookups to the underlying indata object."""
+        return self._indata.get_float(key, default)
+
+    def get_bool(self, key: str, default=None):
+        """Delegate boolean lookups to the underlying indata object."""
+        return self._indata.get_bool(key, default)
+
+    def get(self, key: str, default=None):
+        """Delegate generic lookups to the underlying indata object."""
+        return self._indata.get(key, default)
+
+
+class VmecJax:
+    """
+    JAX-backed fixed-boundary VMEC wrapper.
+
+    This class exposes a minimal subset of the Fortran VMEC interface used
+    in the SIMSOPT examples. It is intended for JAX autodiff workflows.
+    """
+
+    def __init__(self, filename: str, *, verbose: bool = False, warm_start_iters: int = 0) -> None:
+        """Load a VMEC input file and initialize the JAX-backed wrapper."""
+        _require_vmec_jax()
+        try:
+            cache_helper = getattr(getattr(vj, "driver", None), "_maybe_enable_compilation_cache", None)
+            if callable(cache_helper):
+                cache_helper()
+        except Exception:
+            pass
+        self.filename = filename
+        self.verbose = bool(verbose)
+        self._warm_start_iters = max(0, int(warm_start_iters))
+        self._load_config()
+
+    def _load_config(self) -> None:
+        """Load the VMEC input file and initialize wrapper defaults."""
+        cfg, indata = vj.load_config(self.filename)
+        self._cfg = cfg
+        self._indata_raw = indata
+        self.indata = _InDataProxy(self, cfg, indata)
+        self._static = None
+        self._boundary = None
+        self._context = None
+        self._phipf = None
+        self._chipf = None
+        self._lamscale = None
+        self._pressure = None
+        self._signgs = None
+        self._static_dirty = True
+        self._context_dirty = True
+        self._context_seed_guess = None
+        self._solver = "vmec2000"
+        self._max_iter = _last_input_value(
+            self._indata_raw,
+            array_key="NITER_ARRAY",
+            scalar_key="NITER",
+            default=50,
+            cast=int,
+        )
+        self._grad_tol = _last_input_value(
+            self._indata_raw,
+            array_key="FTOL_ARRAY",
+            scalar_key="FTOL",
+            default=1e-13,
+            cast=float,
+        )
+        self._step_size = 5e-3
+        self._step_size_override = None
+        self._history_size = 8
+        self._jacobian_penalty = 1e3
+        self._preconditioner_override = None
+        self._precond_exponent = 1.0
+        self._precond_radial_alpha_override = None
+        self._implicit_cg_max_iter = 60
+        self._implicit_cg_tol = 1e-10
+        self._implicit_damping = 1e-5
+        self._implicit_converge_tol = None
+        self._implicit_zero_unconverged = False
+        self._residual_adjoint_mode = "auto"
+        self._residual_tangent_mode = "opaque"
+        self._stateless_evaluations = False
+        self._reset_caches()
+
+    def _reset_caches(self, *, reset_warm_start: bool = False) -> None:
+        """Clear cached solve/wout results and optionally reset the warm-start seed."""
+        self._cached_x = None
+        self._cached_state = None
+        self._cached_wout = None
+        self._cached_run = None
+        if reset_warm_start and self._context is not None and self._context_seed_guess is not None:
+            self._context.st_guess = _clone_state(self._context_seed_guess)
+
+    def _invalidate_runtime(self) -> None:
+        """Invalidate stateful runtime caches that depend on static setup."""
+        self._context_dirty = True
+        self._context_seed_guess = None
+        self._reset_caches()
+
+    def _update_cfg(self, *, mpol: int, ntor: int) -> None:
+        """Change the active resolution and invalidate dependent state."""
+        self._cfg = replace(self._cfg, mpol=int(mpol), ntor=int(ntor))
+        self._static_dirty = True
+        self._invalidate_runtime()
+
+    def _ensure_static(self) -> None:
+        """Build static VMEC-JAX structures and the boundary wrapper lazily."""
+        if not self._static_dirty and self._static is not None and self._boundary is not None:
+            return
+        old_boundary = self._boundary
+        self._static = vj.build_static(self._cfg)
+        # Keep the wrapper boundary in the external/input convention. vmec_jax's
+        # initial-guess and residual paths apply the VMEC m=1 constraint
+        # internally; pre-constraining here mixes the m=1, n=+/-1 pair twice and
+        # corrupts the low-order geometry before the solve starts.
+        boundary_input0 = boundary_input_from_indata(self._indata_raw, self._static.modes)
+        boundary0 = vj.boundary_from_indata(self._indata_raw, self._static.modes, apply_m1_constraint=False)
+        self._boundary = JaxBoundary(boundary0, boundary_input0, self._static.modes, lasym=bool(self._cfg.lasym))
+        if old_boundary is not None:
+            old_names = {name: i for i, name in enumerate(old_boundary.dof_names)}
+            x_full = self._boundary.x
+            free = self._boundary.free
+            for i, name in enumerate(self._boundary.dof_names):
+                j = old_names.get(name)
+                if j is None:
+                    continue
+                x_full[i] = old_boundary.x[j]
+                free[i] = old_boundary.free[j]
+            self._boundary.set_full_params(x_full)
+            self._boundary._free[:] = free
+        self._static_dirty = False
+        self._invalidate_runtime()
+
+    def _ensure_context(self) -> None:
+        """Build the warm-start context and profile data for subsequent solves."""
+        self._ensure_static()
+        if not self._context_dirty and self._context is not None:
+            return
+
+        boundary0 = self._boundary._boundary0
+        st_guess = vj.initial_guess_from_boundary(self._static, boundary0, self._indata_raw, vmec_project=True)
+        geom = vj.eval_geom(st_guess, self._static)
+        signgs = vj.signgs_from_sqrtg(np.asarray(geom.sqrtg), axis_index=1)
+        if self._warm_start_iters > 0:
+            try:
+                from vmec_jax.solve import solve_fixed_boundary_lbfgs_vmec_residual
+
+                res = solve_fixed_boundary_lbfgs_vmec_residual(
+                    st_guess,
+                    self._static,
+                    indata=self._indata_raw,
+                    signgs=signgs,
+                    max_iter=int(self._warm_start_iters),
+                    verbose=False,
+                )
+                st_guess = res.state
+                geom = vj.eval_geom(st_guess, self._static)
+                signgs = vj.signgs_from_sqrtg(np.asarray(geom.sqrtg), axis_index=1)
+            except Exception:
+                pass
+
+        flux = vj.flux_profiles_from_indata(self._indata_raw, self._static.s, signgs=signgs)
+        profiles = vj.eval_profiles(self._indata_raw, self._static.s)
+        pressure = jnp.asarray(profiles.get("pressure", jnp.zeros_like(self._static.s)))
+        self._context = SimpleNamespace(
+            st_guess=st_guess,
+            signgs=signgs,
+            flux=flux,
+            pressure=pressure,
+            booz_inputs=None,
+        )
+        self._context_seed_guess = _clone_state(st_guess)
+        self._phipf = jnp.asarray(flux.phipf)
+        self._chipf = jnp.asarray(flux.chipf)
+        self._lamscale = jnp.asarray(flux.lamscale)
+        self._pressure = jnp.asarray(pressure)
+        self._signgs = int(signgs)
+        self._context_dirty = False
+
+    def set_solver_options(
+        self,
+        *,
+        max_iter: int | None = None,
+        grad_tol: float | None = None,
+        solver: str | None = None,
+        warm_start_iters: int | None = None,
+        step_size: float | None = None,
+        history_size: int | None = None,
+        jacobian_penalty: float | None = None,
+        preconditioner: str | None = None,
+        precond_exponent: float | None = None,
+        precond_radial_alpha: float | None = None,
+        implicit_cg_max_iter: int | None = None,
+        implicit_cg_tol: float | None = None,
+        implicit_damping: float | None = None,
+        implicit_converge_tol: float | None = None,
+        implicit_zero_unconverged: bool | None = None,
+        residual_adjoint_mode: str | None = None,
+        residual_tangent_mode: str | None = None,
+        stateless_evaluations: bool | None = None,
+    ) -> None:
+        """Update VMEC-JAX solver controls used by this wrapper."""
+        if max_iter is not None:
+            max_iter = int(max_iter)
+            if max_iter != self._max_iter:
+                self._max_iter = max_iter
+                self._reset_caches(reset_warm_start=True)
+        if grad_tol is not None:
+            grad_tol = float(grad_tol)
+            if grad_tol != self._grad_tol:
+                self._grad_tol = grad_tol
+                self._reset_caches(reset_warm_start=True)
+        if solver is not None:
+            solver = str(solver).strip().lower()
+            if solver != self._solver:
+                self._solver = solver
+                self._reset_caches(reset_warm_start=True)
+        if warm_start_iters is not None:
+            warm_start_iters = int(warm_start_iters)
+            if warm_start_iters != self._warm_start_iters:
+                self._warm_start_iters = warm_start_iters
+                self._invalidate_runtime()
+        if step_size is not None:
+            step_size = float(step_size)
+            if step_size != self._step_size or step_size != self._step_size_override:
+                self._step_size = step_size
+                self._step_size_override = step_size
+                self._reset_caches(reset_warm_start=True)
+        if history_size is not None:
+            history_size = int(history_size)
+            if history_size != self._history_size:
+                self._history_size = history_size
+                self._reset_caches(reset_warm_start=True)
+        if jacobian_penalty is not None:
+            jacobian_penalty = float(jacobian_penalty)
+            if jacobian_penalty != self._jacobian_penalty:
+                self._jacobian_penalty = jacobian_penalty
+                self._reset_caches(reset_warm_start=True)
+        if preconditioner is not None:
+            preconditioner = str(preconditioner).strip().lower()
+            if preconditioner != self._preconditioner_override:
+                self._preconditioner_override = preconditioner
+                self._reset_caches(reset_warm_start=True)
+        if precond_exponent is not None:
+            precond_exponent = float(precond_exponent)
+            if precond_exponent != self._precond_exponent:
+                self._precond_exponent = precond_exponent
+                self._reset_caches(reset_warm_start=True)
+        if precond_radial_alpha is not None:
+            precond_radial_alpha = float(precond_radial_alpha)
+            if precond_radial_alpha != self._precond_radial_alpha_override:
+                self._precond_radial_alpha_override = precond_radial_alpha
+                self._reset_caches(reset_warm_start=True)
+        if implicit_cg_max_iter is not None:
+            implicit_cg_max_iter = int(implicit_cg_max_iter)
+            if implicit_cg_max_iter != self._implicit_cg_max_iter:
+                self._implicit_cg_max_iter = implicit_cg_max_iter
+                self._reset_caches(reset_warm_start=True)
+        if implicit_cg_tol is not None:
+            implicit_cg_tol = float(implicit_cg_tol)
+            if implicit_cg_tol != self._implicit_cg_tol:
+                self._implicit_cg_tol = implicit_cg_tol
+                self._reset_caches(reset_warm_start=True)
+        if implicit_damping is not None:
+            implicit_damping = float(implicit_damping)
+            if implicit_damping != self._implicit_damping:
+                self._implicit_damping = implicit_damping
+                self._reset_caches(reset_warm_start=True)
+        if implicit_converge_tol is not None:
+            implicit_converge_tol = float(implicit_converge_tol)
+            if implicit_converge_tol != self._implicit_converge_tol:
+                self._implicit_converge_tol = implicit_converge_tol
+                self._reset_caches(reset_warm_start=True)
+        if implicit_zero_unconverged is not None:
+            implicit_zero_unconverged = bool(implicit_zero_unconverged)
+            if implicit_zero_unconverged != self._implicit_zero_unconverged:
+                self._implicit_zero_unconverged = implicit_zero_unconverged
+                self._reset_caches(reset_warm_start=True)
+        if residual_adjoint_mode is not None:
+            residual_adjoint_mode = str(residual_adjoint_mode).strip().lower()
+            if residual_adjoint_mode != self._residual_adjoint_mode:
+                self._residual_adjoint_mode = residual_adjoint_mode
+                self._reset_caches(reset_warm_start=True)
+        if residual_tangent_mode is not None:
+            residual_tangent_mode = str(residual_tangent_mode).strip().lower()
+            if residual_tangent_mode != self._residual_tangent_mode:
+                self._residual_tangent_mode = residual_tangent_mode
+                self._reset_caches(reset_warm_start=True)
+        if stateless_evaluations is not None:
+            stateless_evaluations = bool(stateless_evaluations)
+            if stateless_evaluations != self._stateless_evaluations:
+                self._stateless_evaluations = stateless_evaluations
+                self._reset_caches(reset_warm_start=True)
+
+    def use_residual_autodiff_defaults(
+        self,
+        *,
+        outer_method: str | None = None,
+        residual_adjoint_mode: str | None = None,
+        stateless_evaluations: bool | None = None,
+        optimization_profile: str | None = None,
+    ) -> None:
+        """Apply wrapper defaults that worked best for the fixed-resolution JAX examples."""
+        profile = _outer_optimization_profile(optimization_profile)
+        method = None if outer_method is None else str(outer_method).strip().lower()
+        tangent_method = "linearize" if method in (
+            "gauss_newton",
+            "trust_region",
+            "levenberg_marquardt",
+            "truncated_gauss_newton",
+            "scipy",
+        ) else "opaque"
+        adjoint_mode = profile.get("residual_adjoint_mode", "lineax") if residual_adjoint_mode is None else str(residual_adjoint_mode).strip().lower()
+        stateful = profile.get("stateless_evaluations", False) if stateless_evaluations is None else bool(stateless_evaluations)
+        solver_options = {
+            "solver": "vmec2000",
+            "residual_adjoint_mode": adjoint_mode,
+            "residual_tangent_mode": tangent_method,
+            "stateless_evaluations": stateful,
+        }
+        for key in ("max_iter", "grad_tol", "implicit_cg_max_iter", "implicit_cg_tol", "implicit_damping"):
+            if key in profile:
+                solver_options[key] = profile[key]
+        self.set_solver_options(
+            **solver_options,
+        )
+
+    def _x_cache_key(self, x_free) -> tuple[float, ...]:
+        """Return a hashable cache key for concrete parameter vectors."""
+        try:
+            arr = np.asarray(x_free, dtype=float).reshape(-1)
+        except Exception:
+            return None
+        return tuple(arr.tolist())
+
+    def _solve_state(self, x_free: jnp.ndarray):
+        """Solve the fixed-boundary equilibrium and return the VMEC-JAX state."""
+        from vmec_jax.implicit import (
+            ImplicitFixedBoundaryOptions,
+            solve_fixed_boundary_state_implicit,
+            solve_fixed_boundary_state_implicit_vmec_residual,
+        )
+        from vmec_jax.solve import solve_fixed_boundary_residual_iter
+        self._ensure_context()
+        x_key = self._x_cache_key(x_free)
+        use_stateful_cache = x_key is not None and not self._stateless_evaluations
+        if use_stateful_cache and self._cached_x == x_key and self._cached_state is not None:
+            return self._cached_state
+
+        seed_state = self._context.st_guess
+        if self._stateless_evaluations and self._context_seed_guess is not None:
+            seed_state = _clone_state(self._context_seed_guess)
+
+        x_full = self.boundary.expand_free(x_free)
+        boundary = self.boundary.apply_params(x_full)
+
+        # Use edge boundary coefficients for fixed-boundary enforcement.
+        edge_Rcos = jnp.asarray(boundary.R_cos)
+        edge_Rsin = jnp.asarray(boundary.R_sin)
+        edge_Zcos = jnp.asarray(boundary.Z_cos)
+        edge_Zsin = jnp.asarray(boundary.Z_sin)
+
+        implicit_opts = ImplicitFixedBoundaryOptions(
+            cg_max_iter=int(self._implicit_cg_max_iter),
+            cg_tol=float(self._implicit_cg_tol),
+            damping=float(self._implicit_damping),
+            residual_adjoint_mode=str(self._residual_adjoint_mode),
+            residual_tangent_mode=str(self._residual_tangent_mode),
+        )
+        state0_host = vj.VMECState(
+            layout=seed_state.layout,
+            Rcos=np.asarray(seed_state.Rcos),
+            Rsin=np.asarray(seed_state.Rsin),
+            Zcos=np.asarray(seed_state.Zcos),
+            Zsin=np.asarray(seed_state.Zsin),
+            Lcos=np.asarray(seed_state.Lcos),
+            Lsin=np.asarray(seed_state.Lsin),
+        )
+        residual_step_size = (
+            float(self._step_size_override)
+            if self._step_size_override is not None
+            else float(self._indata_raw.get_float("DELT", 1.0))
+        )
+        solver = self._solver
+        use_residual_implicit_wrapper = (
+            solver in ("residual", "vmec2000")
+            and (
+                str(self._residual_adjoint_mode) != "auto"
+                or str(self._residual_tangent_mode) != "opaque"
+            )
+        )
+
+        def _solve(solver: str):
+            if solver in ("residual", "vmec2000"):
+                if x_key is None or use_residual_implicit_wrapper:
+                    return solve_fixed_boundary_state_implicit_vmec_residual(
+                        seed_state,
+                        self._static,
+                        indata=self._indata_raw,
+                        signgs=self._signgs,
+                        state0_host=state0_host,
+                        max_iter=int(self._max_iter),
+                        step_size=residual_step_size,
+                        ftol=float(self._grad_tol),
+                        implicit=implicit_opts,
+                        edge_Rcos=edge_Rcos,
+                        edge_Rsin=edge_Rsin,
+                        edge_Zcos=edge_Zcos,
+                        edge_Zsin=edge_Zsin,
+                    )
+                st0 = vj.initial_guess_from_boundary(self._static, boundary, self._indata_raw, vmec_project=True)
+                geom0 = vj.eval_geom(st0, self._static)
+                signgs0 = vj.signgs_from_sqrtg(np.asarray(geom0.sqrtg), axis_index=1)
+                res = solve_fixed_boundary_residual_iter(
+                    st0,
+                    self._static,
+                    indata=self._indata_raw,
+                    signgs=int(signgs0),
+                    ftol=float(self._grad_tol),
+                    max_iter=int(self._max_iter),
+                    step_size=residual_step_size,
+                    vmec2000_control=True,
+                    reference_mode=False,
+                    backtracking=True,
+                    limit_dt_from_force=True,
+                    limit_update_rms=True,
+                    verbose=False,
+                    verbose_vmec2000_table=False,
+                    jit_forces="auto",
+                    use_scan=False,
+                )
+                return res.state
+            preconditioner = self._preconditioner_override
+            if preconditioner is None:
+                preconditioner = "mode_diag+radial_tridi" if solver == "lbfgs" else "none"
+            precond_radial_alpha = self._precond_radial_alpha_override
+            if precond_radial_alpha is None:
+                precond_radial_alpha = 0.5 if solver == "lbfgs" else 0.0
+            return solve_fixed_boundary_state_implicit(
+                seed_state,
+                self._static,
+                phipf=self._phipf,
+                chipf=self._chipf,
+                signgs=self._signgs,
+                lamscale=self._lamscale,
+                pressure=self._pressure,
+                gamma=float(self._indata_raw.get_float("GAMMA", 0.0)),
+                jacobian_penalty=float(self._jacobian_penalty),
+                solver=solver,
+                max_iter=int(self._max_iter),
+                step_size=float(self._step_size),
+                history_size=int(self._history_size),
+                grad_tol=float(self._grad_tol),
+                preconditioner=preconditioner,
+                precond_exponent=float(self._precond_exponent),
+                precond_radial_alpha=precond_radial_alpha,
+                implicit=implicit_opts,
+                implicit_converge_tol=(
+                    float(self._implicit_converge_tol)
+                    if self._implicit_converge_tol is not None
+                    else float(self._grad_tol)
+                ),
+                implicit_zero_unconverged=bool(self._implicit_zero_unconverged),
+                edge_Rcos=edge_Rcos,
+                edge_Rsin=edge_Rsin,
+                edge_Zcos=edge_Zcos,
+                edge_Zsin=edge_Zsin,
+            )
+
+        if solver == "initial":
+            return vj.initial_guess_from_boundary(self._static, boundary, self._indata_raw, vmec_project=False)
+        try:
+            state = _solve(solver)
+        except ValueError as exc:
+            msg = str(exc).lower()
+            if "invalid jacobian" in msg and solver != "gd":
+                state = _solve("gd")
+            else:
+                raise
+        # Reuse the last converged state as the next solve's starting point for
+        # ordinary concrete evaluations. Avoid mutating the warm-start state
+        # during traced/JAX-transformed solves, which would make subsequent
+        # objective calls history-dependent and can leak traced values into the
+        # Python wrapper state.
+        if use_stateful_cache:
+            self._context.st_guess = state
+        if use_stateful_cache:
+            self._cached_x = x_key
+            self._cached_state = state
+            self._cached_wout = None
+            self._cached_run = None
+        return state
+
+    def get_run(self, x_free):
+        """Return a :class:`vmec_jax.driver.FixedBoundaryRun` for the current point."""
+        state = self._solve_state(x_free)
+        if self._cached_run is not None and self._cached_state is state:
+            return self._cached_run
+        self._ensure_context()
+        run = vj.FixedBoundaryRun(
+            cfg=self._cfg,
+            indata=self._indata_raw,
+            static=self.get_static(),
+            state=state,
+            result=None,
+            flux=self._context.flux,
+            profiles={},
+            signgs=self._signgs,
+        )
+        if self._x_cache_key(x_free) is not None:
+            self._cached_run = run
+        return run
+
+    def get_wout(self, x_free):
+        """Return a VMEC-style ``wout`` object for the current point."""
+        run = self.get_run(x_free)
+        if self._cached_wout is not None and self._cached_run is run:
+            return self._cached_wout
+        wout = vj.wout_from_fixed_boundary_run(run, include_fsq=False, fast_bcovar=True)
+        if self._x_cache_key(x_free) is not None:
+            self._cached_wout = wout
+        return wout
+
+    def get_wout_from_state(self, state):
+        """Return a VMEC-style ``wout`` object for an already solved state."""
+        self._ensure_context()
+        run = vj.FixedBoundaryRun(
+            cfg=self._cfg,
+            indata=self._indata_raw,
+            static=self.get_static(),
+            state=state,
+            result=None,
+            flux=self._context.flux,
+            profiles={},
+            signgs=self._signgs,
+        )
+        return vj.wout_from_fixed_boundary_run(run, include_fsq=False, fast_bcovar=True)
+
+    def quasisymmetry_diagnostics_from_state_jax(self, state):
+        """Build the VMEC-only QS channels directly from a solved state.
+
+        This helper mirrors the subset of ``wout`` synthesis needed by
+        :class:`simsopt.mhd.QuasisymmetryRatioResidual`, but keeps the data on
+        the JAX side instead of materializing a Python ``wout`` object. The
+        returned namespace contains the Nyquist Fourier coefficients and 1D
+        profiles needed to evaluate the VMEC-only quasisymmetry residual.
+        """
+        self._ensure_context()
+
+        from vmec_jax.booz_input import _filter_bsubuv_jxbforce_parity_jax
+        from vmec_jax.driver import _final_flux_profiles_from_state
+        from vmec_jax.energy import _iotaf_from_iotas
+        from vmec_jax.integrals import cumrect_s_halfmesh
+        from vmec_jax.modes import nyquist_mode_table_from_grid
+        from vmec_jax.vmec_bcovar import vmec_bcovar_half_mesh_from_wout
+        from vmec_jax.vmec_lforbal import currents_from_bcovar
+        from vmec_jax.vmec_tomnsp import vmec_trig_tables
+
+        static = self.get_static()
+        context = self.get_context()
+        flux, prof = _final_flux_profiles_from_state(
+            indata=self._indata_raw,
+            static_in=static,
+            state=state,
+            signgs=self._signgs,
+            flux_local=context.flux,
+            prof_local={"pressure": context.pressure},
+            pressure_local=context.pressure,
+        )
+
+        s_full = jnp.asarray(static.s)
+        pres = jnp.asarray(prof.get("pressure", context.pressure))
+        if int(pres.shape[0]) > 0:
+            pres = pres.at[0].set(0.0)
+
+        iotas = prof.get("iota", None)
+        if iotas is None:
+            phips = jnp.asarray(flux.phips)
+            chipf = jnp.asarray(flux.chipf)
+            chips = jnp.concatenate([chipf[:1], 0.5 * (chipf[1:] + chipf[:-1])], axis=0)
+            safe_phips = jnp.where(phips != 0.0, phips, 1.0)
+            iotas = jnp.where(phips != 0.0, chips / safe_phips, 0.0)
+        iotas = jnp.asarray(iotas)
+        if int(iotas.shape[0]) > 0:
+            iotas = iotas.at[0].set(0.0)
+        iotaf = jnp.asarray(prof.get("iotaf", _iotaf_from_iotas(iotas, lrfp=bool(self._indata_raw.get_bool("LRFP", False)))))
+
+        wout_like = SimpleNamespace(
+            phipf=jnp.asarray(flux.phipf),
+            chipf=jnp.asarray(flux.chipf),
+            phips=jnp.asarray(flux.phips),
+            iotas=iotas,
+            iotaf=iotaf,
+            nfp=int(self._cfg.nfp),
+            mpol=int(self._cfg.mpol),
+            ntor=int(self._cfg.ntor),
+            lasym=bool(self._cfg.lasym),
+            signgs=int(self._signgs),
+            ncurr=int(self._indata_raw.get_int("NCURR", 0)),
+            lcurrent=bool(int(self._indata_raw.get_int("NCURR", 0)) == 1),
+            flux_is_internal=True,
+        )
+
+        nyq_modes = nyquist_mode_table_from_grid(
+            mpol=int(self._cfg.mpol),
+            ntor=int(self._cfg.ntor),
+            ntheta=int(self._cfg.ntheta),
+            nzeta=int(self._cfg.nzeta),
+        )
+        mmax_nyq = int(np.max(np.asarray(nyq_modes.m))) if int(nyq_modes.K) > 0 else 0
+        nmax_nyq = int(np.max(np.abs(np.asarray(nyq_modes.n)))) if int(nyq_modes.K) > 0 else 0
+        trig = vmec_trig_tables(
+            ntheta=int(self._cfg.ntheta),
+            nzeta=int(self._cfg.nzeta),
+            nfp=int(self._cfg.nfp),
+            mmax=max(int(self._cfg.mpol) - 1, mmax_nyq),
+            nmax=max(int(self._cfg.ntor), nmax_nyq),
+            lasym=bool(self._cfg.lasym),
+            dtype=jnp.asarray(state.Rcos).dtype,
+            cache=not _is_traced_value(state.Rcos),
+        )
+
+        bc = vmec_bcovar_half_mesh_from_wout(
+            state=state,
+            static=static,
+            wout=wout_like,
+            pres=pres,
+            use_wout_bsup=False,
+            use_wout_bsub_for_lambda=False,
+            use_wout_bmag_for_bsq=False,
+            use_vmec_synthesis=True,
+            trig=trig,
+        )
+        buco, bvco, _, _ = currents_from_bcovar(bc=bc, trig=trig, wout=wout_like, s=s_full)
+
+        bsq = jnp.asarray(bc.bsq)
+        # Keep |B| differentiable where the pressure-corrected magnitude lands
+        # exactly on zero. This only changes exact-zero values by machine tiny,
+        # but avoids undefined reverse-mode sensitivities in the QS diagnostic.
+        bmod_sq = jnp.maximum(
+            2.0 * (bsq - pres[:, None, None]),
+            jnp.asarray(jnp.finfo(bsq.dtype).tiny, dtype=bsq.dtype),
+        )
+        bmod = jnp.sqrt(bmod_sq)
+        bsubu = jnp.asarray(bc.bsubu)
+        bsubv = jnp.asarray(bc.bsubv)
+        if not bool(self._cfg.lasym):
+            pshalf = jnp.sqrt(jnp.maximum(0.5 * (s_full[1:] + s_full[:-1]), 0.0))
+            pshalf = jnp.concatenate([pshalf[:1], pshalf], axis=0)
+            if int(pshalf.shape[0]) > 1:
+                pshalf = pshalf.at[0].set(pshalf[1])
+            pshalf = pshalf[:, None, None]
+            bsubu, bsubv = _filter_bsubuv_jxbforce_parity_jax(
+                bsubu_even=bsubu,
+                bsubu_odd=pshalf * bsubu,
+                bsubv_even=bsubv,
+                bsubv_odd=pshalf * bsubv,
+                trig=trig,
+                mmax_force=max(int(self._cfg.mpol) - 1, 0),
+                nmax_force=int(self._cfg.ntor),
+                s=s_full,
+            )
+
+        gmnc = _vmec_wrout_nyquist_cos_coeffs_jax(f=jnp.asarray(bc.jac.sqrtg), modes=nyq_modes, trig=trig)
+        bmnc = _vmec_wrout_nyquist_cos_coeffs_jax(f=bmod, modes=nyq_modes, trig=trig)
+        bsubumnc = _vmec_wrout_nyquist_cos_coeffs_jax(f=bsubu, modes=nyq_modes, trig=trig)
+        bsubvmnc = _vmec_wrout_nyquist_cos_coeffs_jax(f=bsubv, modes=nyq_modes, trig=trig)
+        bsupumnc = _vmec_wrout_nyquist_cos_coeffs_jax(f=jnp.asarray(bc.bsupu), modes=nyq_modes, trig=trig)
+        bsupvmnc = _vmec_wrout_nyquist_cos_coeffs_jax(f=jnp.asarray(bc.bsupv), modes=nyq_modes, trig=trig)
+
+        if not bool(self._cfg.lasym):
+            mask_bsub = (jnp.asarray(nyq_modes.m) >= int(self._cfg.mpol)) | (
+                jnp.abs(jnp.asarray(nyq_modes.n)) > int(self._cfg.ntor)
+            )
+            bsubumnc = jnp.where(mask_bsub[None, :], 0.0, jnp.asarray(bsubumnc))
+            bsubvmnc = jnp.where(mask_bsub[None, :], 0.0, jnp.asarray(bsubvmnc))
+
+        phi = cumrect_s_halfmesh(jnp.asarray(flux.phipf) * float(2.0 * np.pi * self._signgs), s_full)
+        return SimpleNamespace(
+            lasym=bool(self._cfg.lasym),
+            nfp=int(self._cfg.nfp),
+            iotas=iotas,
+            buco=jnp.asarray(buco),
+            bvco=jnp.asarray(bvco),
+            gmnc=jnp.asarray(gmnc),
+            bmnc=jnp.asarray(bmnc),
+            bsubumnc=jnp.asarray(bsubumnc),
+            bsubvmnc=jnp.asarray(bsubvmnc),
+            bsupumnc=jnp.asarray(bsupumnc),
+            bsupvmnc=jnp.asarray(bsupvmnc),
+            xm_nyq=jnp.asarray(nyq_modes.m, dtype=jnp.float64),
+            xn_nyq=jnp.asarray(nyq_modes.n * int(self._cfg.nfp), dtype=jnp.float64),
+            phi=jnp.asarray(phi),
+        )
+
+    def aspect_jax(self, x_free: jnp.ndarray):
+        """Return the fast boundary-only aspect-ratio surrogate."""
+        self._ensure_static()
+        boundary = self.boundary.apply_params(self.boundary.expand_free(x_free))
+        return vj.boundary_aspect_ratio_from_static(boundary, self._static)
+
+    def aspect_equilibrium_from_state_jax(self, state):
+        """Return the equilibrium aspect ratio for an already-solved state."""
+        return vj.equilibrium_aspect_ratio_from_state(state=state, static=self.get_static())
+
+    def aspect_equilibrium_jax(self, x_free: jnp.ndarray):
+        """Return the equilibrium aspect ratio directly from the solved state."""
+        state = self._solve_state(x_free)
+        return self.aspect_equilibrium_from_state_jax(state)
+
+    def aspect_equilibrium(self, x_free=None):
+        """Return the equilibrium aspect ratio derived from the solved ``wout``."""
+        if x_free is None:
+            x_free = self.boundary.get_free_params()
+        return float(np.asarray(self.aspect_equilibrium_jax(jnp.asarray(x_free))))
+
+    def aspect(self, x_free=None):
+        """Return the plasma aspect ratio, matching :class:`simsopt.mhd.Vmec`."""
+        return self.aspect_equilibrium(x_free)
+
+    def mean_iota_from_state_jax(self, state):
+        """Return the mean rotational transform, matching :class:`simsopt.mhd.Vmec`."""
+        _chips, iotas, _iotaf = vj.equilibrium_iota_profiles_from_state(
+            state=state,
+            static=self.get_static(),
+            indata=self._indata_raw,
+            signgs=self._signgs,
+        )
+        iotas = jnp.asarray(iotas)
+        if int(iotas.shape[0]) <= 1:
+            return jnp.asarray(0.0, dtype=iotas.dtype)
+        return jnp.mean(iotas[1:])
+
+    def mean_iota_jax(self, x_free: jnp.ndarray):
+        """Return the mean rotational transform directly from a solved state."""
+        state = self._solve_state(x_free)
+        return self.mean_iota_from_state_jax(state)
+
+    def mean_iota(self, x_free=None):
+        """Return the mean rotational transform in the same style as :class:`simsopt.mhd.Vmec`."""
+        if x_free is None:
+            x_free = self.boundary.get_free_params()
+        return float(np.asarray(self.mean_iota_jax(jnp.asarray(x_free))))
+
+    def get_static(self):
+        """Expose the cached vmec_jax static data structure."""
+        self._ensure_static()
+        return self._static
+
+    def get_context(self):
+        """Expose the cached warm-start/profile context."""
+        self._ensure_context()
+        return self._context
+
+    @property
+    def boundary(self):
+        """Return the mutable boundary wrapper for this VMEC-JAX instance."""
+        self._ensure_static()
+        return self._boundary

--- a/src/simsopt/mhd/vmec_jax.py
+++ b/src/simsopt/mhd/vmec_jax.py
@@ -804,11 +804,8 @@ class VmecJax:
             (xf_tangent,) = tangents
             packed_final, payload = _forward_payload(xf)
 
-            def _frozen_initial_state(x):
-                return _initial_state_packed(x, axis_override=payload["axis_override"])
-
             _packed0, packed_tangent0 = jax.jvp(
-                _frozen_initial_state,
+                _initial_state_packed,
                 (jnp.asarray(xf),),
                 (jnp.asarray(xf_tangent),),
             )
@@ -874,9 +871,6 @@ class VmecJax:
             )
             return jnp.asarray(vj.pack_state(state0), dtype=jnp.float64)
 
-        def _frozen_initial_state(x):
-            return _initial_state_packed(x, axis_override=payload["axis_override"])
-
         def _residuals_from_packed(x):
             return residuals_from_state(vj.unpack_state(x, layout))
 
@@ -888,9 +882,9 @@ class VmecJax:
         helper_cache = self._discrete_jacobian_helper_cache.get(cache_key)
         if helper_cache is None:
             @jax.jit
-            def _initial_tangent_columns(xf, axis_override, directions):
+            def _initial_tangent_columns(xf, directions):
                 _, initial_state_linear = jax.linearize(
-                    lambda x: _initial_state_packed(x, axis_override=axis_override),
+                    _initial_state_packed,
                     xf,
                 )
                 return jax.vmap(initial_state_linear)(directions)
@@ -909,7 +903,6 @@ class VmecJax:
         directions = jnp.asarray(np.eye(int(x_free.size), dtype=float), dtype=x_free.dtype)
         packed_tangents0 = helper_cache["initial_tangent_columns"](
             x_free,
-            payload["axis_override"],
             directions,
         )
         packed_tangents = vj.checkpoint_tape_state_jvp_columns(

--- a/src/simsopt/mhd/vmec_jax.py
+++ b/src/simsopt/mhd/vmec_jax.py
@@ -830,7 +830,7 @@ class VmecJax:
         packed_state = _packed_state_from_xfree(jnp.asarray(x_free))
         return vj.unpack_state(packed_state, layout)
 
-    def _discrete_adjoint_residual_jacobian(self, x_free, residuals_from_state):
+    def _discrete_adjoint_residual_jacobian(self, x_free, residuals_from_state, *, state=None, payload=None):
         self._ensure_context()
         x_free = jnp.asarray(x_free, dtype=jnp.float64)
         if self._residual_derivative_backend != "discrete_adjoint":
@@ -841,11 +841,12 @@ class VmecJax:
             if self._step_size_override is not None
             else float(self._indata_raw.get_float("DELT", 1.0))
         )
-        state, payload = self._solve_state_discrete_adjoint_residual(
-            x_free,
-            step_size=residual_step_size,
-            return_payload=True,
-        )
+        if state is None or payload is None:
+            state, payload = self._solve_state_discrete_adjoint_residual(
+                x_free,
+                step_size=residual_step_size,
+                return_payload=True,
+            )
 
         static = self._static
         boundary_wrapper = self.boundary

--- a/src/simsopt/mhd/vmec_jax.py
+++ b/src/simsopt/mhd/vmec_jax.py
@@ -778,7 +778,7 @@ class VmecJax:
                 light_history=True,
                 resume_state_mode="full",
             )
-            tape = vj.build_residual_checkpoint_tape(
+            tape = vj.build_residual_checkpoint_tape_direct(
                 state0,
                 static,
                 max_iter=max_iter,
@@ -788,12 +788,9 @@ class VmecJax:
                 ftol=ftol,
                 step_size=float(step_size),
                 light_history=True,
-                resume_state_mode="full",
+                store_trace=False,
             )
-            if int(tape.packed_states.shape[0]) > 0:
-                packed_final = jnp.asarray(tape.packed_states[-1], dtype=x0.dtype)
-            else:
-                packed_final = x0
+            packed_final = jnp.asarray(tape.final_packed_state, dtype=x0.dtype)
             return packed_final, {"tape": tape, "axis_override": axis_override}
 
         @jax.custom_jvp

--- a/src/simsopt/mhd/vmec_jax.py
+++ b/src/simsopt/mhd/vmec_jax.py
@@ -896,6 +896,36 @@ class VmecJax:
             columns.append(np.asarray(col, dtype=float))
         return np.stack(columns, axis=1)
 
+    def _solve_state_residual_forward(self, x_free, *, step_size: float):
+        from vmec_jax.solve import solve_fixed_boundary_residual_iter
+
+        self._ensure_context()
+        boundary = self.boundary.apply_params(self.boundary.expand_free(x_free))
+        st0 = vj.initial_guess_from_boundary(self._static, boundary, self._indata_raw, vmec_project=True)
+        geom0 = vj.eval_geom(st0, self._static)
+        signgs0 = vj.signgs_from_sqrtg(np.asarray(geom0.sqrtg), axis_index=1)
+        res = solve_fixed_boundary_residual_iter(
+            st0,
+            self._static,
+            indata=self._indata_raw,
+            signgs=int(signgs0),
+            ftol=float(self._grad_tol),
+            max_iter=int(self._max_iter),
+            step_size=float(step_size),
+            vmec2000_control=True,
+            reference_mode=False,
+            backtracking=True,
+            limit_dt_from_force=True,
+            limit_update_rms=True,
+            verbose=False,
+            verbose_vmec2000_table=False,
+            jit_forces="auto",
+            use_scan=False,
+            light_history=True,
+            resume_state_mode="full",
+        )
+        return _clone_state(res.state)
+
     def _x_cache_key(self, x_free) -> tuple[float, ...]:
         """Return a hashable cache key for concrete parameter vectors."""
         try:

--- a/src/simsopt/mhd/vmec_jax.py
+++ b/src/simsopt/mhd/vmec_jax.py
@@ -13,6 +13,7 @@ implemented on top of `vmec_jax` with implicit differentiation.
 from __future__ import annotations
 
 from dataclasses import replace
+from itertools import count
 import re
 from typing import Sequence
 from types import SimpleNamespace
@@ -36,6 +37,10 @@ else:
 
 
 __all__ = ["VmecJax", "JaxBoundary"]
+
+
+_DISCRETE_ADJOINT_PAYLOADS: dict[int, dict] = {}
+_DISCRETE_ADJOINT_PAYLOAD_IDS = count()
 
 
 _OUTER_OPTIMIZATION_PROFILES = {
@@ -211,6 +216,16 @@ def _outer_optimization_profile(name: str | None) -> dict:
         return dict(_OUTER_OPTIMIZATION_PROFILES[key])
     except KeyError as exc:
         raise ValueError(f"Unknown VmecJax optimization profile: {name}") from exc
+
+
+def _store_discrete_adjoint_payload(payload: dict) -> int:
+    token = next(_DISCRETE_ADJOINT_PAYLOAD_IDS)
+    _DISCRETE_ADJOINT_PAYLOADS[token] = payload
+    if len(_DISCRETE_ADJOINT_PAYLOADS) > 32:
+        oldest = min(_DISCRETE_ADJOINT_PAYLOADS)
+        if oldest != token:
+            _DISCRETE_ADJOINT_PAYLOADS.pop(oldest, None)
+    return token
 
 
 class JaxBoundary:
@@ -463,6 +478,7 @@ class VmecJax:
         self._implicit_damping = 1e-5
         self._implicit_converge_tol = None
         self._implicit_zero_unconverged = False
+        self._residual_derivative_backend = "implicit"
         self._residual_adjoint_mode = "auto"
         self._residual_tangent_mode = "opaque"
         self._stateless_evaluations = False
@@ -581,6 +597,7 @@ class VmecJax:
         implicit_damping: float | None = None,
         implicit_converge_tol: float | None = None,
         implicit_zero_unconverged: bool | None = None,
+        residual_derivative_backend: str | None = None,
         residual_adjoint_mode: str | None = None,
         residual_tangent_mode: str | None = None,
         stateless_evaluations: bool | None = None,
@@ -662,6 +679,15 @@ class VmecJax:
             if implicit_zero_unconverged != self._implicit_zero_unconverged:
                 self._implicit_zero_unconverged = implicit_zero_unconverged
                 self._reset_caches(reset_warm_start=True)
+        if residual_derivative_backend is not None:
+            residual_derivative_backend = str(residual_derivative_backend).strip().lower()
+            if residual_derivative_backend not in ("implicit", "discrete_adjoint"):
+                raise ValueError(
+                    "residual_derivative_backend must be 'implicit' or 'discrete_adjoint'"
+                )
+            if residual_derivative_backend != self._residual_derivative_backend:
+                self._residual_derivative_backend = residual_derivative_backend
+                self._reset_caches(reset_warm_start=True)
         if residual_adjoint_mode is not None:
             residual_adjoint_mode = str(residual_adjoint_mode).strip().lower()
             if residual_adjoint_mode != self._residual_adjoint_mode:
@@ -710,6 +736,112 @@ class VmecJax:
         self.set_solver_options(
             **solver_options,
         )
+
+    def _solve_state_discrete_adjoint_residual(self, x_free: jnp.ndarray, *, step_size: float):
+        """Solve the residual iteration with a discrete-adjoint VJP over x_free."""
+        self._ensure_context()
+        static = self._static
+        boundary_wrapper = self.boundary
+        indata = self._indata_raw
+        base_full = jnp.asarray(boundary_wrapper._base)
+        specs = tuple(boundary_wrapper._specs)
+        lasym = bool(self._cfg.lasym)
+        max_iter = int(self._max_iter)
+        ftol = float(self._grad_tol)
+        modes = boundary_wrapper._modes
+        layout = self._context.st_guess.layout
+
+        def _initial_state_packed(xf, *, axis_override=None):
+            x_full = boundary_wrapper.expand_free(xf)
+            delta_full = jnp.asarray(x_full) - base_full
+            boundary_input = vj.apply_boundary_params(boundary_wrapper._boundary_input0, specs, delta_full)
+            boundary = boundary_from_input_convention(
+                boundary_input,
+                modes,
+                lasym=lasym,
+                apply_m1_constraint=False,
+            )
+            state = vj.initial_guess_from_boundary(
+                static,
+                boundary,
+                indata,
+                vmec_project=True,
+                axis_override=axis_override,
+            )
+            return jnp.asarray(vj.pack_state(state))
+
+        def _forward_payload(xf):
+            x0 = jnp.asarray(_initial_state_packed(xf), dtype=jnp.float64)
+            state0 = vj.unpack_state(x0, layout)
+            axis_override = vj.extract_axis_override_from_state(state0, static)
+            signgs0 = int(self._signgs)
+            solver_kwargs = dict(
+                indata=indata,
+                signgs=signgs0,
+                ftol=ftol,
+                step_size=float(step_size),
+                vmec2000_control=True,
+                reference_mode=False,
+                backtracking=True,
+                limit_dt_from_force=True,
+                limit_update_rms=True,
+                verbose=False,
+                verbose_vmec2000_table=False,
+                jit_forces="auto",
+                use_scan=False,
+                light_history=True,
+                resume_state_mode="full",
+            )
+            tape = vj.build_residual_checkpoint_tape(
+                state0,
+                static,
+                max_iter=max_iter,
+                solver_kwargs=solver_kwargs,
+                indata=indata,
+                signgs=signgs0,
+                ftol=ftol,
+                step_size=float(step_size),
+                light_history=True,
+                resume_state_mode="full",
+            )
+            if int(tape.packed_states.shape[0]) > 0:
+                packed_final = jnp.asarray(tape.packed_states[-1], dtype=x0.dtype)
+            else:
+                packed_final = x0
+            token = _store_discrete_adjoint_payload(
+                {"tape": tape, "axis_override": axis_override, "x_free": jnp.asarray(xf)}
+            )
+            return packed_final, token
+
+        @jax.custom_vjp
+        def _packed_state_from_xfree(xf):
+            packed_final, _ = _forward_payload(xf)
+            return packed_final
+
+        def _packed_state_from_xfree_fwd(xf):
+            return _forward_payload(xf)
+
+        def _packed_state_from_xfree_bwd(token, cotangent):
+            token = int(token)
+            res = _DISCRETE_ADJOINT_PAYLOADS[token]
+            state_cotangent = vj.checkpoint_tape_state_vjp(
+                tape=res["tape"],
+                static=static,
+                final_cotangent=jnp.asarray(cotangent),
+                rebuild_preconditioner=True,
+            )
+
+            def _frozen_initial_state(xf):
+                return _initial_state_packed(xf, axis_override=res["axis_override"])
+
+            _, vjp_fun = jax.vjp(_frozen_initial_state, res["x_free"])
+            grad_x = vjp_fun(jnp.asarray(state_cotangent))[0]
+            _DISCRETE_ADJOINT_PAYLOADS.pop(token, None)
+            return (grad_x,)
+
+        _packed_state_from_xfree.defvjp(_packed_state_from_xfree_fwd, _packed_state_from_xfree_bwd)
+        packed_state = _packed_state_from_xfree(jnp.asarray(x_free))
+        return vj.unpack_state(packed_state, layout)
 
     def _x_cache_key(self, x_free) -> tuple[float, ...]:
         """Return a hashable cache key for concrete parameter vectors."""
@@ -768,8 +900,12 @@ class VmecJax:
             else float(self._indata_raw.get_float("DELT", 1.0))
         )
         solver = self._solver
+        use_residual_discrete_adjoint = (
+            solver in ("residual", "vmec2000") and self._residual_derivative_backend == "discrete_adjoint"
+        )
         use_residual_implicit_wrapper = (
             solver in ("residual", "vmec2000")
+            and not use_residual_discrete_adjoint
             and (
                 str(self._residual_adjoint_mode) != "auto"
                 or str(self._residual_tangent_mode) != "opaque"
@@ -778,6 +914,11 @@ class VmecJax:
 
         def _solve(solver: str):
             if solver in ("residual", "vmec2000"):
+                if use_residual_discrete_adjoint:
+                    return self._solve_state_discrete_adjoint_residual(
+                        x_free,
+                        step_size=residual_step_size,
+                    )
                 if x_key is None or use_residual_implicit_wrapper:
                     return solve_fixed_boundary_state_implicit_vmec_residual(
                         seed_state,

--- a/src/simsopt/mhd/vmec_jax.py
+++ b/src/simsopt/mhd/vmec_jax.py
@@ -13,7 +13,6 @@ implemented on top of `vmec_jax` with implicit differentiation.
 from __future__ import annotations
 
 from dataclasses import replace
-from itertools import count
 import re
 from typing import Sequence
 from types import SimpleNamespace
@@ -37,10 +36,6 @@ else:
 
 
 __all__ = ["VmecJax", "JaxBoundary"]
-
-
-_DISCRETE_ADJOINT_PAYLOADS: dict[int, dict] = {}
-_DISCRETE_ADJOINT_PAYLOAD_IDS = count()
 
 
 _OUTER_OPTIMIZATION_PROFILES = {
@@ -216,16 +211,6 @@ def _outer_optimization_profile(name: str | None) -> dict:
         return dict(_OUTER_OPTIMIZATION_PROFILES[key])
     except KeyError as exc:
         raise ValueError(f"Unknown VmecJax optimization profile: {name}") from exc
-
-
-def _store_discrete_adjoint_payload(payload: dict) -> int:
-    token = next(_DISCRETE_ADJOINT_PAYLOAD_IDS)
-    _DISCRETE_ADJOINT_PAYLOADS[token] = payload
-    if len(_DISCRETE_ADJOINT_PAYLOADS) > 32:
-        oldest = min(_DISCRETE_ADJOINT_PAYLOADS)
-        if oldest != token:
-            _DISCRETE_ADJOINT_PAYLOADS.pop(oldest, None)
-    return token
 
 
 class JaxBoundary:
@@ -808,38 +793,35 @@ class VmecJax:
                 packed_final = jnp.asarray(tape.packed_states[-1], dtype=x0.dtype)
             else:
                 packed_final = x0
-            token = _store_discrete_adjoint_payload(
-                {"tape": tape, "axis_override": axis_override, "x_free": jnp.asarray(xf)}
-            )
-            return packed_final, token
+            return packed_final, {"tape": tape, "axis_override": axis_override}
 
-        @jax.custom_vjp
+        @jax.custom_jvp
         def _packed_state_from_xfree(xf):
-            packed_final, _ = _forward_payload(xf)
+            packed_final, _payload = _forward_payload(xf)
             return packed_final
 
-        def _packed_state_from_xfree_fwd(xf):
-            return _forward_payload(xf)
+        @_packed_state_from_xfree.defjvp
+        def _packed_state_from_xfree_jvp(primals, tangents):
+            (xf,) = primals
+            (xf_tangent,) = tangents
+            packed_final, payload = _forward_payload(xf)
 
-        def _packed_state_from_xfree_bwd(token, cotangent):
-            token = int(token)
-            res = _DISCRETE_ADJOINT_PAYLOADS[token]
-            state_cotangent = vj.checkpoint_tape_state_vjp(
-                tape=res["tape"],
+            def _frozen_initial_state(x):
+                return _initial_state_packed(x, axis_override=payload["axis_override"])
+
+            _packed0, packed_tangent0 = jax.jvp(
+                _frozen_initial_state,
+                (jnp.asarray(xf),),
+                (jnp.asarray(xf_tangent),),
+            )
+            packed_tangent = vj.checkpoint_tape_state_jvp(
+                tape=payload["tape"],
                 static=static,
-                final_cotangent=jnp.asarray(cotangent),
+                initial_tangent=packed_tangent0,
                 rebuild_preconditioner=True,
             )
+            return packed_final, packed_tangent
 
-            def _frozen_initial_state(xf):
-                return _initial_state_packed(xf, axis_override=res["axis_override"])
-
-            _, vjp_fun = jax.vjp(_frozen_initial_state, res["x_free"])
-            grad_x = vjp_fun(jnp.asarray(state_cotangent))[0]
-            _DISCRETE_ADJOINT_PAYLOADS.pop(token, None)
-            return (grad_x,)
-
-        _packed_state_from_xfree.defvjp(_packed_state_from_xfree_fwd, _packed_state_from_xfree_bwd)
         packed_state = _packed_state_from_xfree(jnp.asarray(x_free))
         return vj.unpack_state(packed_state, layout)
 

--- a/src/simsopt/mhd/vmec_jax.py
+++ b/src/simsopt/mhd/vmec_jax.py
@@ -884,7 +884,6 @@ class VmecJax:
             id(residuals_from_state),
             int(x_free.size),
             int(layout.size),
-            int(len(payload["tape"].step_traces)),
         )
         helper_cache = self._discrete_jacobian_helper_cache.get(cache_key)
         if helper_cache is None:

--- a/src/simsopt/solve/__init__.py
+++ b/src/simsopt/solve/__init__.py
@@ -1,7 +1,8 @@
 from .serial import *
 from .mpi import *
+from .jax_solve import *
 from .permanent_magnet_optimization import *
 from .wireframe_optimization import *
 
 __all__ = (serial.__all__ + mpi.__all__ + permanent_magnet_optimization.__all__
-           + wireframe_optimization.__all__)
+           + jax_solve.__all__ + wireframe_optimization.__all__)

--- a/src/simsopt/solve/jax_solve.py
+++ b/src/simsopt/solve/jax_solve.py
@@ -463,6 +463,10 @@ def least_squares_jax_solve(
         jac_residual_y = jax.jacfwd(residuals_y_raw)
         if jit:
             jac_residual_y = jax.jit(jac_residual_y)
+    elif jac_mode in ("reverse", "rev", "jacrev"):
+        jac_residual_y = jax.jacrev(residuals_y_raw)
+        if jit:
+            jac_residual_y = jax.jit(jac_residual_y)
     elif jac_mode in ("fd", "finite_difference", "finite-difference", "2-point", "3-point"):
         fd_method = "forward" if jac_mode == "2-point" else "centered"
 
@@ -604,7 +608,9 @@ def least_squares_jax_solve(
             res = _scipy_least_squares(
                 residuals_numpy,
                 np.asarray(y0),
-                jac=jac_numpy if jac_scipy in ("jax", "auto", "fd", "finite_difference", "finite-difference", "2-point", "3-point") else jac_scipy,
+                jac=jac_numpy
+                if jac_scipy in ("jax", "auto", "reverse", "rev", "jacrev", "fd", "finite_difference", "finite-difference", "2-point", "3-point")
+                else jac_scipy,
                 max_nfev=int(max_nfev),
                 xtol=float(gtol),
                 ftol=float(gtol),

--- a/src/simsopt/solve/jax_solve.py
+++ b/src/simsopt/solve/jax_solve.py
@@ -1,0 +1,1027 @@
+# coding: utf-8
+# Copyright (c) HiddenSymmetries Development Team.
+# Distributed under the terms of the MIT License
+
+"""JAX-native least-squares solvers and fixed-resolution VMEC-JAX helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import re
+import time
+from types import SimpleNamespace
+from typing import Callable, Dict, Sequence
+
+import numpy as np
+
+try:
+    import jax
+    import jax.numpy as jnp
+except Exception as exc:  # pragma: no cover - optional dependency
+    jax = None
+    jnp = None
+    _import_error = exc
+else:
+    _import_error = None
+
+try:
+    import jaxopt  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    jaxopt = None
+
+try:
+    from scipy.optimize import least_squares as _scipy_least_squares  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    _scipy_least_squares = None
+
+__all__ = [
+    "least_squares_jax_solve",
+    "build_vmec_objective_stage",
+    "run_continuation_jax_solve",
+]
+
+
+@dataclass
+class VmecObjectiveStage:
+    x0: np.ndarray
+    x_scale: np.ndarray
+    residuals: Callable[[jnp.ndarray], jnp.ndarray]
+    free_names: list[str]
+    extras: dict
+
+
+def _require_jax():
+    """Raise a helpful error when the optional JAX dependency is unavailable."""
+    if jax is None or jnp is None:
+        raise ImportError(
+            "least_squares_jax_solve requires JAX. "
+            "Install jax/jaxlib before using this solver."
+        ) from _import_error
+
+
+def _normalize_scale(x0, x_scale):
+    """Return a nonzero parameter scaling vector in solver coordinates."""
+    if x_scale is None:
+        return jnp.ones_like(x0)
+    scale = jnp.asarray(x_scale, dtype=x0.dtype)
+    scale = jnp.where(scale == 0, jnp.ones_like(scale), scale)
+    return scale
+
+
+def _block_until_ready(value):
+    try:
+        return jax.block_until_ready(value)
+    except Exception:
+        return value
+
+
+def _sync_numpy(value):
+    value = _block_until_ready(value)
+    return np.asarray(value)
+
+
+def _safe_float(value) -> float:
+    arr = _sync_numpy(value)
+    if arr.shape == ():
+        return float(arr)
+    return float(np.asarray(arr).reshape(-1)[0])
+
+
+def _safe_int(value) -> int:
+    arr = _sync_numpy(value)
+    if arr.shape == ():
+        return int(arr)
+    return int(np.asarray(arr).reshape(-1)[0])
+
+
+def _tree_select(cond, true_value, false_value):
+    return jax.tree_util.tree_map(lambda a, b: jnp.where(cond, a, b), true_value, false_value)
+
+
+def _make_profile(enabled: bool):
+    if not enabled:
+        return None
+    return {
+        "residual_calls": 0,
+        "residual_wall_s": 0.0,
+        "jacobian_calls": 0,
+        "jacobian_wall_s": 0.0,
+        "objective_calls": 0,
+        "objective_wall_s": 0.0,
+        "value_and_grad_calls": 0,
+        "value_and_grad_wall_s": 0.0,
+        "normal_matvec_calls": 0,
+        "normal_matvec_wall_s": 0.0,
+        "line_search_calls": 0,
+        "line_search_wall_s": 0.0,
+        "fallback_trial_calls": 0,
+        "backtrack_trial_calls": 0,
+        "cauchy_step_calls": 0,
+    }
+
+
+def _profiled_call(profile, count_key: str, wall_key: str, fn, *args):
+    if profile is None:
+        return fn(*args)
+    start = time.perf_counter()
+    result = fn(*args)
+    _block_until_ready(result)
+    profile[count_key] += 1
+    profile[wall_key] += time.perf_counter() - start
+    return result
+
+
+def _deadline_from_limit(wall_clock_limit_s):
+    if wall_clock_limit_s is None:
+        return None
+    wall_clock_limit_s = float(wall_clock_limit_s)
+    if wall_clock_limit_s <= 0.0:
+        return None
+    return time.perf_counter() + wall_clock_limit_s
+
+
+def _deadline_exhausted(deadline) -> bool:
+    return deadline is not None and time.perf_counter() >= deadline
+
+
+def _remaining_wall_clock(deadline):
+    if deadline is None:
+        return None
+    return max(0.0, deadline - time.perf_counter())
+
+
+def _mode_weighted_x_scale(dof_names: Sequence[str], alpha=1.2, min_scale=1e-9):
+    x_scale = np.ones(len(dof_names), dtype=float)
+    pattern = re.compile(r"[rz][cs]\((\d+),(-?\d+)\)")
+    for index, name in enumerate(dof_names):
+        match = pattern.search(str(name))
+        if match is None:
+            continue
+        mode_level = max(abs(int(match.group(1))), abs(int(match.group(2))))
+        scale = math.exp(-alpha * mode_level) / math.exp(-alpha)
+        x_scale[index] = max(scale, min_scale)
+    return x_scale
+
+
+def _lift_free_params(previous_names, previous_x, next_names, next_x0):
+    previous_map = {str(name): float(value) for name, value in zip(previous_names, np.asarray(previous_x, dtype=float))}
+    lifted = np.asarray(next_x0, dtype=float).copy()
+    for index, name in enumerate(next_names):
+        if str(name) in previous_map:
+            lifted[index] = previous_map[str(name)]
+    return lifted
+
+
+def _directional_fd_epsilon(y, direction):
+    dtype = getattr(y, "dtype", jnp.float64)
+    eps = jnp.sqrt(jnp.asarray(np.finfo(np.float64).eps, dtype=dtype))
+    scale = jnp.maximum(1.0, jnp.linalg.norm(y))
+    direction_norm = jnp.maximum(1.0, jnp.linalg.norm(direction))
+    return eps * scale / direction_norm
+
+
+def _finite_difference_jacobian(fun, x, *, method: str, abs_step: float, rel_step: float):
+    x_np = np.asarray(x, dtype=float)
+    base_val = np.asarray(fun(jnp.asarray(x_np, dtype=jnp.float64)), dtype=float)
+    fd_jac = np.zeros((int(base_val.size), int(x_np.size)), dtype=float)
+    for index in range(int(x_np.size)):
+        step = max(float(abs_step), float(rel_step) * max(1.0, abs(float(x_np[index]))))
+        xp = np.array(x_np, copy=True)
+        xp[index] += step
+        fp = np.asarray(fun(jnp.asarray(xp, dtype=jnp.float64)), dtype=float)
+        if method == "centered":
+            xm = np.array(x_np, copy=True)
+            xm[index] -= step
+            fm = np.asarray(fun(jnp.asarray(xm, dtype=jnp.float64)), dtype=float)
+            fd_jac[:, index] = (fp - fm) / (2.0 * step)
+        else:
+            fd_jac[:, index] = (fp - base_val) / step
+    return fd_jac
+
+
+def _build_gradient_preconditioner(gradient, x_scale, spectral_scale=1.0):
+    grad = jnp.asarray(gradient)
+    scale = jnp.asarray(x_scale, dtype=grad.dtype)
+    scale = jnp.where(scale == 0.0, 1.0, scale)
+    diag = 1.0 / jnp.maximum(jnp.abs(grad) / scale + 1e-6, 1e-6)
+    return jnp.asarray(float(spectral_scale), dtype=grad.dtype) * diag
+
+
+def _boundary_intersection_norm(step, direction, trust_radius):
+    step_norm = float(jnp.linalg.norm(step))
+    if step_norm >= trust_radius:
+        return step, True
+    direction_norm = float(jnp.linalg.norm(direction))
+    if direction_norm == 0.0:
+        return step, False
+    remaining_sq = max(0.0, trust_radius * trust_radius - step_norm * step_norm)
+    dot_sd = float(jnp.dot(step, direction))
+    a = direction_norm * direction_norm
+    b = 2.0 * dot_sd
+    c = step_norm * step_norm - trust_radius * trust_radius
+    disc = max(0.0, b * b - 4.0 * a * c)
+    tau = (-b + math.sqrt(disc)) / (2.0 * a)
+    tau = max(0.0, tau)
+    return step + tau * direction, True
+
+
+def _scaled_cauchy_step(gradient, normal_matvec, trust_radius, *, h_direction=None, profile=None):
+    if profile is not None:
+        profile["cauchy_step_calls"] += 1
+    grad = jnp.asarray(gradient)
+    grad_norm = float(jnp.linalg.norm(grad))
+    if grad_norm == 0.0:
+        return {
+            "step": jnp.zeros_like(grad),
+            "predicted_reduction": 0.0,
+            "hit_boundary": False,
+            "h_direction": jnp.zeros_like(grad),
+        }
+    direction = -grad
+    h_direction = normal_matvec(direction) if h_direction is None else h_direction
+    curvature = float(jnp.dot(direction, h_direction))
+    if curvature <= 0.0:
+        alpha = trust_radius / grad_norm
+    else:
+        alpha = min((grad_norm * grad_norm) / curvature, trust_radius / grad_norm)
+    step = alpha * direction
+    predicted_reduction = max(0.0, alpha * grad_norm * grad_norm - 0.5 * alpha * alpha * curvature)
+    hit_boundary = abs(float(jnp.linalg.norm(step)) - trust_radius) <= 1e-12 or alpha == trust_radius / grad_norm
+    return {
+        "step": step,
+        "predicted_reduction": predicted_reduction,
+        "hit_boundary": hit_boundary,
+        "h_direction": h_direction,
+    }
+
+
+def _steihaug_trust_region_cg(gradient, normal_matvec, trust_radius, *, preconditioner=None, max_iter=20, tol=1e-4):
+    grad = jnp.asarray(gradient)
+    step = jnp.zeros_like(grad)
+    residual = -grad
+    if preconditioner is None:
+        z = residual
+    else:
+        z = residual * jnp.asarray(preconditioner)
+    direction = z
+    rz_old = float(jnp.dot(residual, z))
+    if rz_old <= 0.0:
+        return {
+            "step": step,
+            "predicted_reduction": 0.0,
+            "hit_boundary": False,
+            "iterations": 0,
+            "first_h_direction": jnp.zeros_like(grad),
+        }
+
+    first_h_direction = None
+    for iteration in range(int(max_iter)):
+        h_direction = normal_matvec(direction)
+        if first_h_direction is None:
+            first_h_direction = h_direction
+        curvature = float(jnp.dot(direction, h_direction))
+        if curvature <= 0.0:
+            boundary_step, _ = _boundary_intersection_norm(step, direction, trust_radius)
+            predicted = float(jnp.dot(-grad, boundary_step) - 0.5 * jnp.dot(boundary_step, normal_matvec(boundary_step)))
+            return {
+                "step": boundary_step,
+                "predicted_reduction": max(0.0, predicted),
+                "hit_boundary": True,
+                "iterations": iteration + 1,
+                "first_h_direction": first_h_direction,
+            }
+
+        alpha = rz_old / curvature
+        next_step = step + alpha * direction
+        if float(jnp.linalg.norm(next_step)) >= trust_radius:
+            boundary_step, _ = _boundary_intersection_norm(step, direction, trust_radius)
+            predicted = float(jnp.dot(-grad, boundary_step) - 0.5 * jnp.dot(boundary_step, normal_matvec(boundary_step)))
+            return {
+                "step": boundary_step,
+                "predicted_reduction": max(0.0, predicted),
+                "hit_boundary": True,
+                "iterations": iteration + 1,
+                "first_h_direction": first_h_direction,
+            }
+
+        step = next_step
+        residual = residual - alpha * h_direction
+        if float(jnp.linalg.norm(residual)) <= tol * max(1.0, float(jnp.linalg.norm(grad))):
+            predicted = float(jnp.dot(-grad, step) - 0.5 * jnp.dot(step, normal_matvec(step)))
+            return {
+                "step": step,
+                "predicted_reduction": max(0.0, predicted),
+                "hit_boundary": False,
+                "iterations": iteration + 1,
+                "first_h_direction": first_h_direction,
+            }
+
+        if preconditioner is None:
+            z = residual
+        else:
+            z = residual * jnp.asarray(preconditioner)
+        rz_new = float(jnp.dot(residual, z))
+        if rz_old == 0.0:
+            break
+        beta = rz_new / rz_old
+        direction = z + beta * direction
+        rz_old = rz_new
+
+    predicted = float(jnp.dot(-grad, step) - 0.5 * jnp.dot(step, normal_matvec(step)))
+    if first_h_direction is None:
+        first_h_direction = jnp.zeros_like(grad)
+    return {
+        "step": step,
+        "predicted_reduction": max(0.0, predicted),
+        "hit_boundary": False,
+        "iterations": int(max_iter),
+        "first_h_direction": first_h_direction,
+    }
+
+
+def build_vmec_objective_stage(
+    vmec,
+    *,
+    max_mode: int,
+    objective_tuples,
+    surfaces,
+    helicity_m: int,
+    helicity_n: int,
+    x_scale_alpha: float = 1.2,
+    x_scale_min: float = 1e-9,
+):
+    from simsopt.mhd import QuasisymmetryRatioResidualJax
+
+    vmec.indata.mpol = int(max_mode) + 2
+    vmec.indata.ntor = vmec.indata.mpol
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=int(max_mode), nmin=-int(max_mode), nmax=int(max_mode), fixed=False)
+    surf.fix("rc(0,0)")
+
+    free_names = [name for name, free in zip(surf.dof_names, surf.free) if free]
+    x0 = np.asarray(surf.get_free_params(), dtype=float)
+    x_scale = _mode_weighted_x_scale(free_names, alpha=x_scale_alpha, min_scale=x_scale_min)
+
+    qs = None
+    if any(str(name).strip().lower() == "qs" for name, _, _ in objective_tuples):
+        qs = QuasisymmetryRatioResidualJax(
+            vmec,
+            surfaces,
+            helicity_m=int(helicity_m),
+            helicity_n=int(helicity_n),
+        )
+
+    ensure_context = getattr(vmec, "_ensure_context", None)
+    if callable(ensure_context):
+        ensure_context()
+
+    def residuals(x_free):
+        x_free = jnp.asarray(x_free, dtype=jnp.float64)
+        state = vmec._solve_state(x_free)
+        blocks = []
+        for name, target, weight in objective_tuples:
+            key = str(name).strip().lower()
+            weight_value = float(weight)
+            if key == "aspect":
+                value = vmec.aspect_equilibrium_from_state_jax(state)
+                blocks.append(jnp.asarray([weight_value * (value - float(target))], dtype=jnp.float64))
+            elif key in ("mean_iota", "iota"):
+                value = vmec.mean_iota_from_state_jax(state)
+                blocks.append(jnp.asarray([weight_value * (value - float(target))], dtype=jnp.float64))
+            elif key == "qs":
+                if abs(float(target)) > 0.0:
+                    raise ValueError("The VMEC-JAX QS tuple currently expects target=0.0.")
+                blocks.append(weight_value * jnp.asarray(qs.residuals_from_state(state), dtype=jnp.float64))
+            else:
+                raise ValueError(f"Unsupported VMEC-JAX objective tuple name: {name}")
+        if not blocks:
+            return jnp.zeros((0,), dtype=jnp.float64)
+        return jnp.concatenate(blocks)
+
+    return VmecObjectiveStage(
+        x0=x0,
+        x_scale=np.asarray(x_scale, dtype=float),
+        residuals=residuals,
+        free_names=list(free_names),
+        extras={
+            "surf": surf,
+            "qs": qs,
+            "objective_tuples": list(objective_tuples),
+            "surfaces": np.asarray(surfaces, dtype=float),
+            "max_mode": int(max_mode),
+        },
+    )
+
+
+def least_squares_jax_solve(
+    residual_fun: Callable[[jnp.ndarray], jnp.ndarray],
+    x0,
+    *,
+    method: str = "scipy",
+    max_nfev: int = 50,
+    gtol: float = 1e-7,
+    step_size: float = 1e-2,
+    x_scale=None,
+    jit: bool = True,
+    verbose: int = 1,
+    jac: str | Callable | None = None,
+    profile: bool = False,
+    wall_clock_limit_s: float | None = None,
+) -> Dict[str, object]:
+    """Solve a nonlinear least-squares problem with JAX derivatives."""
+    _require_jax()
+
+    x0 = jnp.asarray(x0, dtype=jnp.float64)
+    scale = _normalize_scale(x0, x_scale)
+    y0 = x0 / scale
+    method = str(method).strip().lower()
+    profile_data = _make_profile(profile)
+    deadline = _deadline_from_limit(wall_clock_limit_s)
+
+    def residuals_y_raw(y):
+        return residual_fun(y * scale)
+
+    def objective_y_raw(y):
+        r = residuals_y_raw(y)
+        return 0.5 * jnp.sum(r * r)
+
+    def residuals_y(y):
+        return _profiled_call(profile_data, "residual_calls", "residual_wall_s", residuals_y_raw, y)
+
+    def objective_y(y):
+        return _profiled_call(profile_data, "objective_calls", "objective_wall_s", objective_y_raw, y)
+
+    def residual_cost_eval(y):
+        residual = residuals_y(y)
+        return 0.5 * jnp.sum(residual * residual), residual
+
+    jac_mode = "jax" if jac is None else str(jac).strip().lower()
+    if jac_mode in ("jax", "auto"):
+        jac_residual_y = jax.jacfwd(residuals_y_raw)
+        if jit:
+            jac_residual_y = jax.jit(jac_residual_y)
+    elif jac_mode in ("fd", "finite_difference", "finite-difference", "2-point", "3-point"):
+        fd_method = "forward" if jac_mode == "2-point" else "centered"
+
+        def jac_residual_y(y):
+            return _finite_difference_jacobian(
+                residuals_y_raw,
+                y,
+                method=fd_method,
+                abs_step=1e-6,
+                rel_step=1e-6,
+            )
+    else:
+        raise ValueError(f"Unsupported jac mode: {jac}")
+
+    def jacobian_y(y):
+        return _profiled_call(profile_data, "jacobian_calls", "jacobian_wall_s", jac_residual_y, y)
+
+    value_and_grad_y = jax.value_and_grad(objective_y_raw)
+    if jit:
+        value_and_grad_y = jax.jit(value_and_grad_y)
+
+    def profiled_value_and_grad(y):
+        return _profiled_call(profile_data, "value_and_grad_calls", "value_and_grad_wall_s", value_and_grad_y, y)
+
+    max_backtracking_trials = 12
+    trial_ids = jnp.arange(int(max_backtracking_trials), dtype=jnp.int32)
+
+    def _accept_by_backtracking_raw(y_in, cost_in, grad_in, direction_in, initial_step_in, c1_in):
+        dtype = y_in.dtype
+        step_norm_sq = jnp.dot(grad_in, direction_in)
+        initial_step_arr = jnp.asarray(initial_step_in, dtype=dtype)
+        c1_arr = jnp.asarray(c1_in, dtype=dtype)
+        init = (
+            y_in,
+            cost_in,
+            jnp.asarray(-1, dtype=jnp.int32),
+            y_in,
+            cost_in,
+            jnp.asarray(-1, dtype=jnp.int32),
+            jnp.asarray(False),
+            jnp.asarray(0, dtype=jnp.int32),
+        )
+
+        def body(carry, trial):
+            best_y, best_cost, best_idx, accepted_y, accepted_cost, accepted_idx, accepted, eval_count = carry
+
+            def skip(_):
+                return carry, jnp.asarray(0, dtype=jnp.int32)
+
+            def run_trial(_):
+                alpha = initial_step_arr * jnp.power(jnp.asarray(0.5, dtype=dtype), trial.astype(dtype))
+                trial_y = y_in + alpha * direction_in
+                trial_cost = objective_y_raw(trial_y)
+                improved = trial_cost < best_cost
+                new_best_y = _tree_select(improved, trial_y, best_y)
+                new_best_cost = jnp.where(improved, trial_cost, best_cost)
+                new_best_idx = jnp.where(improved, trial, best_idx)
+                armijo = trial_cost <= cost_in + c1_arr * alpha * step_norm_sq
+                take_trial = jnp.logical_and(~accepted, armijo)
+                new_accepted_y = _tree_select(take_trial, trial_y, accepted_y)
+                new_accepted_cost = jnp.where(take_trial, trial_cost, accepted_cost)
+                new_accepted_idx = jnp.where(take_trial, trial, accepted_idx)
+                new_accepted = jnp.logical_or(accepted, armijo)
+                new_carry = (
+                    new_best_y,
+                    new_best_cost,
+                    new_best_idx,
+                    new_accepted_y,
+                    new_accepted_cost,
+                    new_accepted_idx,
+                    new_accepted,
+                    eval_count + jnp.asarray(1, dtype=jnp.int32),
+                )
+                return new_carry, jnp.asarray(1, dtype=jnp.int32)
+
+            return jax.lax.cond(accepted, skip, run_trial, operand=None)
+
+        final_carry, _ = jax.lax.scan(body, init, trial_ids)
+        best_y, best_cost, best_idx, accepted_y, accepted_cost, accepted_idx, accepted, eval_count = final_carry
+        best_improves = best_cost < cost_in
+        result_y = _tree_select(accepted, accepted_y, best_y)
+        result_cost = jnp.where(accepted, accepted_cost, best_cost)
+        result_idx = jnp.where(accepted, accepted_idx, best_idx)
+        return result_y, result_cost, result_idx, jnp.logical_or(accepted, best_improves), eval_count
+
+    accept_by_backtracking_impl = jax.jit(_accept_by_backtracking_raw) if jit else _accept_by_backtracking_raw
+
+    def accept_by_backtracking(y, cost, grad, direction, *, initial_step=1.0, c1=1e-4, max_trials=12):
+        if int(max_trials) != int(max_backtracking_trials):
+            raise ValueError(f"accept_by_backtracking currently requires max_trials={max_backtracking_trials}")
+        start = time.perf_counter()
+        y_next, cost_next, trial_idx, accepted, eval_count = accept_by_backtracking_impl(
+            y,
+            jnp.asarray(cost, dtype=y.dtype),
+            grad,
+            direction,
+            jnp.asarray(float(initial_step), dtype=y.dtype),
+            jnp.asarray(float(c1), dtype=y.dtype),
+        )
+        _block_until_ready(cost_next)
+        if profile_data is not None:
+            profile_data["line_search_calls"] += _safe_int(eval_count)
+            profile_data["line_search_wall_s"] += time.perf_counter() - start
+        accepted_bool = bool(_safe_int(accepted))
+        trial_idx_int = _safe_int(trial_idx)
+        if trial_idx_int < 0:
+            step_label = "none"
+        elif trial_idx_int == 0:
+            step_label = "full"
+        else:
+            step_label = f"bt_{trial_idx_int}"
+        return y_next, cost_next, step_label, accepted_bool
+
+    status = 0
+    success = False
+    wall_clock_exhausted = False
+    nfev = 0
+    grad = jnp.zeros_like(y0)
+    y = y0
+    cost = jnp.asarray(0.0, dtype=y0.dtype)
+    step_description = None
+
+    if method in ("scipy", "least_squares"):
+        if _scipy_least_squares is None:
+            if jaxopt is not None:
+                method = "lbfgs"
+            else:
+                raise ImportError("scipy is required for method='scipy'.")
+        else:
+            jac_scipy = jac_mode
+            def residuals_numpy(y_np):
+                return np.asarray(residuals_y_raw(jnp.asarray(y_np)))
+
+            def jac_numpy(y_np):
+                J = jac_residual_y(jnp.asarray(y_np, dtype=y0.dtype))
+                return np.asarray(J)
+
+            verbose_scipy = 2 if verbose else 0
+            res = _scipy_least_squares(
+                residuals_numpy,
+                np.asarray(y0),
+                jac=jac_numpy if jac_scipy in ("jax", "auto", "fd", "finite_difference", "finite-difference", "2-point", "3-point") else jac_scipy,
+                max_nfev=int(max_nfev),
+                xtol=float(gtol),
+                ftol=float(gtol),
+                gtol=float(gtol),
+                verbose=verbose_scipy,
+            )
+            y = jnp.asarray(res.x, dtype=y0.dtype)
+            if res.jac is not None:
+                grad = jnp.asarray(res.jac.T @ res.fun, dtype=y0.dtype)
+            cost = jnp.asarray(0.5 * np.sum(res.fun * res.fun), dtype=y0.dtype)
+            nfev = int(res.nfev)
+            status = 1 if bool(res.success) else 0
+            success = status == 1
+    elif method == "lbfgs":
+        if jaxopt is None:
+            method = "gradient_descent"
+        else:
+            solver = jaxopt.LBFGS(fun=objective_y_raw, maxiter=int(max_nfev), tol=float(gtol))
+            result = solver.run(y0)
+            y = result.params
+            grad = result.state.grad
+            cost = objective_y(y)
+            nfev = int(result.state.iter_num)
+            status = 1 if float(result.state.error) <= float(gtol) else 0
+            success = status == 1
+
+    elif method == "gradient_descent":
+        y = y0
+        if int(max_nfev) <= 0 or _deadline_exhausted(deadline):
+            cost = objective_y(y)
+        for iteration in range(int(max_nfev)):
+            if _deadline_exhausted(deadline):
+                wall_clock_exhausted = True
+                status = 2
+                break
+            cost, grad = profiled_value_and_grad(y)
+            nfev = iteration + 1
+            grad_norm = float(jnp.linalg.norm(grad))
+            if verbose:
+                print(f"iter {iteration:3d}  cost={float(cost):.6e}  grad_norm={grad_norm:.3e}")
+            if grad_norm < float(gtol):
+                status = 1
+                success = True
+                break
+            direction = -grad
+            y_trial, cost_trial, step_description, accepted = accept_by_backtracking(
+                y,
+                cost,
+                grad,
+                direction,
+                initial_step=float(step_size),
+            )
+            if not accepted:
+                break
+            y = y_trial
+            cost = cost_trial
+    elif method == "gauss_newton":
+        y = y0
+        cost = objective_y(y)
+        for iteration in range(int(max_nfev)):
+            if _deadline_exhausted(deadline):
+                wall_clock_exhausted = True
+                status = 2
+                break
+            residual = residuals_y(y)
+            J = jacobian_y(y)
+            J_np = np.asarray(J)
+            residual_np = np.asarray(residual)
+            grad = jnp.asarray(J_np.T @ residual_np, dtype=y.dtype)
+            nfev = iteration + 1
+            grad_norm = float(jnp.linalg.norm(grad))
+            if verbose:
+                print(f"iter {iteration:3d}  cost={float(0.5 * np.dot(residual_np, residual_np)):.6e}  grad_norm={grad_norm:.3e}")
+            if grad_norm < float(gtol):
+                status = 1
+                success = True
+                cost = jnp.asarray(0.5 * np.dot(residual_np, residual_np), dtype=y.dtype)
+                break
+            step_np, *_ = np.linalg.lstsq(J_np, -residual_np, rcond=None)
+            direction = jnp.asarray(step_np, dtype=y.dtype)
+            cost_current = jnp.asarray(0.5 * np.dot(residual_np, residual_np), dtype=y.dtype)
+            y_trial, cost_trial, step_description, accepted = accept_by_backtracking(y, cost_current, grad, direction)
+            if not accepted:
+                break
+            y = y_trial
+            cost = cost_trial
+    elif method == "trust_region":
+        y = y0
+        cost = objective_y(y)
+        trust_radius = max(float(step_size), 1.0)
+        for iteration in range(int(max_nfev)):
+            if _deadline_exhausted(deadline):
+                wall_clock_exhausted = True
+                status = 2
+                break
+            residual = residuals_y(y)
+            J = jacobian_y(y)
+            J_np = np.asarray(J)
+            residual_np = np.asarray(residual)
+            grad_np = J_np.T @ residual_np
+            H_np = J_np.T @ J_np
+            grad = jnp.asarray(grad_np, dtype=y.dtype)
+            nfev = iteration + 1
+            grad_norm = float(np.linalg.norm(grad_np))
+            if grad_norm < float(gtol):
+                status = 1
+                success = True
+                cost = jnp.asarray(0.5 * np.dot(residual_np, residual_np), dtype=y.dtype)
+                break
+            try:
+                step_np = np.linalg.solve(H_np + 1e-10 * np.eye(H_np.shape[0]), -grad_np)
+            except np.linalg.LinAlgError:
+                step_np = -grad_np
+            step_norm = float(np.linalg.norm(step_np))
+            if step_norm > trust_radius and step_norm > 0.0:
+                step_np = step_np * (trust_radius / step_norm)
+            trial_y = y + jnp.asarray(step_np, dtype=y.dtype)
+            trial_cost = objective_y(trial_y)
+            predicted = max(1e-16, float(-grad_np @ step_np - 0.5 * step_np @ (H_np @ step_np)))
+            actual = float(0.5 * np.dot(residual_np, residual_np) - float(trial_cost))
+            ratio = actual / predicted
+            if verbose:
+                print(f"iter {iteration:3d}  cost={float(0.5 * np.dot(residual_np, residual_np)):.6e}  grad_norm={grad_norm:.3e}  tr_ratio={ratio:.3e}")
+            if ratio > 1e-4 and float(trial_cost) < float(0.5 * np.dot(residual_np, residual_np)):
+                y = trial_y
+                cost = trial_cost
+                step_description = "trust_region"
+                if ratio > 0.75:
+                    trust_radius *= 2.0
+            else:
+                trust_radius *= 0.5
+                if trust_radius < 1e-12:
+                    break
+    elif method == "levenberg_marquardt":
+        y = y0
+        cost = objective_y(y)
+        damping = max(float(step_size), 1e-6)
+        for iteration in range(int(max_nfev)):
+            if _deadline_exhausted(deadline):
+                wall_clock_exhausted = True
+                status = 2
+                break
+            residual = residuals_y(y)
+            J = jacobian_y(y)
+            J_np = np.asarray(J)
+            residual_np = np.asarray(residual)
+            grad_np = J_np.T @ residual_np
+            H_np = J_np.T @ J_np
+            grad = jnp.asarray(grad_np, dtype=y.dtype)
+            nfev = iteration + 1
+            grad_norm = float(np.linalg.norm(grad_np))
+            cost_current = float(0.5 * np.dot(residual_np, residual_np))
+            if verbose:
+                print(f"iter {iteration:3d}  cost={cost_current:.6e}  grad_norm={grad_norm:.3e}  damping={damping:.3e}")
+            if grad_norm < float(gtol):
+                status = 1
+                success = True
+                cost = jnp.asarray(cost_current, dtype=y.dtype)
+                break
+            accepted = False
+            for _ in range(8):
+                if _deadline_exhausted(deadline):
+                    wall_clock_exhausted = True
+                    status = 2
+                    break
+                try:
+                    step_np = np.linalg.solve(H_np + damping * np.eye(H_np.shape[0]), -grad_np)
+                except np.linalg.LinAlgError:
+                    step_np = -grad_np / max(damping, 1.0)
+                trial_y = y + jnp.asarray(step_np, dtype=y.dtype)
+                trial_cost = objective_y(trial_y)
+                if float(trial_cost) < cost_current:
+                    y = trial_y
+                    cost = trial_cost
+                    damping = max(damping * 0.3, 1e-8)
+                    step_description = "lm"
+                    accepted = True
+                    break
+                damping = min(damping * 10.0, 1e8)
+            if status == 2 or not accepted:
+                break
+    elif method == "truncated_gauss_newton":
+        y = y0
+        cost = objective_y(y)
+        trust_radius = max(float(step_size), 1.0)
+        damping = 1e-6
+        previous_y = None
+        previous_grad = None
+        spectral_scale = 1.0
+        for iteration in range(int(max_nfev)):
+            if _deadline_exhausted(deadline):
+                wall_clock_exhausted = True
+                status = 2
+                break
+            residual = residuals_y(y)
+            _, vjp_fun = jax.vjp(residuals_y_raw, y)
+            grad = vjp_fun(residual)[0]
+            grad_norm = float(jnp.linalg.norm(grad))
+            nfev = iteration + 1
+            if previous_y is not None and previous_grad is not None:
+                s = y - previous_y
+                z = grad - previous_grad
+                denom = float(jnp.dot(s, z))
+                if denom > 0.0:
+                    spectral_scale = float(np.clip(float(jnp.dot(s, s)) / denom, 1e-3, 1e3))
+            M = _build_gradient_preconditioner(grad, scale, spectral_scale=spectral_scale)
+
+            def normal_matvec(direction):
+                direction = jnp.asarray(direction)
+                epsilon = _directional_fd_epsilon(y, direction)
+                start = time.perf_counter()
+                residual_plus = residuals_y(y + epsilon * direction)
+                residual_minus = residuals_y(y - epsilon * direction)
+                jv = (residual_plus - residual_minus) / (2.0 * epsilon)
+                value = vjp_fun(jv)[0] + damping * direction
+                if profile_data is not None:
+                    profile_data["normal_matvec_calls"] += 1
+                    profile_data["normal_matvec_wall_s"] += time.perf_counter() - start
+                return value
+
+            if verbose:
+                print(
+                    f"iter {iteration:3d}  cost={float(0.5 * jnp.sum(residual * residual)):.6e}  "
+                    f"grad_norm={grad_norm:.3e}  trust_radius={trust_radius:.3e}  spectral_M={spectral_scale:.3e}"
+                )
+            if grad_norm < float(gtol):
+                status = 1
+                success = True
+                cost = 0.5 * jnp.sum(residual * residual)
+                break
+
+            cg_info = _steihaug_trust_region_cg(
+                grad,
+                normal_matvec,
+                trust_radius,
+                preconditioner=M,
+                max_iter=min(20, max(5, int(grad.shape[0]))),
+                tol=1e-3,
+            )
+            cauchy_info = _scaled_cauchy_step(
+                grad,
+                normal_matvec,
+                trust_radius,
+                h_direction=cg_info.get("first_h_direction"),
+                profile=profile_data,
+            )
+
+            choose_cauchy = (
+                cauchy_info["predicted_reduction"] > 0.0
+                and cg_info["hit_boundary"]
+                and cauchy_info["predicted_reduction"] >= 0.9 * max(cg_info["predicted_reduction"], 1e-16)
+            )
+            trial_info = cauchy_info if choose_cauchy else cg_info
+            step_label = "cauchy" if choose_cauchy else "cg"
+            trial_step = trial_info["step"]
+            trial_predicted = max(float(trial_info["predicted_reduction"]), 1e-16)
+            base_cost = float(0.5 * jnp.sum(residual * residual))
+
+            trial_y = y + trial_step
+            if _deadline_exhausted(deadline):
+                wall_clock_exhausted = True
+                status = 2
+                break
+            trial_cost, _ = residual_cost_eval(trial_y)
+            actual = base_cost - float(trial_cost)
+            ratio = actual / trial_predicted
+
+            if float(trial_cost) >= base_cost:
+                scales = (0.125, 0.25, 0.5) if bool(trial_info.get("hit_boundary")) else (0.5, 0.25, 0.125)
+                accepted = False
+                for scale_factor in scales:
+                    if _deadline_exhausted(deadline):
+                        wall_clock_exhausted = True
+                        status = 2
+                        break
+                    if profile_data is not None:
+                        profile_data["backtrack_trial_calls"] += 1
+                    scaled_step = float(scale_factor) * trial_step
+                    scaled_cost, _ = residual_cost_eval(y + scaled_step)
+                    if float(scaled_cost) < base_cost:
+                        trial_step = scaled_step
+                        trial_cost = scaled_cost
+                        actual = base_cost - float(trial_cost)
+                        ratio = actual / trial_predicted
+                        step_label += "_bt"
+                        accepted = True
+                        break
+                if not accepted and status != 2:
+                    trust_radius *= 0.5
+                    if choose_cauchy:
+                        step_description = "cauchy_rejected"
+                    else:
+                        step_description = "cg_rejected"
+                    continue
+
+            if ratio > 1e-4 and float(trial_cost) < base_cost:
+                previous_y = y
+                previous_grad = grad
+                y = y + trial_step
+                cost = trial_cost
+                step_description = step_label
+                if ratio > 0.75:
+                    trust_radius = max(trust_radius, 2.0 * float(jnp.linalg.norm(trial_step)))
+                elif ratio < 0.25:
+                    trust_radius *= 0.5
+            else:
+                trust_radius *= 0.5
+                step_description = f"{step_label}_rejected"
+                if trust_radius < 1e-12:
+                    break
+    else:
+        raise ValueError(
+            "method must be one of 'scipy', 'lbfgs', 'gradient_descent', 'gauss_newton', "
+            "'trust_region', 'levenberg_marquardt', or 'truncated_gauss_newton'"
+        )
+
+    if status == 0 and _deadline_exhausted(deadline):
+        status = 2
+        wall_clock_exhausted = True
+
+    x_opt = np.asarray(y * scale)
+    return {
+        "x": x_opt,
+        "status": int(status),
+        "success": bool(success),
+        "nfev": int(nfev),
+        "cost": float(cost),
+        "grad": np.asarray(grad),
+        "profile": profile_data,
+        "wall_clock_exhausted": bool(wall_clock_exhausted),
+        "step": step_description,
+    }
+
+
+def run_continuation_jax_solve(
+    stage_builder: Callable[[int], VmecObjectiveStage],
+    continuation_modes,
+    *,
+    method: str = "gradient_descent",
+    max_nfev: int = 50,
+    gtol: float = 1e-7,
+    step_size: float = 1e-2,
+    jit: bool = True,
+    verbose: int = 1,
+    jac: str | Callable | None = None,
+    profile: bool = False,
+    wall_clock_limit_s: float | None = None,
+):
+    continuation_modes = [int(mode) for mode in continuation_modes]
+    if not continuation_modes:
+        raise ValueError("continuation_modes must contain at least one stage")
+
+    deadline = _deadline_from_limit(wall_clock_limit_s)
+    stage_results = []
+    current_x = None
+    current_names = None
+    last_result = None
+    last_mode = None
+
+    for mode in continuation_modes:
+        if _deadline_exhausted(deadline):
+            break
+        stage = stage_builder(mode)
+        x0 = np.asarray(stage.x0, dtype=float)
+        if current_x is not None and current_names is not None:
+            x0 = _lift_free_params(current_names, current_x, stage.free_names, x0)
+            stage.extras["surf"].set_free_params(x0)
+        remaining = _remaining_wall_clock(deadline)
+        result = least_squares_jax_solve(
+            stage.residuals,
+            x0,
+            method=method,
+            max_nfev=max_nfev,
+            gtol=gtol,
+            step_size=step_size,
+            x_scale=stage.x_scale,
+            jit=jit,
+            verbose=verbose,
+            jac=jac,
+            profile=profile,
+            wall_clock_limit_s=remaining,
+        )
+        stage_results.append({"mode": mode, "result": result})
+        current_x = np.asarray(result["x"], dtype=float)
+        current_names = list(stage.free_names)
+        last_result = result
+        last_mode = mode
+        if result.get("status") == 2:
+            break
+
+    final_mode = continuation_modes[-1]
+    if current_x is None:
+        final_stage = stage_builder(final_mode)
+        current_x = np.asarray(final_stage.x0, dtype=float)
+        current_names = list(final_stage.free_names)
+        last_result = {
+            "x": current_x,
+            "status": 2 if _deadline_exhausted(deadline) else 0,
+            "success": False,
+            "nfev": 0,
+            "cost": float(np.sum(np.asarray(final_stage.residuals(current_x)) ** 2) / 2.0),
+            "grad": np.zeros_like(current_x),
+            "profile": None,
+            "wall_clock_exhausted": bool(_deadline_exhausted(deadline)),
+            "step": None,
+        }
+    elif last_mode != final_mode:
+        final_stage = stage_builder(final_mode)
+        current_x = _lift_free_params(current_names, current_x, final_stage.free_names, final_stage.x0)
+        current_names = list(final_stage.free_names)
+        last_result = dict(last_result)
+        last_result["x"] = np.asarray(current_x, dtype=float)
+        last_result["wall_clock_exhausted"] = True
+        if last_result.get("status", 0) == 0:
+            last_result["status"] = 2
+
+    return {
+        "stage_results": stage_results,
+        "result": last_result,
+    }

--- a/src/simsopt/solve/jax_solve.py
+++ b/src/simsopt/solve/jax_solve.py
@@ -405,9 +405,20 @@ def build_vmec_objective_stage(
         return residuals_from_state(state)
 
     if getattr(vmec, "_residual_derivative_backend", None) == "discrete_adjoint":
+        residual_step_size = (
+            float(vmec._step_size_override)
+            if getattr(vmec, "_step_size_override", None) is not None
+            else float(vmec._indata_raw.get_float("DELT", 1.0))
+        )
+
+        def scipy_residuals(x_free):
+            state = vmec._solve_state_residual_forward(x_free, step_size=residual_step_size)
+            return np.asarray(residuals_from_state(state), dtype=float)
+
         def scipy_jacobian(x_free):
             return vmec._discrete_adjoint_residual_jacobian(x_free, residuals_from_state)
 
+        residuals.scipy_residuals = scipy_residuals
         residuals.scipy_jacobian = scipy_jacobian
 
     return VmecObjectiveStage(
@@ -607,7 +618,10 @@ def least_squares_jax_solve(
         else:
             jac_scipy = jac_mode
             scipy_jacobian_override = getattr(residual_fun, "scipy_jacobian", None)
+            scipy_residuals_override = getattr(residual_fun, "scipy_residuals", None)
             def residuals_numpy(y_np):
+                if callable(scipy_residuals_override):
+                    return np.asarray(scipy_residuals_override(jnp.asarray(y_np, dtype=y0.dtype) * scale))
                 return np.asarray(residuals_y_raw(jnp.asarray(y_np)))
 
             def jac_numpy(y_np):

--- a/src/simsopt/solve/jax_solve.py
+++ b/src/simsopt/solve/jax_solve.py
@@ -410,12 +410,48 @@ def build_vmec_objective_stage(
             if getattr(vmec, "_step_size_override", None) is not None
             else float(vmec._indata_raw.get_float("DELT", 1.0))
         )
+        scipy_callback_cache = {
+            "x_key": None,
+            "state": None,
+            "payload": None,
+            "residual": None,
+        }
+
+        def _clear_scipy_callback_cache():
+            scipy_callback_cache["x_key"] = None
+            scipy_callback_cache["state"] = None
+            scipy_callback_cache["payload"] = None
+            scipy_callback_cache["residual"] = None
+
+        def _solve_exact_payload(x_free):
+            state, payload = vmec._solve_state_discrete_adjoint_residual(
+                x_free,
+                step_size=residual_step_size,
+                return_payload=True,
+            )
+            residual = np.asarray(residuals_from_state(state), dtype=float)
+            scipy_callback_cache["x_key"] = vmec._x_cache_key(x_free)
+            scipy_callback_cache["state"] = state
+            scipy_callback_cache["payload"] = payload
+            scipy_callback_cache["residual"] = residual
+            return residual
 
         def scipy_residuals(x_free):
-            state = vmec._solve_state_residual_forward(x_free, step_size=residual_step_size)
-            return np.asarray(residuals_from_state(state), dtype=float)
+            x_key = vmec._x_cache_key(x_free)
+            if x_key is not None and scipy_callback_cache["x_key"] == x_key and scipy_callback_cache["residual"] is not None:
+                return scipy_callback_cache["residual"]
+            return _solve_exact_payload(x_free)
 
         def scipy_jacobian(x_free):
+            x_key = vmec._x_cache_key(x_free)
+            if x_key is not None and scipy_callback_cache["x_key"] == x_key and scipy_callback_cache["payload"] is not None:
+                return vmec._discrete_adjoint_residual_jacobian(
+                    x_free,
+                    residuals_from_state,
+                    state=scipy_callback_cache["state"],
+                    payload=scipy_callback_cache["payload"],
+                )
+            _clear_scipy_callback_cache()
             return vmec._discrete_adjoint_residual_jacobian(x_free, residuals_from_state)
 
         residuals.scipy_residuals = scipy_residuals

--- a/src/simsopt/solve/jax_solve.py
+++ b/src/simsopt/solve/jax_solve.py
@@ -465,6 +465,7 @@ def build_vmec_objective_stage(
         extras={
             "surf": surf,
             "qs": qs,
+            "residuals_from_state": residuals_from_state,
             "objective_tuples": list(objective_tuples),
             "surfaces": np.asarray(surfaces, dtype=float),
             "max_mode": int(max_mode),

--- a/src/simsopt/solve/jax_solve.py
+++ b/src/simsopt/solve/jax_solve.py
@@ -378,9 +378,7 @@ def build_vmec_objective_stage(
     if callable(ensure_context):
         ensure_context()
 
-    def residuals(x_free):
-        x_free = jnp.asarray(x_free, dtype=jnp.float64)
-        state = vmec._solve_state(x_free)
+    def residuals_from_state(state):
         blocks = []
         for name, target, weight in objective_tuples:
             key = str(name).strip().lower()
@@ -400,6 +398,17 @@ def build_vmec_objective_stage(
         if not blocks:
             return jnp.zeros((0,), dtype=jnp.float64)
         return jnp.concatenate(blocks)
+
+    def residuals(x_free):
+        x_free = jnp.asarray(x_free, dtype=jnp.float64)
+        state = vmec._solve_state(x_free)
+        return residuals_from_state(state)
+
+    if getattr(vmec, "_residual_derivative_backend", None) == "discrete_adjoint":
+        def scipy_jacobian(x_free):
+            return vmec._discrete_adjoint_residual_jacobian(x_free, residuals_from_state)
+
+        residuals.scipy_jacobian = scipy_jacobian
 
     return VmecObjectiveStage(
         x0=x0,
@@ -597,10 +606,14 @@ def least_squares_jax_solve(
                 raise ImportError("scipy is required for method='scipy'.")
         else:
             jac_scipy = jac_mode
+            scipy_jacobian_override = getattr(residual_fun, "scipy_jacobian", None)
             def residuals_numpy(y_np):
                 return np.asarray(residuals_y_raw(jnp.asarray(y_np)))
 
             def jac_numpy(y_np):
+                if callable(scipy_jacobian_override) and jac_scipy in ("jax", "auto"):
+                    J = scipy_jacobian_override(jnp.asarray(y_np, dtype=y0.dtype) * scale)
+                    return np.asarray(J) * np.asarray(scale, dtype=float)[None, :]
                 J = jac_residual_y(jnp.asarray(y_np, dtype=y0.dtype))
                 return np.asarray(J)
 

--- a/src/simsopt/solve/jax_solve.py
+++ b/src/simsopt/solve/jax_solve.py
@@ -454,8 +454,19 @@ def build_vmec_objective_stage(
             _clear_scipy_callback_cache()
             return vmec._discrete_adjoint_residual_jacobian(x_free, residuals_from_state)
 
+        def scipy_state_payload(x_free):
+            x_key = vmec._x_cache_key(x_free)
+            if x_key is None or scipy_callback_cache["x_key"] != x_key or scipy_callback_cache["state"] is None:
+                _solve_exact_payload(x_free)
+            return (
+                scipy_callback_cache["state"],
+                scipy_callback_cache["payload"],
+                scipy_callback_cache["residual"],
+            )
+
         residuals.scipy_residuals = scipy_residuals
         residuals.scipy_jacobian = scipy_jacobian
+        residuals.scipy_state_payload = scipy_state_payload
 
     return VmecObjectiveStage(
         x0=x0,

--- a/tests/mhd/test_vmec_diagnostics_jax.py
+++ b/tests/mhd/test_vmec_diagnostics_jax.py
@@ -1,0 +1,102 @@
+import os
+import tempfile
+import unittest
+from contextlib import contextmanager
+
+import numpy as np
+import jax.numpy as jnp
+
+try:
+    import vmec_jax as vj  # noqa: F401
+except Exception as exc:
+    raise unittest.SkipTest(f"vmec_jax not installed: {exc}")
+
+try:
+    import vmec as vmec_mod  # noqa: F401
+except Exception:
+    vmec_mod = None
+
+from simsopt.mhd import (
+    Vmec,
+    VmecJax,
+    QuasisymmetryRatioResidual,
+    QuasisymmetryRatioResidualJax,
+    quasisymmetry_ratio_residual_from_wout_jax,
+)
+
+
+@contextmanager
+def _temporary_cwd():
+    """Run a test inside a temporary working directory."""
+    cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        try:
+            yield tmpdir
+        finally:
+            os.chdir(cwd)
+
+
+def _input_filename():
+    filename = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "examples",
+        "2_Intermediate",
+        "inputs",
+        "input.nfp4_QH_warm_start",
+    )
+    return os.path.abspath(filename)
+
+
+@unittest.skipIf(vmec_mod is None, "vmec not installed")
+def test_qs_ratio_residual_jax_matches_classic_formula():
+    with _temporary_cwd():
+        filename = _input_filename()
+        surfaces = [0.25, 0.5, 0.75]
+
+        vmec = Vmec(filename, verbose=False)
+        vmec.indata.mpol = 3
+        vmec.indata.ntor = 3
+
+        qs_ref = QuasisymmetryRatioResidual(
+            vmec,
+            surfaces,
+            helicity_m=1,
+            helicity_n=-1,
+            ntheta=17,
+            nphi=18,
+        )
+        residuals_ref = qs_ref.residuals()
+        total_ref = qs_ref.total()
+
+        calc = quasisymmetry_ratio_residual_from_wout_jax(
+            vmec.wout,
+            surfaces=surfaces,
+            helicity_m=1,
+            helicity_n=-1,
+            ntheta=17,
+            nphi=18,
+        )
+
+        np.testing.assert_allclose(np.asarray(calc["residuals1d"]), np.asarray(residuals_ref), rtol=1e-10, atol=1e-12)
+        np.testing.assert_allclose(np.asarray(calc["total"]), np.asarray(total_ref), rtol=1e-10, atol=1e-12)
+
+
+def test_qs_ratio_residual_jax_wrapper_matches_wout_path():
+    filename = _input_filename()
+    vmec = VmecJax(filename, verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    vmec.set_solver_options(solver="gd", warm_start_iters=0, max_iter=5, grad_tol=1e-2)
+
+    surf = vmec.boundary
+    x0 = surf.get_free_params()
+    state = vmec._solve_state(jnp.asarray(x0))
+
+    qs = QuasisymmetryRatioResidualJax(vmec, [0.25, 0.5, 0.75], helicity_m=1, helicity_n=-1, ntheta=17, nphi=18)
+    total_from_state = qs.total_from_state(state)
+    total_from_wout = qs.total_from_wout(vmec.get_wout_from_state(state))
+
+    np.testing.assert_allclose(np.asarray(total_from_state), np.asarray(total_from_wout), rtol=1e-12, atol=1e-12)

--- a/tests/mhd/test_vmec_jax_wrapper.py
+++ b/tests/mhd/test_vmec_jax_wrapper.py
@@ -1,0 +1,386 @@
+import os
+import tempfile
+import unittest
+from contextlib import contextmanager
+
+import numpy as np
+import jax
+
+try:
+    import vmec_jax as vj
+except Exception as exc:
+    raise unittest.SkipTest(f"vmec_jax not installed: {exc}")
+
+try:
+    import vmec as vmec_mod  # noqa: F401
+except Exception:
+    vmec_mod = None
+
+from vmec_jax.implicit import _pack_stellsym_feasible_state, _stellsym_feasible_indices
+from vmec_jax.solve import _mask_grad_for_constraints, _mode00_index
+
+from simsopt.mhd import VmecJax
+from simsopt.mhd import Vmec
+from simsopt.solve import build_vmec_objective_stage
+
+
+@contextmanager
+def _temporary_cwd():
+    """Run a test inside a temporary working directory."""
+    cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        try:
+            yield tmpdir
+        finally:
+            os.chdir(cwd)
+
+
+def _input_filename():
+    filename = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "examples",
+        "2_Intermediate",
+        "inputs",
+        "input.nfp4_QH_warm_start",
+    )
+    return os.path.abspath(filename)
+
+
+def test_vmec_jax_lazy_static_and_context():
+    vmec = VmecJax(_input_filename(), verbose=False)
+
+    assert vmec._static is None
+    assert vmec._context is None
+    assert vmec._static_dirty
+    assert vmec._context_dirty
+
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+
+    assert vmec._static is None
+    assert vmec._context is None
+    assert vmec._static_dirty
+    assert vmec._context_dirty
+
+    boundary = vmec.boundary
+    assert boundary is vmec._boundary
+    assert vmec._static is not None
+    assert vmec._context is None
+    assert not vmec._static_dirty
+    assert vmec._context_dirty
+
+
+def test_vmec_jax_resolution_change_preserves_matching_dofs():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.unfix("rc(0,1)")
+    x_before = surf.x
+    free_before = surf.free
+
+    vmec.indata.mpol = 4
+    vmec.indata.ntor = 4
+    surf2 = vmec.boundary
+
+    idx = surf2.dof_names.index("rc(0,1)")
+    assert surf2.free[idx] == free_before[surf.dof_names.index("rc(0,1)")]
+    np.testing.assert_allclose(surf2.x[idx], x_before[surf.dof_names.index("rc(0,1)")])
+
+
+def test_vmec_jax_solver_option_change_invalidates_cache():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    _ = vmec.boundary
+
+    vmec._cached_x = (1.0,)
+    vmec._cached_state = object()
+    vmec._cached_wout = object()
+    vmec._cached_run = object()
+
+    vmec.set_solver_options(max_iter=123, implicit_cg_tol=1.0e-8, step_size=1.0e-2)
+
+    assert vmec._cached_x is None
+    assert vmec._cached_state is None
+    assert vmec._cached_wout is None
+    assert vmec._cached_run is None
+
+
+def test_vmec_jax_defaults_honor_staged_input_controls():
+    vmec = VmecJax(_input_filename(), verbose=False)
+
+    assert vmec._max_iter == 1500
+    np.testing.assert_allclose(vmec._grad_tol, 1.0e-13)
+    assert vmec._warm_start_iters == 0
+
+
+def test_vmec_jax_qh_profile_applies_outer_optimization_defaults():
+    vmec = VmecJax(_input_filename(), verbose=False)
+
+    vmec.use_residual_autodiff_defaults(
+        outer_method="gradient_descent",
+        optimization_profile="qh",
+    )
+
+    assert vmec._solver == "vmec2000"
+    assert vmec._max_iter == 1500
+    np.testing.assert_allclose(vmec._grad_tol, 1.0e-13)
+    assert vmec._residual_adjoint_mode == "chunked"
+    assert vmec._residual_tangent_mode == "opaque"
+    assert not vmec._stateless_evaluations
+
+
+def test_vmec_jax_wrapper_keeps_unconstrained_boundary_coefficients():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+
+    static = vmec.get_static()
+    boundary = vmec.boundary._boundary0
+    boundary_expected = vj.boundary_from_indata(vmec._indata_raw, static.modes, apply_m1_constraint=False)
+    boundary_wrong = vj.boundary_from_indata(vmec._indata_raw, static.modes, apply_m1_constraint=True)
+
+    np.testing.assert_allclose(np.asarray(boundary.R_cos), np.asarray(boundary_expected.R_cos))
+    np.testing.assert_allclose(np.asarray(boundary.Z_sin), np.asarray(boundary_expected.Z_sin))
+    assert not np.allclose(np.asarray(boundary.R_cos), np.asarray(boundary_wrong.R_cos))
+    assert not np.allclose(np.asarray(boundary.Z_sin), np.asarray(boundary_wrong.Z_sin))
+
+
+@unittest.skipIf(vmec_mod is None, "vmec not installed")
+def test_vmec_jax_wrapper_initial_guess_has_correct_qh_iota_sign():
+    from vmec_jax.driver import _final_flux_profiles_from_state
+
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+
+    static = vmec.get_static()
+    boundary = vmec.boundary._boundary0
+    st = vj.initial_guess_from_boundary(static, boundary, vmec._indata_raw, vmec_project=True)
+    geom = vj.eval_geom(st, static)
+    signgs = int(vj.signgs_from_sqrtg(np.asarray(geom.sqrtg), axis_index=1))
+    flux = vj.flux_profiles_from_indata(vmec._indata_raw, static.s, signgs=signgs)
+    s_half = np.concatenate([np.asarray(static.s)[:1], 0.5 * (np.asarray(static.s)[1:] + np.asarray(static.s)[:-1])])
+    prof = vj.eval_profiles(vmec._indata_raw, s_half)
+    pressure = np.asarray(prof.get("pressure", np.zeros_like(s_half)))
+    _, prof_out = _final_flux_profiles_from_state(
+        indata=vmec._indata_raw,
+        static_in=static,
+        state=st,
+        signgs=signgs,
+        flux_local=flux,
+        prof_local=prof,
+        pressure_local=pressure,
+    )
+
+    iota = np.asarray(prof_out["iota"])
+    assert iota[1] < 0.0
+
+
+def test_vmec_jax_context_uses_plain_initial_guess_by_default():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+
+    static = vmec.get_static()
+    boundary = vmec.boundary._boundary0
+    expected = vj.initial_guess_from_boundary(static, boundary, vmec._indata_raw, vmec_project=True)
+    context = vmec.get_context()
+
+    np.testing.assert_allclose(np.asarray(context.st_guess.Rcos), np.asarray(expected.Rcos))
+    np.testing.assert_allclose(np.asarray(context.st_guess.Zsin), np.asarray(expected.Zsin))
+    np.testing.assert_allclose(np.asarray(context.st_guess.Lsin), np.asarray(expected.Lsin))
+
+
+def test_vmec_jax_solver_option_change_resets_warm_start_seed():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+
+    context = vmec.get_context()
+    seed_before = np.asarray(context.st_guess.Rcos)
+    context.st_guess = vj.initial_guess_from_boundary(vmec.get_static(), vmec.boundary._boundary0, vmec._indata_raw, vmec_project=False)
+
+    vmec.set_solver_options(max_iter=123)
+
+    np.testing.assert_allclose(np.asarray(vmec.get_context().st_guess.Rcos), seed_before)
+
+
+def test_vmec_jax_aspect_jax_is_jittable_for_qh_setup():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=1, nmin=-1, nmax=1, fixed=False)
+    surf.fix("rc(0,0)")
+    x0 = jax.numpy.asarray(surf.get_free_params())
+
+    aspect = jax.jit(vmec.aspect_jax)(x0)
+    assert np.isfinite(float(np.asarray(aspect)))
+
+
+def test_vmec_jax_qh_start_objective_matches_converged_control_path():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=1, nmin=-1, nmax=1, fixed=False)
+    surf.fix("rc(0,0)")
+
+    stage = build_vmec_objective_stage(
+        vmec,
+        max_mode=1,
+        objective_tuples=[("aspect", 7.0, 1.0), ("qs", 0.0, 1.0)],
+        surfaces=np.arange(0, 1.01, 0.1),
+        helicity_m=1,
+        helicity_n=-1,
+        x_scale_alpha=1.2,
+        x_scale_min=1e-9,
+    )
+    x0 = jax.numpy.asarray(stage.x0, dtype=jax.numpy.float64)
+    residual = np.asarray(stage.residuals(x0))
+    objective = float(np.sum(residual * residual))
+
+    np.testing.assert_allclose(objective, 0.2983122217172473, rtol=0.0, atol=1.0e-12)
+
+
+def test_vmec_jax_qh_qs_state_gradient_is_finite():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=1, nmin=-1, nmax=1, fixed=False)
+    surf.fix("rc(0,0)")
+
+    stage = build_vmec_objective_stage(
+        vmec,
+        max_mode=1,
+        objective_tuples=[("aspect", 7.0, 1.0), ("qs", 0.0, 1.0)],
+        surfaces=np.arange(0, 1.01, 0.1),
+        helicity_m=1,
+        helicity_n=-1,
+        x_scale_alpha=1.2,
+        x_scale_min=1e-9,
+    )
+    state = vmec._solve_state(jax.numpy.asarray(stage.x0, dtype=jax.numpy.float64))
+    qs = stage.extras["qs"]
+    static = vmec.get_static()
+    idx00 = int(_mode00_index(static.modes))
+    rz_idx, lam_idx, _ns, _K = _stellsym_feasible_indices(static, idx00=idx00, mask_lambda_axis=True)
+
+    def qs_objective(state):
+        residual = jax.numpy.asarray(qs.residuals_from_state(state), dtype=jax.numpy.float64)
+        return 0.5 * jax.numpy.sum(residual * residual)
+
+    grad = jax.grad(qs_objective)(state)
+    grad = _mask_grad_for_constraints(grad, static, idx00=idx00, mask_lambda_axis=True)
+    packed = np.asarray(_pack_stellsym_feasible_state(grad, rz_idx=rz_idx, lam_idx=lam_idx))
+
+    assert np.all(np.isfinite(packed))
+
+
+def test_vmec_jax_aspect_matches_vmec_interface():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    vmec.set_solver_options(solver="vmec2000", warm_start_iters=0, max_iter=100, grad_tol=1.0e-3)
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=1, nmin=-1, nmax=1, fixed=False)
+    surf.fix("rc(0,0)")
+    x0 = surf.get_free_params()
+
+    np.testing.assert_allclose(vmec.aspect(x0), vmec.aspect_equilibrium(x0))
+
+
+def test_vmec_jax_equilibrium_aspect_jax_matches_wout():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    vmec.set_solver_options(solver="vmec2000", warm_start_iters=0, max_iter=100, grad_tol=1.0e-3)
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=1, nmin=-1, nmax=1, fixed=False)
+    surf.fix("rc(0,0)")
+    x0 = jax.numpy.asarray(surf.get_free_params())
+
+    aspect_jax = vmec.aspect_equilibrium_jax(x0)
+    aspect_wout = vmec.get_wout(x0).aspect
+    np.testing.assert_allclose(np.asarray(aspect_jax), np.asarray(aspect_wout), rtol=1e-10, atol=1e-10)
+
+
+def test_vmec_jax_mean_iota_from_state_matches_wout():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    vmec.set_solver_options(solver="vmec2000", warm_start_iters=0, max_iter=100, grad_tol=1.0e-3)
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=1, nmin=-1, nmax=1, fixed=False)
+    surf.fix("rc(0,0)")
+    x0 = jax.numpy.asarray(surf.get_free_params())
+
+    state = vmec._solve_state(x0)
+    mean_iota_jax = vmec.mean_iota_from_state_jax(state)
+    iotas_wout = np.asarray(vmec.get_wout(x0).iotas)
+    mean_iota_wout = 0.0 if iotas_wout.size <= 1 else float(np.mean(iotas_wout[1:]))
+    np.testing.assert_allclose(np.asarray(mean_iota_jax), mean_iota_wout, rtol=1e-10, atol=1e-10)
+
+
+
+def test_vmec_jax_wout_exposes_mode_count_metadata():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    vmec.set_solver_options(solver="initial", warm_start_iters=0)
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=1, nmin=-1, nmax=1, fixed=False)
+    surf.fix("rc(0,0)")
+    x0 = surf.get_free_params()
+
+    wout = vmec.get_wout(x0)
+
+    assert int(wout.mnmax) == len(np.asarray(wout.xm))
+    assert int(wout.mnmax_nyq) == len(np.asarray(wout.xm_nyq))
+    assert int(wout.mpol_nyq) == int(np.max(np.asarray(wout.xm_nyq)))
+    assert int(wout.ntor_nyq) == int(np.max(np.abs(np.asarray(wout.xn_nyq) // int(wout.nfp))))
+
+
+@unittest.skipIf(vmec_mod is None, "vmec not installed")
+def test_vmec_jax_boundary_free_modes_match_vmec_for_stellsym_qh_setup():
+    vmec_ref = Vmec(_input_filename(), verbose=False)
+    vmec_ref.indata.mpol = 3
+    vmec_ref.indata.ntor = 3
+    surf_ref = vmec_ref.boundary
+    surf_ref.fix_all()
+    surf_ref.fixed_range(mmin=0, mmax=1, nmin=-1, nmax=1, fixed=False)
+    surf_ref.fix("rc(0,0)")
+    free_ref = [name.split(":", 1)[-1] for name in surf_ref.dof_names]
+
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=1, nmin=-1, nmax=1, fixed=False)
+    surf.fix("rc(0,0)")
+    free = [name for name, is_free in zip(surf.dof_names, surf.free) if is_free]
+
+    assert free == free_ref

--- a/tests/mhd/test_vmec_jax_wrapper.py
+++ b/tests/mhd/test_vmec_jax_wrapper.py
@@ -136,6 +136,12 @@ def test_vmec_jax_qh_profile_applies_outer_optimization_defaults():
     assert not vmec._stateless_evaluations
 
 
+def test_vmec_jax_can_select_discrete_adjoint_backend():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.set_solver_options(residual_derivative_backend="discrete_adjoint")
+    assert vmec._residual_derivative_backend == "discrete_adjoint"
+
+
 def test_vmec_jax_wrapper_keeps_unconstrained_boundary_coefficients():
     vmec = VmecJax(_input_filename(), verbose=False)
     vmec.indata.mpol = 3
@@ -289,6 +295,38 @@ def test_vmec_jax_qh_qs_state_gradient_is_finite():
     packed = np.asarray(_pack_stellsym_feasible_state(grad, rz_idx=rz_idx, lam_idx=lam_idx))
 
     assert np.all(np.isfinite(packed))
+
+
+def test_vmec_jax_discrete_backend_aspect_directional_derivative_matches_fd():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    vmec.set_solver_options(
+        solver="vmec2000",
+        max_iter=1,
+        grad_tol=1.0e-13,
+        residual_derivative_backend="discrete_adjoint",
+    )
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=1, nmin=-1, nmax=1, fixed=False)
+    surf.fix("rc(0,0)")
+    x0 = jax.numpy.asarray(surf.get_free_params(), dtype=jax.numpy.float64)
+    direction = jax.numpy.zeros_like(x0).at[0].set(1.0)
+
+    def aspect_fn(x):
+        return vmec.aspect_equilibrium_jax(x)
+
+    grad = jax.grad(aspect_fn)(x0)
+    ad = float(np.asarray(jax.numpy.dot(grad, direction)))
+    eps = 1.0e-5
+    fd = (
+        float(np.asarray(aspect_fn(x0 + eps * direction)))
+        - float(np.asarray(aspect_fn(x0 - eps * direction)))
+    ) / (2.0 * eps)
+
+    np.testing.assert_allclose(ad, fd, rtol=1.0e-5, atol=1.0e-8)
 
 
 def test_vmec_jax_aspect_matches_vmec_interface():

--- a/tests/mhd/test_vmec_jax_wrapper.py
+++ b/tests/mhd/test_vmec_jax_wrapper.py
@@ -638,6 +638,70 @@ def test_vmec_jax_discrete_backend_qh_jacobian_matches_moving_axis_fd_full_inner
     np.testing.assert_allclose(ad_objective_direction, fd_objective_direction, rtol=1.5e-2, atol=1.0e-4)
 
 
+def test_vmec_jax_discrete_backend_qh_jacobian_matches_moving_axis_fd_after_restart_point():
+    if os.environ.get("RUN_SLOW", "") != "1":
+        raise unittest.SkipTest("Set RUN_SLOW=1 to run slow discrete-adjoint QH checks")
+
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    vmec.set_solver_options(
+        solver="vmec2000",
+        max_iter=1500,
+        grad_tol=1.0e-13,
+        residual_derivative_backend="discrete_adjoint",
+    )
+    vmec.use_residual_autodiff_defaults(
+        outer_method="scipy",
+        residual_adjoint_mode="chunked",
+        stateless_evaluations=False,
+        optimization_profile="qh",
+    )
+
+    stage = build_vmec_objective_stage(
+        vmec,
+        max_mode=1,
+        objective_tuples=[("aspect", 7.0, 1.0), ("qs", 0.0, 1.0)],
+        surfaces=np.arange(0, 1.01, 0.1),
+        helicity_m=1,
+        helicity_n=-1,
+        x_scale_alpha=1.2,
+        x_scale_min=1e-9,
+    )
+    # Challenging late-iteration point from the exact 10-evaluation QH benchmark.
+    x = np.asarray(
+        [
+            0.13131474,
+            -0.07482285,
+            0.16300289,
+            -0.00986183,
+            0.12673185,
+            0.09467063,
+            0.16613359,
+            -0.01292121,
+        ],
+        dtype=float,
+    )
+    residual = np.asarray(stage.residuals.scipy_residuals(x), dtype=float)
+    jacobian = np.asarray(stage.residuals.scipy_jacobian(x), dtype=float)
+
+    eps = 1.0e-6
+    for idx in range(4):
+        direction = np.zeros_like(x)
+        direction[idx] = 1.0
+        residual_plus = np.asarray(stage.residuals.scipy_residuals(x + eps * direction), dtype=float)
+        residual_minus = np.asarray(stage.residuals.scipy_residuals(x - eps * direction), dtype=float)
+        fd_column = (residual_plus - residual_minus) / (2.0 * eps)
+
+        rel_column_error = np.linalg.norm(jacobian[:, idx] - fd_column) / max(np.linalg.norm(fd_column), 1.0e-30)
+        assert rel_column_error < 3.0e-2
+        assert float(np.max(np.abs(jacobian[:, idx] - fd_column))) < 3.0e-2
+
+        ad_objective_direction = float(2.0 * residual.dot(jacobian[:, idx]))
+        fd_objective_direction = float(2.0 * residual.dot(fd_column))
+        np.testing.assert_allclose(ad_objective_direction, fd_objective_direction, rtol=3.0e-2, atol=1.0e-4)
+
+
 def test_vmec_jax_aspect_matches_vmec_interface():
     vmec = VmecJax(_input_filename(), verbose=False)
     vmec.indata.mpol = 3

--- a/tests/mhd/test_vmec_jax_wrapper.py
+++ b/tests/mhd/test_vmec_jax_wrapper.py
@@ -18,6 +18,7 @@ except Exception:
 
 from vmec_jax.implicit import _pack_stellsym_feasible_state, _stellsym_feasible_indices
 from vmec_jax.solve import _mask_grad_for_constraints, _mode00_index
+from vmec_jax.boundary import boundary_from_input_convention
 
 from simsopt.mhd import VmecJax
 from simsopt.mhd import Vmec
@@ -375,6 +376,132 @@ def test_vmec_jax_discrete_backend_reuses_exact_solve_between_residual_and_jacob
     assert residual.ndim == 1
     assert jacobian.shape[0] == residual.shape[0]
     assert jacobian.shape[1] == x0.size
+
+
+def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd():
+    if os.environ.get("RUN_SLOW", "") != "1":
+        raise unittest.SkipTest("Set RUN_SLOW=1 to run slow discrete-adjoint QH checks")
+
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    vmec.set_solver_options(
+        solver="vmec2000",
+        max_iter=1,
+        grad_tol=1.0e-13,
+        residual_derivative_backend="discrete_adjoint",
+    )
+    vmec.use_residual_autodiff_defaults(
+        outer_method="scipy",
+        residual_adjoint_mode="chunked",
+        stateless_evaluations=False,
+        optimization_profile="qh",
+    )
+
+    stage = build_vmec_objective_stage(
+        vmec,
+        max_mode=1,
+        objective_tuples=[("aspect", 7.0, 1.0), ("qs", 0.0, 1.0)],
+        surfaces=np.arange(0, 1.01, 0.1),
+        helicity_m=1,
+        helicity_n=-1,
+        x_scale_alpha=1.2,
+        x_scale_min=1e-9,
+    )
+    x0 = np.asarray(stage.x0, dtype=float)
+    residual0 = np.asarray(stage.residuals.scipy_residuals(x0), dtype=float)
+    jacobian = np.asarray(stage.residuals.scipy_jacobian(x0), dtype=float)
+
+    state0, payload0 = vmec._solve_state_discrete_adjoint_residual(
+        x0,
+        step_size=float(vmec._indata_raw.get_float("DELT", 1.0)),
+        return_payload=True,
+    )
+    axis_override = payload0["axis_override"]
+
+    static = vmec._static
+    boundary_wrapper = vmec.boundary
+    indata = vmec._indata_raw
+    base_full = np.asarray(boundary_wrapper._base)
+    specs = tuple(boundary_wrapper._specs)
+    modes = boundary_wrapper._modes
+    lasym = bool(vmec._cfg.lasym)
+    layout = state0.layout
+    step_size = float(vmec._indata_raw.get_float("DELT", 1.0))
+    qs = stage.extras["qs"]
+
+    def initial_state_packed(x_free, *, axis_override_local=None):
+        x_full = boundary_wrapper.expand_free(x_free)
+        delta_full = np.asarray(x_full) - base_full
+        boundary_input = vj.apply_boundary_params(boundary_wrapper._boundary_input0, specs, delta_full)
+        boundary = boundary_from_input_convention(
+            boundary_input,
+            modes,
+            lasym=lasym,
+            apply_m1_constraint=False,
+        )
+        state = vj.initial_guess_from_boundary(
+            static,
+            boundary,
+            indata,
+            vmec_project=True,
+            axis_override=axis_override_local,
+        )
+        return np.asarray(vj.pack_state(state), dtype=float)
+
+    def solve_frozen_axis(x_free):
+        packed0 = initial_state_packed(x_free, axis_override_local=axis_override)
+        state_init = vj.unpack_state(packed0, layout)
+        tape = vj.build_residual_checkpoint_tape_direct(
+            state_init,
+            static,
+            max_iter=int(vmec._max_iter),
+            solver_kwargs=dict(
+                indata=indata,
+                signgs=int(vmec._signgs),
+                ftol=float(vmec._grad_tol),
+                step_size=step_size,
+                vmec2000_control=True,
+                reference_mode=False,
+                backtracking=True,
+                limit_dt_from_force=True,
+                limit_update_rms=True,
+                verbose=False,
+                verbose_vmec2000_table=False,
+                jit_forces="auto",
+                use_scan=False,
+                light_history=True,
+                resume_state_mode="full",
+            ),
+            indata=indata,
+            signgs=int(vmec._signgs),
+            ftol=float(vmec._grad_tol),
+            step_size=step_size,
+            light_history=True,
+            store_trace=False,
+        )
+        return vj.unpack_state(np.asarray(tape.final_packed_state, dtype=float), layout)
+
+    def frozen_axis_residuals(x_free):
+        state = solve_frozen_axis(x_free)
+        aspect_residual = np.asarray([vmec.aspect_equilibrium_from_state_jax(state) - 7.0], dtype=float)
+        qs_residual = np.asarray(qs.residuals_from_state(state), dtype=float)
+        return np.concatenate((aspect_residual, qs_residual))
+
+    eps = 1.0e-6
+    direction = np.zeros_like(x0)
+    direction[0] = 1.0
+    residual_plus = frozen_axis_residuals(x0 + eps * direction)
+    residual_minus = frozen_axis_residuals(x0 - eps * direction)
+    fd_column = (residual_plus - residual_minus) / (2.0 * eps)
+
+    rel_column_error = np.linalg.norm(jacobian[:, 0] - fd_column) / max(np.linalg.norm(fd_column), 1.0e-30)
+    assert rel_column_error < 5.0e-4
+    assert float(np.max(np.abs(jacobian[:, 0] - fd_column))) < 1.0e-3
+
+    ad_objective_direction = float(2.0 * residual0.dot(jacobian[:, 0]))
+    fd_objective_direction = float(2.0 * residual0.dot(fd_column))
+    np.testing.assert_allclose(ad_objective_direction, fd_objective_direction, rtol=5.0e-4, atol=1.0e-5)
 
 
 def test_vmec_jax_aspect_matches_vmec_interface():

--- a/tests/mhd/test_vmec_jax_wrapper.py
+++ b/tests/mhd/test_vmec_jax_wrapper.py
@@ -378,6 +378,54 @@ def test_vmec_jax_discrete_backend_reuses_exact_solve_between_residual_and_jacob
     assert jacobian.shape[1] == x0.size
 
 
+def test_vmec_jax_discrete_backend_exposes_cached_state_payload():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    vmec.set_solver_options(
+        solver="vmec2000",
+        max_iter=1,
+        grad_tol=1.0e-13,
+        residual_derivative_backend="discrete_adjoint",
+    )
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=1, nmin=-1, nmax=1, fixed=False)
+    surf.fix("rc(0,0)")
+
+    stage = build_vmec_objective_stage(
+        vmec,
+        max_mode=1,
+        objective_tuples=[("aspect", 7.0, 1.0), ("qs", 0.0, 1.0)],
+        surfaces=np.arange(0, 1.01, 0.1),
+        helicity_m=1,
+        helicity_n=-1,
+        x_scale_alpha=1.2,
+        x_scale_min=1e-9,
+    )
+    x0 = jax.numpy.asarray(stage.x0, dtype=jax.numpy.float64)
+
+    solve_calls = {"count": 0}
+    original = vmec._solve_state_discrete_adjoint_residual
+
+    def counted_solve(*args, **kwargs):
+        solve_calls["count"] += 1
+        return original(*args, **kwargs)
+
+    vmec._solve_state_discrete_adjoint_residual = counted_solve
+    try:
+        residual = np.asarray(stage.residuals.scipy_residuals(x0))
+        state, payload, cached_residual = stage.residuals.scipy_state_payload(x0)
+    finally:
+        vmec._solve_state_discrete_adjoint_residual = original
+
+    assert solve_calls["count"] == 1
+    np.testing.assert_allclose(np.asarray(cached_residual), residual)
+    assert payload is not None
+    assert state is not None
+
+
 def test_vmec_jax_solve_state_for_objective_uses_forward_residual_path():
     vmec = VmecJax(_input_filename(), verbose=False)
     vmec.indata.mpol = 3

--- a/tests/mhd/test_vmec_jax_wrapper.py
+++ b/tests/mhd/test_vmec_jax_wrapper.py
@@ -504,6 +504,132 @@ def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd():
     np.testing.assert_allclose(ad_objective_direction, fd_objective_direction, rtol=5.0e-4, atol=1.0e-5)
 
 
+def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd_full_inner():
+    if os.environ.get("RUN_SLOW", "") != "1":
+        raise unittest.SkipTest("Set RUN_SLOW=1 to run slow discrete-adjoint QH checks")
+
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    vmec.set_solver_options(
+        solver="vmec2000",
+        max_iter=20,
+        grad_tol=1.0e-13,
+        residual_derivative_backend="discrete_adjoint",
+    )
+    vmec.use_residual_autodiff_defaults(
+        outer_method="scipy",
+        residual_adjoint_mode="chunked",
+        stateless_evaluations=False,
+        optimization_profile="qh",
+    )
+
+    stage = build_vmec_objective_stage(
+        vmec,
+        max_mode=1,
+        objective_tuples=[("aspect", 7.0, 1.0), ("qs", 0.0, 1.0)],
+        surfaces=np.arange(0, 1.01, 0.1),
+        helicity_m=1,
+        helicity_n=-1,
+        x_scale_alpha=1.2,
+        x_scale_min=1e-9,
+    )
+    x0 = np.asarray(stage.x0, dtype=float)
+    residual0 = np.asarray(stage.residuals.scipy_residuals(x0), dtype=float)
+    jacobian = np.asarray(stage.residuals.scipy_jacobian(x0), dtype=float)
+
+    state0, payload0 = vmec._solve_state_discrete_adjoint_residual(
+        x0,
+        step_size=float(vmec._indata_raw.get_float("DELT", 1.0)),
+        return_payload=True,
+    )
+    axis_override = payload0["axis_override"]
+
+    static = vmec._static
+    boundary_wrapper = vmec.boundary
+    indata = vmec._indata_raw
+    base_full = np.asarray(boundary_wrapper._base)
+    specs = tuple(boundary_wrapper._specs)
+    modes = boundary_wrapper._modes
+    lasym = bool(vmec._cfg.lasym)
+    layout = state0.layout
+    step_size = float(vmec._indata_raw.get_float("DELT", 1.0))
+    qs = stage.extras["qs"]
+
+    def initial_state_packed(x_free, *, axis_override_local=None):
+        x_full = boundary_wrapper.expand_free(x_free)
+        delta_full = np.asarray(x_full) - base_full
+        boundary_input = vj.apply_boundary_params(boundary_wrapper._boundary_input0, specs, delta_full)
+        boundary = boundary_from_input_convention(
+            boundary_input,
+            modes,
+            lasym=lasym,
+            apply_m1_constraint=False,
+        )
+        state = vj.initial_guess_from_boundary(
+            static,
+            boundary,
+            indata,
+            vmec_project=True,
+            axis_override=axis_override_local,
+        )
+        return np.asarray(vj.pack_state(state), dtype=float)
+
+    def solve_frozen_axis(x_free):
+        packed0 = initial_state_packed(x_free, axis_override_local=axis_override)
+        state_init = vj.unpack_state(packed0, layout)
+        tape = vj.build_residual_checkpoint_tape_direct(
+            state_init,
+            static,
+            max_iter=int(vmec._max_iter),
+            solver_kwargs=dict(
+                indata=indata,
+                signgs=int(vmec._signgs),
+                ftol=float(vmec._grad_tol),
+                step_size=step_size,
+                vmec2000_control=True,
+                reference_mode=False,
+                backtracking=True,
+                limit_dt_from_force=True,
+                limit_update_rms=True,
+                verbose=False,
+                verbose_vmec2000_table=False,
+                jit_forces="auto",
+                use_scan=False,
+                light_history=True,
+                resume_state_mode="full",
+            ),
+            indata=indata,
+            signgs=int(vmec._signgs),
+            ftol=float(vmec._grad_tol),
+            step_size=step_size,
+            light_history=True,
+            store_trace=False,
+        )
+        return vj.unpack_state(np.asarray(tape.final_packed_state, dtype=float), layout)
+
+    def frozen_axis_residuals(x_free):
+        state = solve_frozen_axis(x_free)
+        aspect_residual = np.asarray([vmec.aspect_equilibrium_from_state_jax(state) - 7.0], dtype=float)
+        qs_residual = np.asarray(qs.residuals_from_state(state), dtype=float)
+        return np.concatenate((aspect_residual, qs_residual))
+
+    eps = 1.0e-6
+    direction = np.zeros_like(x0)
+    direction[0] = 1.0
+    residual_plus = frozen_axis_residuals(x0 + eps * direction)
+    residual_minus = frozen_axis_residuals(x0 - eps * direction)
+    fd_column = (residual_plus - residual_minus) / (2.0 * eps)
+
+    rel_column_error = np.linalg.norm(jacobian[:, 0] - fd_column) / max(np.linalg.norm(fd_column), 1.0e-30)
+    assert rel_column_error < 1.0e-3
+    assert float(np.max(np.abs(jacobian[:, 0] - fd_column))) < 1.0e-2
+
+    ad_objective_direction = float(2.0 * residual0.dot(jacobian[:, 0]))
+    fd_objective_direction = float(2.0 * residual0.dot(fd_column))
+    np.testing.assert_allclose(ad_objective_direction, fd_objective_direction, rtol=1.0e-3, atol=1.0e-4)
+
+
 def test_vmec_jax_aspect_matches_vmec_interface():
     vmec = VmecJax(_input_filename(), verbose=False)
     vmec.indata.mpol = 3

--- a/tests/mhd/test_vmec_jax_wrapper.py
+++ b/tests/mhd/test_vmec_jax_wrapper.py
@@ -329,6 +329,54 @@ def test_vmec_jax_discrete_backend_aspect_directional_derivative_matches_fd():
     np.testing.assert_allclose(ad, fd, rtol=1.0e-5, atol=1.0e-8)
 
 
+def test_vmec_jax_discrete_backend_reuses_exact_solve_between_residual_and_jacobian():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    vmec.set_solver_options(
+        solver="vmec2000",
+        max_iter=1,
+        grad_tol=1.0e-13,
+        residual_derivative_backend="discrete_adjoint",
+    )
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=1, nmin=-1, nmax=1, fixed=False)
+    surf.fix("rc(0,0)")
+
+    stage = build_vmec_objective_stage(
+        vmec,
+        max_mode=1,
+        objective_tuples=[("aspect", 7.0, 1.0), ("qs", 0.0, 1.0)],
+        surfaces=np.arange(0, 1.01, 0.1),
+        helicity_m=1,
+        helicity_n=-1,
+        x_scale_alpha=1.2,
+        x_scale_min=1e-9,
+    )
+    x0 = jax.numpy.asarray(stage.x0, dtype=jax.numpy.float64)
+
+    solve_calls = {"count": 0}
+    original = vmec._solve_state_discrete_adjoint_residual
+
+    def counted_solve(*args, **kwargs):
+        solve_calls["count"] += 1
+        return original(*args, **kwargs)
+
+    vmec._solve_state_discrete_adjoint_residual = counted_solve
+    try:
+        residual = np.asarray(stage.residuals.scipy_residuals(x0))
+        jacobian = np.asarray(stage.residuals.scipy_jacobian(x0))
+    finally:
+        vmec._solve_state_discrete_adjoint_residual = original
+
+    assert solve_calls["count"] == 1
+    assert residual.ndim == 1
+    assert jacobian.shape[0] == residual.shape[0]
+    assert jacobian.shape[1] == x0.size
+
+
 def test_vmec_jax_aspect_matches_vmec_interface():
     vmec = VmecJax(_input_filename(), verbose=False)
     vmec.indata.mpol = 3

--- a/tests/mhd/test_vmec_jax_wrapper.py
+++ b/tests/mhd/test_vmec_jax_wrapper.py
@@ -378,6 +378,30 @@ def test_vmec_jax_discrete_backend_reuses_exact_solve_between_residual_and_jacob
     assert jacobian.shape[1] == x0.size
 
 
+def test_vmec_jax_solve_state_for_objective_uses_forward_residual_path():
+    vmec = VmecJax(_input_filename(), verbose=False)
+    vmec.indata.mpol = 3
+    vmec.indata.ntor = 3
+    vmec.set_solver_options(
+        solver="vmec2000",
+        max_iter=1,
+        grad_tol=1.0e-13,
+        residual_derivative_backend="discrete_adjoint",
+    )
+
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=1, nmin=-1, nmax=1, fixed=False)
+    surf.fix("rc(0,0)")
+    x0 = jax.numpy.asarray(surf.get_free_params(), dtype=jax.numpy.float64)
+    step_size = float(vmec._indata_raw.get_float("DELT", 1.0))
+
+    state_report = vmec.solve_state_for_objective(x0)
+    state_forward = vmec._solve_state_residual_forward(x0, step_size=step_size)
+
+    np.testing.assert_allclose(np.asarray(vj.pack_state(state_report)), np.asarray(vj.pack_state(state_forward)))
+
+
 def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd():
     if os.environ.get("RUN_SLOW", "") != "1":
         raise unittest.SkipTest("Set RUN_SLOW=1 to run slow discrete-adjoint QH checks")

--- a/tests/mhd/test_vmec_jax_wrapper.py
+++ b/tests/mhd/test_vmec_jax_wrapper.py
@@ -402,7 +402,7 @@ def test_vmec_jax_solve_state_for_objective_uses_forward_residual_path():
     np.testing.assert_allclose(np.asarray(vj.pack_state(state_report)), np.asarray(vj.pack_state(state_forward)))
 
 
-def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd():
+def test_vmec_jax_discrete_backend_qh_jacobian_matches_moving_axis_fd():
     if os.environ.get("RUN_SLOW", "") != "1":
         raise unittest.SkipTest("Set RUN_SLOW=1 to run slow discrete-adjoint QH checks")
 
@@ -436,13 +436,6 @@ def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd():
     residual0 = np.asarray(stage.residuals.scipy_residuals(x0), dtype=float)
     jacobian = np.asarray(stage.residuals.scipy_jacobian(x0), dtype=float)
 
-    state0, payload0 = vmec._solve_state_discrete_adjoint_residual(
-        x0,
-        step_size=float(vmec._indata_raw.get_float("DELT", 1.0)),
-        return_payload=True,
-    )
-    axis_override = payload0["axis_override"]
-
     static = vmec._static
     boundary_wrapper = vmec.boundary
     indata = vmec._indata_raw
@@ -450,11 +443,11 @@ def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd():
     specs = tuple(boundary_wrapper._specs)
     modes = boundary_wrapper._modes
     lasym = bool(vmec._cfg.lasym)
-    layout = state0.layout
+    layout = vmec.solve_state_for_objective(x0).layout
     step_size = float(vmec._indata_raw.get_float("DELT", 1.0))
     qs = stage.extras["qs"]
 
-    def initial_state_packed(x_free, *, axis_override_local=None):
+    def initial_state_packed(x_free):
         x_full = boundary_wrapper.expand_free(x_free)
         delta_full = np.asarray(x_full) - base_full
         boundary_input = vj.apply_boundary_params(boundary_wrapper._boundary_input0, specs, delta_full)
@@ -469,12 +462,11 @@ def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd():
             boundary,
             indata,
             vmec_project=True,
-            axis_override=axis_override_local,
         )
         return np.asarray(vj.pack_state(state), dtype=float)
 
-    def solve_frozen_axis(x_free):
-        packed0 = initial_state_packed(x_free, axis_override_local=axis_override)
+    def solve_moving_axis(x_free):
+        packed0 = initial_state_packed(x_free)
         state_init = vj.unpack_state(packed0, layout)
         tape = vj.build_residual_checkpoint_tape_direct(
             state_init,
@@ -506,8 +498,8 @@ def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd():
         )
         return vj.unpack_state(np.asarray(tape.final_packed_state, dtype=float), layout)
 
-    def frozen_axis_residuals(x_free):
-        state = solve_frozen_axis(x_free)
+    def moving_axis_residuals(x_free):
+        state = solve_moving_axis(x_free)
         aspect_residual = np.asarray([vmec.aspect_equilibrium_from_state_jax(state) - 7.0], dtype=float)
         qs_residual = np.asarray(qs.residuals_from_state(state), dtype=float)
         return np.concatenate((aspect_residual, qs_residual))
@@ -515,8 +507,8 @@ def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd():
     eps = 1.0e-6
     direction = np.zeros_like(x0)
     direction[0] = 1.0
-    residual_plus = frozen_axis_residuals(x0 + eps * direction)
-    residual_minus = frozen_axis_residuals(x0 - eps * direction)
+    residual_plus = moving_axis_residuals(x0 + eps * direction)
+    residual_minus = moving_axis_residuals(x0 - eps * direction)
     fd_column = (residual_plus - residual_minus) / (2.0 * eps)
 
     rel_column_error = np.linalg.norm(jacobian[:, 0] - fd_column) / max(np.linalg.norm(fd_column), 1.0e-30)
@@ -528,7 +520,7 @@ def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd():
     np.testing.assert_allclose(ad_objective_direction, fd_objective_direction, rtol=5.0e-4, atol=1.0e-5)
 
 
-def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd_full_inner():
+def test_vmec_jax_discrete_backend_qh_jacobian_matches_moving_axis_fd_full_inner():
     if os.environ.get("RUN_SLOW", "") != "1":
         raise unittest.SkipTest("Set RUN_SLOW=1 to run slow discrete-adjoint QH checks")
 
@@ -562,13 +554,6 @@ def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd_full_inner
     residual0 = np.asarray(stage.residuals.scipy_residuals(x0), dtype=float)
     jacobian = np.asarray(stage.residuals.scipy_jacobian(x0), dtype=float)
 
-    state0, payload0 = vmec._solve_state_discrete_adjoint_residual(
-        x0,
-        step_size=float(vmec._indata_raw.get_float("DELT", 1.0)),
-        return_payload=True,
-    )
-    axis_override = payload0["axis_override"]
-
     static = vmec._static
     boundary_wrapper = vmec.boundary
     indata = vmec._indata_raw
@@ -576,11 +561,11 @@ def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd_full_inner
     specs = tuple(boundary_wrapper._specs)
     modes = boundary_wrapper._modes
     lasym = bool(vmec._cfg.lasym)
-    layout = state0.layout
+    layout = vmec.solve_state_for_objective(x0).layout
     step_size = float(vmec._indata_raw.get_float("DELT", 1.0))
     qs = stage.extras["qs"]
 
-    def initial_state_packed(x_free, *, axis_override_local=None):
+    def initial_state_packed(x_free):
         x_full = boundary_wrapper.expand_free(x_free)
         delta_full = np.asarray(x_full) - base_full
         boundary_input = vj.apply_boundary_params(boundary_wrapper._boundary_input0, specs, delta_full)
@@ -595,12 +580,11 @@ def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd_full_inner
             boundary,
             indata,
             vmec_project=True,
-            axis_override=axis_override_local,
         )
         return np.asarray(vj.pack_state(state), dtype=float)
 
-    def solve_frozen_axis(x_free):
-        packed0 = initial_state_packed(x_free, axis_override_local=axis_override)
+    def solve_moving_axis(x_free):
+        packed0 = initial_state_packed(x_free)
         state_init = vj.unpack_state(packed0, layout)
         tape = vj.build_residual_checkpoint_tape_direct(
             state_init,
@@ -632,8 +616,8 @@ def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd_full_inner
         )
         return vj.unpack_state(np.asarray(tape.final_packed_state, dtype=float), layout)
 
-    def frozen_axis_residuals(x_free):
-        state = solve_frozen_axis(x_free)
+    def moving_axis_residuals(x_free):
+        state = solve_moving_axis(x_free)
         aspect_residual = np.asarray([vmec.aspect_equilibrium_from_state_jax(state) - 7.0], dtype=float)
         qs_residual = np.asarray(qs.residuals_from_state(state), dtype=float)
         return np.concatenate((aspect_residual, qs_residual))
@@ -641,17 +625,17 @@ def test_vmec_jax_discrete_backend_qh_jacobian_matches_frozen_axis_fd_full_inner
     eps = 1.0e-6
     direction = np.zeros_like(x0)
     direction[0] = 1.0
-    residual_plus = frozen_axis_residuals(x0 + eps * direction)
-    residual_minus = frozen_axis_residuals(x0 - eps * direction)
+    residual_plus = moving_axis_residuals(x0 + eps * direction)
+    residual_minus = moving_axis_residuals(x0 - eps * direction)
     fd_column = (residual_plus - residual_minus) / (2.0 * eps)
 
     rel_column_error = np.linalg.norm(jacobian[:, 0] - fd_column) / max(np.linalg.norm(fd_column), 1.0e-30)
-    assert rel_column_error < 1.0e-3
+    assert rel_column_error < 3.0e-3
     assert float(np.max(np.abs(jacobian[:, 0] - fd_column))) < 1.0e-2
 
     ad_objective_direction = float(2.0 * residual0.dot(jacobian[:, 0]))
     fd_objective_direction = float(2.0 * residual0.dot(fd_column))
-    np.testing.assert_allclose(ad_objective_direction, fd_objective_direction, rtol=1.0e-3, atol=1.0e-4)
+    np.testing.assert_allclose(ad_objective_direction, fd_objective_direction, rtol=1.5e-2, atol=1.0e-4)
 
 
 def test_vmec_jax_aspect_matches_vmec_interface():

--- a/tests/solve/test_jax_solve.py
+++ b/tests/solve/test_jax_solve.py
@@ -61,3 +61,21 @@ def test_least_squares_jax_solve_scipy_numeric_jacobian():
     )
 
     np.testing.assert_allclose(result["x"], np.array([3.0, -4.0]), atol=1e-8)
+
+
+def test_least_squares_jax_solve_scipy_reverse_jacobian():
+    def residual(x):
+        return jnp.array([x[0] - 3.0, x[1] + 4.0])
+
+    result = least_squares_jax_solve(
+        residual,
+        np.array([0.0, 0.0]),
+        method="scipy",
+        max_nfev=20,
+        gtol=1e-10,
+        jit=False,
+        jac="reverse",
+        verbose=0,
+    )
+
+    np.testing.assert_allclose(result["x"], np.array([3.0, -4.0]), atol=1e-8)

--- a/tests/solve/test_jax_solve.py
+++ b/tests/solve/test_jax_solve.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("jax")
+import jax.numpy as jnp
+
+from simsopt.solve import least_squares_jax_solve
+
+
+def test_least_squares_jax_solve_quadratic():
+    def residual(x):
+        return jnp.array([x[0] - 2.0, 2.0 * x[1] + 1.0])
+
+    result = least_squares_jax_solve(
+        residual,
+        np.array([0.0, 0.0]),
+        method="gradient_descent",
+        max_nfev=200,
+        step_size=0.2,
+        gtol=1e-8,
+        jit=False,
+        verbose=0,
+    )
+
+    np.testing.assert_allclose(result["x"], np.array([2.0, -0.5]), atol=1e-3)
+
+
+def test_least_squares_jax_solve_gradient_descent_avoids_redundant_startup_objectives():
+    def residual(x):
+        return jnp.array([x[0] - 2.0, 2.0 * x[1] + 1.0])
+
+    result = least_squares_jax_solve(
+        residual,
+        np.array([0.0, 0.0]),
+        method="gradient_descent",
+        max_nfev=1,
+        step_size=0.2,
+        gtol=1e-8,
+        jit=False,
+        verbose=0,
+        profile=True,
+    )
+
+    assert result["profile"]["value_and_grad_calls"] == 1
+    assert result["profile"]["objective_calls"] == 0
+
+
+def test_least_squares_jax_solve_scipy_numeric_jacobian():
+    def residual(x):
+        return jnp.array([x[0] - 3.0, x[1] + 4.0])
+
+    result = least_squares_jax_solve(
+        residual,
+        np.array([0.0, 0.0]),
+        method="scipy",
+        max_nfev=20,
+        gtol=1e-10,
+        jit=False,
+        jac="2-point",
+        verbose=0,
+    )
+
+    np.testing.assert_allclose(result["x"], np.array([3.0, -4.0]), atol=1e-8)

--- a/tools/diagnostics/qh_classic_vs_jax_compare.py
+++ b/tools/diagnostics/qh_classic_vs_jax_compare.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python
+
+import argparse
+import gc
+import json
+import os
+import resource
+import subprocess
+import sys
+import time
+import traceback
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import psutil
+from scipy.optimize import least_squares
+
+from simsopt._core.finite_difference import FiniteDifference
+from simsopt.mhd import QuasisymmetryRatioResidual, Vmec, VmecJax
+from simsopt.objectives import LeastSquaresProblem
+from simsopt.solve import build_vmec_objective_stage
+
+
+DEFAULT_OUTPUT_DIR = Path("/Users/rogeriojorge/local/tests/qh_compare_outputs")
+WALL_CLOCK_LIMIT_S = 300.0
+MAX_NFEV = 20
+
+
+class WallClockStop(RuntimeError):
+    pass
+
+
+def peak_rss_bytes():
+    value = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform == "darwin":
+        return int(value)
+    return int(value) * 1024
+
+
+def current_rss_bytes():
+    return int(psutil.Process(os.getpid()).memory_info().rss)
+
+
+def qh_input_filename():
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        "examples",
+        "2_Intermediate",
+        "inputs",
+        "input.nfp4_QH_warm_start",
+    )
+
+
+def check_wall_clock(start_time, wall_clock_limit_s):
+    elapsed = time.perf_counter() - start_time
+    if elapsed > float(wall_clock_limit_s):
+        raise WallClockStop(f"timed out after {wall_clock_limit_s:.1f} s")
+    return elapsed
+
+
+def make_classic_context(max_mode):
+    filename = qh_input_filename()
+    vmec = Vmec(filename, verbose=False)
+    vmec.indata.mpol = int(max_mode) + 2
+    vmec.indata.ntor = vmec.indata.mpol
+    surf = vmec.boundary
+    surf.fix_all()
+    surf.fixed_range(mmin=0, mmax=int(max_mode), nmin=-int(max_mode), nmax=int(max_mode), fixed=False)
+    surf.fix("rc(0,0)")
+    qs = QuasisymmetryRatioResidual(vmec, np.arange(0, 1.01, 0.1), helicity_m=1, helicity_n=-1)
+    prob = LeastSquaresProblem.from_tuples([(vmec.aspect, 7.0, 1.0), (qs.residuals, 0.0, 1.0)])
+    x0 = np.asarray(surf.x, dtype=float)
+    return {
+        "solver": "classic",
+        "vmec": vmec,
+        "surf": surf,
+        "qs": qs,
+        "prob": prob,
+        "x0": x0,
+        "x_scale": 1.0,
+    }
+
+
+def make_jax_context(max_mode):
+    filename = qh_input_filename()
+    vmec = VmecJax(filename, verbose=False)
+    vmec.use_residual_autodiff_defaults(
+        outer_method="scipy",
+        residual_adjoint_mode="chunked",
+        stateless_evaluations=False,
+        optimization_profile="qh",
+    )
+    vmec.set_solver_options(residual_derivative_backend="discrete_adjoint")
+    objective_tuples = [("aspect", 7.0, 1.0), ("qs", 0.0, 1.0)]
+    stage = build_vmec_objective_stage(
+        vmec,
+        max_mode=int(max_mode),
+        objective_tuples=objective_tuples,
+        surfaces=np.arange(0, 1.01, 0.1),
+        helicity_m=1,
+        helicity_n=-1,
+        x_scale_alpha=1.2,
+        x_scale_min=1e-9,
+    )
+    return {
+        "solver": "jax",
+        "vmec": vmec,
+        "stage": stage,
+        "qs": stage.extras["qs"],
+        "residuals_from_state": stage.extras["residuals_from_state"],
+        "x0": np.asarray(stage.x0, dtype=float),
+        "x_scale": np.asarray(stage.x_scale, dtype=float),
+    }
+
+
+def classic_metrics(context, x):
+    context["prob"].x = np.asarray(x, dtype=float)
+    total = float(context["prob"].objective())
+    qs_objective = float(context["qs"].total())
+    aspect_value = float(context["vmec"].aspect())
+    aspect_term = float((aspect_value - 7.0) ** 2)
+    return {
+        "total_objective": total,
+        "qs_objective": qs_objective,
+        "aspect_term": aspect_term,
+        "aspect_value": aspect_value,
+    }
+
+
+def jax_metrics(context, x):
+    x = np.asarray(x, dtype=float)
+    state_payload = getattr(context["stage"].residuals, "scipy_state_payload", None)
+    if callable(state_payload):
+        state, _payload, residual = state_payload(x)
+        residual = np.asarray(residual, dtype=float)
+    else:
+        state = context["vmec"].solve_state_for_objective(x)
+        residual = np.asarray(context["residuals_from_state"](state), dtype=float)
+    qs_objective = float(np.asarray(context["qs"].total_from_state(state)))
+    aspect_value = float(np.asarray(context["vmec"].aspect_equilibrium_from_state_jax(state)))
+    aspect_term = float((aspect_value - 7.0) ** 2)
+    total = float(np.dot(residual, residual))
+    return {
+        "total_objective": total,
+        "qs_objective": qs_objective,
+        "aspect_term": aspect_term,
+        "aspect_value": aspect_value,
+    }
+
+
+def make_iteration_logger(context, solver_name, start_time, wall_clock_limit_s):
+    rows = []
+    counters = {
+        "residual_calls": 0,
+        "jacobian_calls": 0,
+    }
+    last_logged_x = None
+    last_eval_x = None
+
+    def log_snapshot(label, x):
+        nonlocal last_logged_x
+        x = np.asarray(x, dtype=float)
+        snapshot = {
+            "label": str(label),
+            "iteration": len(rows),
+            "nfev_observed": int(counters["residual_calls"]),
+            "njev_observed": int(counters["jacobian_calls"]),
+            "elapsed_s": float(time.perf_counter() - start_time),
+            "rss_bytes": current_rss_bytes(),
+            "peak_rss_bytes": peak_rss_bytes(),
+            "x": x.tolist(),
+        }
+        rows.append(snapshot)
+        last_logged_x = x.copy()
+        return snapshot
+
+    def residual_wrapper(fun):
+        def wrapped(x):
+            nonlocal last_eval_x
+            counters["residual_calls"] += 1
+            last_eval_x = np.asarray(x, dtype=float).copy()
+            check_wall_clock(start_time, wall_clock_limit_s)
+            return fun(x)
+
+        return wrapped
+
+    def jacobian_wrapper(fun):
+        def wrapped(x):
+            nonlocal last_eval_x
+            counters["jacobian_calls"] += 1
+            last_eval_x = np.asarray(x, dtype=float).copy()
+            check_wall_clock(start_time, wall_clock_limit_s)
+            return fun(x)
+
+        return wrapped
+
+    def callback(xk, *args, **kwargs):
+        check_wall_clock(start_time, wall_clock_limit_s)
+        log_snapshot("callback", xk)
+        check_wall_clock(start_time, wall_clock_limit_s)
+
+    def finalize(final_x, label):
+        if final_x is None:
+            final_x = last_eval_x if last_eval_x is not None else last_logged_x
+        if final_x is None:
+            return
+        final_x = np.asarray(final_x, dtype=float)
+        if last_logged_x is None or np.linalg.norm(final_x - last_logged_x) > 0.0:
+            log_snapshot(label, final_x)
+
+    return rows, counters, log_snapshot, residual_wrapper, jacobian_wrapper, callback, finalize
+
+
+def enrich_iteration_metrics(rows, context, solver_name):
+    enriched = []
+    for row in rows:
+        x = np.asarray(row["x"], dtype=float)
+        if solver_name == "classic":
+            metrics = classic_metrics(context, x)
+        else:
+            metrics = jax_metrics(context, x)
+        merged = dict(row)
+        merged.update(metrics)
+        enriched.append(merged)
+    return enriched
+
+
+def run_case(case_name, max_mode, max_nfev, wall_clock_limit_s, output_dir):
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = output_dir / f"{case_name}_mode{max_mode}_summary.json"
+    iterations_path = output_dir / f"{case_name}_mode{max_mode}_iterations.jsonl"
+
+    if case_name == "classic":
+        context = make_classic_context(max_mode)
+    elif case_name == "jax":
+        context = make_jax_context(max_mode)
+    else:
+        raise ValueError(f"Unsupported case: {case_name}")
+
+    start_time = time.perf_counter()
+    rows, counters, log_snapshot, residual_wrapper, jacobian_wrapper, callback, finalize = make_iteration_logger(
+        context,
+        case_name,
+        start_time,
+        wall_clock_limit_s,
+    )
+    log_snapshot("initial", context["x0"])
+
+    result = None
+    timed_out = False
+    error_text = None
+    metrics_error_text = None
+
+    try:
+        if case_name == "classic":
+            residual_fun = residual_wrapper(lambda x: np.asarray(context["prob"].residuals(x), dtype=float))
+            fd = FiniteDifference(
+                context["prob"].residuals,
+                x0=context["x0"],
+                abs_step=1.0e-8,
+                rel_step=1.0e-5,
+                diff_method="forward",
+            )
+            jac_fun = jacobian_wrapper(lambda x: np.asarray(fd.jac(np.asarray(x, dtype=float)), dtype=float))
+            result = least_squares(
+                residual_fun,
+                context["x0"],
+                jac=jac_fun,
+                x_scale=context["x_scale"],
+                max_nfev=int(max_nfev),
+                ftol=1.0e-8,
+                xtol=1.0e-8,
+                gtol=1.0e-8,
+                verbose=2,
+                callback=callback,
+            )
+        else:
+            residual_fun = residual_wrapper(
+                lambda x: np.asarray(context["stage"].residuals.scipy_residuals(np.asarray(x, dtype=float)), dtype=float)
+            )
+            jac_fun = jacobian_wrapper(
+                lambda x: np.asarray(context["stage"].residuals.scipy_jacobian(np.asarray(x, dtype=float)), dtype=float)
+            )
+            result = least_squares(
+                residual_fun,
+                context["x0"],
+                jac=jac_fun,
+                x_scale=context["x_scale"],
+                max_nfev=int(max_nfev),
+                ftol=1.0e-7,
+                xtol=1.0e-7,
+                gtol=1.0e-7,
+                verbose=2,
+                callback=callback,
+            )
+    except WallClockStop as exc:
+        timed_out = True
+        error_text = str(exc)
+    except Exception:
+        error_text = traceback.format_exc()
+
+    final_x = None
+    if result is not None:
+        final_x = np.asarray(result.x, dtype=float)
+    finalize(final_x, "final")
+    try:
+        rows = enrich_iteration_metrics(rows, context, case_name)
+    except Exception:
+        metrics_error_text = traceback.format_exc()
+
+    summary = {
+        "case": case_name,
+        "max_mode": int(max_mode),
+        "max_nfev": int(max_nfev),
+        "wall_clock_limit_s": float(wall_clock_limit_s),
+        "timed_out": bool(timed_out),
+        "error": error_text,
+        "elapsed_s": float(time.perf_counter() - start_time),
+        "peak_rss_bytes": peak_rss_bytes(),
+        "residual_calls": int(counters["residual_calls"]),
+        "jacobian_calls": int(counters["jacobian_calls"]),
+        "n_iterations_logged": len(rows),
+        "metrics_error": metrics_error_text,
+    }
+    if result is not None:
+        summary.update(
+            {
+                "success": bool(result.success),
+                "status": int(result.status),
+                "message": str(result.message),
+                "nfev": int(result.nfev),
+                "njev": None if result.njev is None else int(result.njev),
+                "optimality": float(result.optimality),
+            }
+        )
+    if rows:
+        summary["initial"] = rows[0]
+        summary["final"] = rows[-1]
+
+    with summary_path.open("w") as f:
+        json.dump(summary, f, indent=2)
+    with iterations_path.open("w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+    return summary_path, iterations_path
+
+
+def run_case_subprocess(case_name, max_mode, max_nfev, wall_clock_limit_s, output_dir):
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stdout_path = output_dir / f"{case_name}_mode{max_mode}.stdout.txt"
+    stderr_path = output_dir / f"{case_name}_mode{max_mode}.stderr.txt"
+    cmd = [
+        sys.executable,
+        __file__,
+        "--run-case",
+        case_name,
+        "--max-mode",
+        str(max_mode),
+        "--max-nfev",
+        str(max_nfev),
+        "--wall-clock-limit",
+        str(wall_clock_limit_s),
+        "--output-dir",
+        str(output_dir),
+    ]
+    proc = subprocess.run(
+        cmd,
+        cwd=str(Path(__file__).resolve().parents[2]),
+        capture_output=True,
+        text=True,
+        timeout=float(wall_clock_limit_s) + 120.0,
+    )
+    stdout_path.write_text(proc.stdout)
+    stderr_path.write_text(proc.stderr)
+    summary_path = output_dir / f"{case_name}_mode{max_mode}_summary.json"
+    iterations_path = output_dir / f"{case_name}_mode{max_mode}_iterations.jsonl"
+    return {
+        "returncode": int(proc.returncode),
+        "summary_path": summary_path,
+        "iterations_path": iterations_path,
+        "stdout_path": stdout_path,
+        "stderr_path": stderr_path,
+    }
+
+
+def load_json(path):
+    with Path(path).open() as f:
+        return json.load(f)
+
+
+def load_jsonl(path):
+    rows = []
+    with Path(path).open() as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def write_summary_markdown(results, output_dir):
+    output_dir = Path(output_dir)
+    summary_md = output_dir / "summary.md"
+    lines = [
+        "# QH Classic vs JAX comparison",
+        "",
+        "- Stable comparison set generated from direct per-case runs.",
+        "- Classic runs used a 300 s wall-clock cap.",
+        "- JAX runs used shorter caps to stay inside the exact-path stable window.",
+        f"- Max nfev requested per case: {MAX_NFEV}",
+        "",
+        "| case | mode | wall cap (s) | timed out | success | elapsed (s) | peak RSS (GB) | final total | final qs | final aspect |",
+        "| --- | --- | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for item in results:
+        summary = item["summary"]
+        final_row = summary.get("final", {})
+        lines.append(
+            "| {case} | {mode} | {wall_cap:.0f} | {timed_out} | {success} | {elapsed:.2f} | {peak:.2f} | {total:.6f} | {qs:.6f} | {aspect:.6f} |".format(
+                case=summary["case"],
+                mode=summary["max_mode"],
+                wall_cap=float(summary.get("wall_clock_limit_s", float("nan"))),
+                timed_out=summary.get("timed_out", False),
+                success=summary.get("success", False),
+                elapsed=float(summary.get("elapsed_s", 0.0)),
+                peak=float(summary.get("peak_rss_bytes", 0)) / (1024.0 ** 3),
+                total=float(final_row.get("total_objective", float("nan"))),
+                qs=float(final_row.get("qs_objective", float("nan"))),
+                aspect=float(final_row.get("aspect_value", float("nan"))),
+            )
+        )
+    summary_md.write_text("\n".join(lines) + "\n")
+    return summary_md
+
+
+def make_mode_plot(mode, series_by_case, output_dir):
+    fig, axes = plt.subplots(2, 2, figsize=(13, 9), constrained_layout=True)
+    colors = {"classic": "#1f77b4", "jax": "#d62728"}
+    labels = {"classic": "Classic VMEC2000", "jax": "VMEC-JAX discrete adjoint"}
+    for case_name, rows in series_by_case.items():
+        if not rows:
+            continue
+        color = colors[case_name]
+        label = labels[case_name]
+        iteration = [int(row["iteration"]) for row in rows]
+        elapsed = [float(row["elapsed_s"]) for row in rows]
+        rss_gb = [float(row["rss_bytes"]) / (1024.0 ** 3) for row in rows]
+        total = [float(row["total_objective"]) for row in rows if "total_objective" in row]
+        qs_objective = [float(row["qs_objective"]) for row in rows if "qs_objective" in row]
+        aspect_term = [float(row["aspect_term"]) for row in rows if "aspect_term" in row]
+        aspect_value = [float(row["aspect_value"]) for row in rows if "aspect_value" in row]
+        objective_iteration = [int(row["iteration"]) for row in rows if "total_objective" in row]
+        aspect_iteration = [int(row["iteration"]) for row in rows if "aspect_value" in row]
+
+        axes[0, 0].plot(iteration, elapsed, marker="o", color=color, label=label)
+        axes[0, 1].plot(iteration, rss_gb, marker="o", color=color, label=label)
+        if total:
+            axes[1, 0].plot(objective_iteration, total, marker="o", color=color, label=f"{label} total")
+            axes[1, 0].plot(objective_iteration, qs_objective, marker="s", linestyle="--", color=color, alpha=0.8, label=f"{label} qs")
+            axes[1, 0].plot(objective_iteration, aspect_term, marker="^", linestyle=":", color=color, alpha=0.8, label=f"{label} aspect term")
+        if aspect_value:
+            axes[1, 1].plot(aspect_iteration, aspect_value, marker="o", color=color, label=label)
+
+    axes[0, 0].set_title(f"Mode {mode}: runtime by iteration")
+    axes[0, 0].set_xlabel("Iteration")
+    axes[0, 0].set_ylabel("Elapsed time (s)")
+    axes[0, 0].grid(True, alpha=0.3)
+
+    axes[0, 1].set_title(f"Mode {mode}: memory by iteration")
+    axes[0, 1].set_xlabel("Iteration")
+    axes[0, 1].set_ylabel("RSS (GB)")
+    axes[0, 1].grid(True, alpha=0.3)
+
+    axes[1, 0].set_title(f"Mode {mode}: objective terms by iteration")
+    axes[1, 0].set_xlabel("Iteration")
+    axes[1, 0].set_ylabel("Objective")
+    axes[1, 0].set_yscale("log")
+    axes[1, 0].grid(True, alpha=0.3)
+
+    axes[1, 1].set_title(f"Mode {mode}: aspect value by iteration")
+    axes[1, 1].set_xlabel("Iteration")
+    axes[1, 1].set_ylabel("Aspect")
+    axes[1, 1].grid(True, alpha=0.3)
+
+    for ax in axes.flat:
+        ax.legend(fontsize=8)
+
+    output_path = Path(output_dir) / f"qh_compare_mode{mode}_iterations.png"
+    fig.savefig(output_path, dpi=180)
+    plt.close(fig)
+    return output_path
+
+
+def run_parent(output_dir, max_nfev, wall_clock_limit_s):
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    results = []
+    for max_mode in (1, 2):
+        for case_name in ("classic", "jax"):
+            gc.collect()
+            child = run_case_subprocess(case_name, max_mode, max_nfev, wall_clock_limit_s, output_dir)
+            if child["summary_path"].exists():
+                summary = load_json(child["summary_path"])
+            else:
+                summary = {
+                    "case": case_name,
+                    "max_mode": max_mode,
+                    "max_nfev": max_nfev,
+                    "wall_clock_limit_s": wall_clock_limit_s,
+                    "timed_out": False,
+                    "success": False,
+                    "status": -999,
+                    "message": f"missing summary, child returncode={child['returncode']}",
+                    "error": str(child["stderr_path"]),
+                    "elapsed_s": float("nan"),
+                    "peak_rss_bytes": 0,
+                }
+            iterations = load_jsonl(child["iterations_path"]) if child["iterations_path"].exists() else []
+            results.append(
+                {
+                    "case": case_name,
+                    "mode": max_mode,
+                    "summary": summary,
+                    "iterations": iterations,
+                    "stdout_path": str(child["stdout_path"]),
+                    "stderr_path": str(child["stderr_path"]),
+                }
+            )
+
+    plot_paths = []
+    for max_mode in (1, 2):
+        series = {item["case"]: item["iterations"] for item in results if item["mode"] == max_mode}
+        plot_paths.append(make_mode_plot(max_mode, series, output_dir))
+
+    summary_md = write_summary_markdown(results, output_dir)
+    manifest_path = output_dir / "manifest.json"
+    manifest = {
+        "output_dir": str(output_dir),
+        "summary_markdown": str(summary_md),
+        "plots": [str(path) for path in plot_paths],
+        "results": results,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    return manifest_path
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-case", choices=["classic", "jax"], default=None)
+    parser.add_argument("--max-mode", type=int, default=1)
+    parser.add_argument("--max-nfev", type=int, default=MAX_NFEV)
+    parser.add_argument("--wall-clock-limit", type=float, default=WALL_CLOCK_LIMIT_S)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args()
+
+    if args.run_case is not None:
+        run_case(args.run_case, args.max_mode, args.max_nfev, args.wall_clock_limit, args.output_dir)
+        return
+
+    manifest_path = run_parent(args.output_dir, args.max_nfev, args.wall_clock_limit)
+    print(json.dumps({"manifest": str(manifest_path)}, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- adds a capped classic-vs-VMEC-JAX QH benchmark/plot harness for the fixed-resolution example
- exposes a cached `scipy_state_payload` helper on the discrete-adjoint objective stage so diagnostics can reuse the same exact solve
- adds wrapper coverage for the cached payload helper and same-x solve reuse
- records the latest stable comparison window in the branch plan

## Benchmarks
Stable comparison set generated by `tools/diagnostics/qh_classic_vs_jax_compare.py`:
- classic mode 1, 300 s cap: final total `0.2137756`, peak RSS `0.49 GB`
- classic mode 2, 300 s cap: final total `0.0055640`, peak RSS `0.49 GB`
- JAX mode 1, 90 s cap: final total `0.2490250`, peak RSS `14.93 GB`
- JAX mode 2, 90 s cap: final total `0.2262223`, peak RSS `16.91 GB`

## Status
This PR is draft on purpose.
- The late-iterate Jacobian blow-up is fixed on the current branch stack.
- The remaining blocker is forward exact solve cost plus memory/executable retention on nearby points.
- The new benchmark harness is intended to be the acceptance gate for the next runtime pass.
