### PR TITLE
Desc Integration

### DIFF
--- a/src/simsopt/mhd/desc.py
+++ b/src/simsopt/mhd/desc.py
@@ -1,3 +1,11 @@
+# coding: utf-8
+# Copyright (c) HiddenSymmetries Development Team.
+# Distributed under the terms of the MIT License
+
+"""
+This module provides a class that handles the DESC equilibrium code.
+"""
+
 import logging
 import os
 import re
@@ -10,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 from simsopt.mhd import ProfileSpline, ProfilePolynomial, Vmec
 from simsopt._core import Optimizable
+
+# TODO: remove this import after merging the surface conversion.
 from constellaration.geometry.surface_utils_desc import (
     to_desc_fourier_rz_toroidal_surface,
     from_desc_fourier_rz_toroidal_surface,
@@ -17,14 +27,22 @@ from constellaration.geometry.surface_utils_desc import (
 from constellaration.geometry.surface_rz_fourier import to_simsopt, from_simsopt
 
 from typing import Protocol, runtime_checkable, Any, Optional
-from desc.equilibrium import Equilibrium as DescEquilibrium
-from desc.geometry import FourierRZToroidalSurface as DescFourierRZToroidalSurface
-from desc.profiles import (
-    SplineProfile as DescSplineProfile,
-    PowerSeriesProfile as DescPowerSeriesProfile,
-)
-from desc.vmec import VMECIO
-from desc.compat import rescale as desc_rescale
+
+try:
+    from desc.equilibrium import Equilibrium as DescEquilibrium
+    from desc.geometry import FourierRZToroidalSurface as DescFourierRZToroidalSurface
+    from desc.profiles import (
+        SplineProfile as DescSplineProfile,
+        PowerSeriesProfile as DescPowerSeriesProfile,
+    )
+    from desc.vmec import VMECIO
+    from desc.compat import rescale as desc_rescale
+    desc_available = True
+except ImportError as e:
+    desc_available = False
+    logger.debug(str(e))
+
+__all__ = ["Desc"]
 
 
 @runtime_checkable
@@ -45,7 +63,7 @@ class DescEquilibriumProtocol(Protocol):
     on the DESC Equilibrium object.
     """
 
-    surface: DescFourierRZToroidalSurface
+    surface: Any
     pressure: Any
     current: Optional[Any]
     iota: Optional[Any]
@@ -61,7 +79,7 @@ class DescEquilibriumProtocol(Protocol):
         pass
 
 
-class DescOptimizable(Optimizable):
+class Desc(Optimizable):
     """An Optimizable object for interfacing with the DESC code to solve Ideal MHD equilibria.
 
     In addition to passing in a Surface object representing the plasma boundary, the edge toroidal
@@ -84,7 +102,7 @@ class DescOptimizable(Optimizable):
         # I(rho) = 0
         current_profile = ProfilePolynomial([0.0])
         psi = 5.0
-        eq = DescOptimizable(boundary,
+        eq = Desc(boundary,
                             psi=psi,
                             pressure_profile=pressure_profile,
                             current_profile=current_profile)
@@ -123,6 +141,9 @@ class DescOptimizable(Optimizable):
         eq=None,
         **kwargs,
     ) -> None:
+        
+        if not desc_available:
+            raise RuntimeError("simsopt requires the desc python package to use Desc.")
 
         if pressure_profile is None:
             raise ValueError("pressure_profile is a required input.")
@@ -256,6 +277,8 @@ class DescOptimizable(Optimizable):
         Returns:
             SurfaceRZFourier: boundary shape as a SurfaceRZFourier.
         """
+        # TODO: this will create a new optimizable object. Instead, overwrite the
+        # TODO: existing dofs
         boundary_constellaration = from_desc_fourier_rz_toroidal_surface(eq.surface)
         boundary = to_simsopt(boundary_constellaration)
         return boundary
@@ -291,6 +314,8 @@ class DescOptimizable(Optimizable):
         Returns:
             tuple: (pressure_profile, current_profile, iota_profile) of Simsopt Profile objects (or None).
         """
+        # TODO: this will create a new optimizable object. Instead, overwrite the
+        # TODO: existing dofs
         pressure_profile = cls._profile_from_desc(
             eq.pressure, n_knots=n_knots, degree=degree
         )
@@ -468,7 +493,7 @@ class DescOptimizable(Optimizable):
         The Optimizable boundary, profiles, and psi will be scaled accordingly.
 
         Example:
-            desc_eq = DescOptimizable(...)
+            desc_eq = Desc(...)
             desc_eq.rescale(L=("a", 1.0), B=("<B>", 1.0), scale_pressure=True)
 
         Args:
@@ -579,7 +604,7 @@ class DescOptimizable(Optimizable):
 
     @classmethod
     def from_eq(cls, eq, n_knots=20, degree=3):
-        """Build a DescOptimizable object from a Desc Equilibrium object.
+        """Build a Desc object from a Desc Equilibrium object.
         The profiles are interpolated to spline profiles. The equilibrium object
         will used for evaluation etc.
 
@@ -589,7 +614,7 @@ class DescOptimizable(Optimizable):
             degree (str): Degree of the spline to use for the profiles.
 
         Returns:
-            DescOptimizable: Optimizable object representing the equilibrium.
+            Desc: Optimizable object representing the equilibrium.
         """
         # check protocol
         if not isinstance(eq, DescEquilibriumProtocol):
@@ -616,11 +641,11 @@ class DescOptimizable(Optimizable):
 
     @classmethod
     def from_input_file(cls, filename, n_knots=20, degree=3, **kwargs):
-        """Build a DescOptimizable object from a Desc or Vmec *input* file.
+        """Build a Desc object from a Desc or Vmec *input* file.
         The profiles are interpolated to spline profiles.
 
         Example:
-            eq = DescOptimizable.from_input_file("input.precise_QA")
+            eq = Desc.from_input_file("input.precise_QA")
 
         Args:
             filename (str): Name of the input file to load.
@@ -629,7 +654,7 @@ class DescOptimizable(Optimizable):
             kwargs: Key-word arguments to pass to the Equilibrium object, such as L or M.
 
         Return:
-            DescOptimizable: Optimizable object representing the equilibrium.
+            Desc: Optimizable object representing the equilibrium.
         """
         # DESC writes a `<filename>_desc` sidecar file when loading a VMEC input.
         # Copy to a temp dir so we don't need write access to the source directory.
@@ -649,12 +674,12 @@ class DescOptimizable(Optimizable):
 
     @classmethod
     def from_file(cls, filename, n_knots=20, degree=3):
-        """Build a DescOptimizable object from a Desc hdf5 or pickle file,
+        """Build a Desc object from a Desc hdf5 or pickle file,
         using the eq.load(filename) method. The profiles are interpolated
         to spline profiles.
 
         Example:
-            eq = DescOptimizable.from_file("saved_equilibrium.hdf5")
+            eq = Desc.from_file("saved_equilibrium.hdf5")
 
         Args:
             filename (str): Name of the file to load.
@@ -662,7 +687,7 @@ class DescOptimizable(Optimizable):
             degree (str): Degree of the spline to use for the profiles.
 
         Return:
-            DescOptimizable: Optimizable object representing the equilibrium.
+            Desc: Optimizable object representing the equilibrium.
         """
         eq = DescEquilibrium.load(filename)
         return cls.from_eq(eq, n_knots=n_knots, degree=degree)

--- a/src/simsopt/mhd/desc.py
+++ b/src/simsopt/mhd/desc.py
@@ -16,7 +16,7 @@ from constellaration.geometry.surface_utils_desc import (
 )
 from constellaration.geometry.surface_rz_fourier import to_simsopt, from_simsopt
 
-from typing import Protocol, runtime_checkable, Any
+from typing import Protocol, runtime_checkable, Any, Optional
 from desc.equilibrium import Equilibrium as DescEquilibrium
 from desc.geometry import FourierRZToroidalSurface as DescFourierRZToroidalSurface
 from desc.profiles import (
@@ -47,14 +47,17 @@ class DescEquilibriumProtocol(Protocol):
 
     surface: DescFourierRZToroidalSurface
     pressure: Any
-    current: Any
-    iota: Any
+    current: Optional[Any]
+    iota: Optional[Any]
     Psi: float
 
     def solve(self, *args: Any, **kwargs: Any) -> Any:
         pass
 
     def compute(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    def save(self, *args: Any, **kwargs: Any) -> Any:
         pass
 
 
@@ -257,7 +260,7 @@ class DescOptimizable(Optimizable):
         boundary = to_simsopt(boundary_constellaration)
         return boundary
 
-    def profiles_for_eq(self):
+    def profiles_to_desc(self):
         """Convert simsopt profiles to DESC Profile objects.
 
         Returns:
@@ -277,7 +280,7 @@ class DescOptimizable(Optimizable):
         return pressure, current, iota
 
     @classmethod
-    def extract_profiles_from_eq(cls, eq, n_knots=20, degree=3):
+    def profiles_from_desc(cls, eq, n_knots=20, degree=3):
         """
         Convert the profiles of the Equilibrium object to Simsopt profiles.
 
@@ -389,7 +392,7 @@ class DescOptimizable(Optimizable):
         """
 
         boundary_desc = self.surface_to_desc(self.boundary)
-        pressure, current, iota = self.profiles_for_eq()
+        pressure, current, iota = self.profiles_to_desc()
 
         if eq is None:
             # Determine which profile to use at initialization
@@ -408,7 +411,7 @@ class DescOptimizable(Optimizable):
                 **kwargs,
             )
 
-        # check protocal
+        # check protocol
         if not isinstance(eq, DescEquilibriumProtocol):
             raise TypeError("DESC Equilibrium does not match DescEquilibriumProtocol.")
 
@@ -444,7 +447,7 @@ class DescOptimizable(Optimizable):
             return
 
         boundary_desc = self.surface_to_desc(self.boundary)
-        pressure, current, iota = self.profiles_for_eq()
+        pressure, current, iota = self.profiles_to_desc()
 
         self.eq.surface = boundary_desc
         self.eq.pressure = pressure
@@ -480,7 +483,7 @@ class DescOptimizable(Optimizable):
         # get scaled variables
         psi = eq.Psi
         boundary = self.surface_from_desc(eq)
-        pressure_profile, current_profile, iota_profile = self.extract_profiles_from_eq(
+        pressure_profile, current_profile, iota_profile = self.profiles_from_desc(
             eq, n_knots=self.n_knots, degree=self.degree
         )
 
@@ -493,8 +496,7 @@ class DescOptimizable(Optimizable):
         self.eq = eq
 
         scale_pressure = kwargs.get("scale_pressure", False)
-        if not scale_pressure:
-            self.need_to_run_code = True
+        self.need_to_run_code = not scale_pressure
 
         return
 
@@ -589,13 +591,13 @@ class DescOptimizable(Optimizable):
         Returns:
             DescOptimizable: Optimizable object representing the equilibrium.
         """
-        # check protocal
+        # check protocol
         if not isinstance(eq, DescEquilibriumProtocol):
             raise TypeError("DESC Equilibrium does not match DescEquilibriumProtocol.")
 
         boundary = cls.surface_from_desc(eq)
 
-        pressure_profile, current_profile, iota_profile = cls.extract_profiles_from_eq(
+        pressure_profile, current_profile, iota_profile = cls.profiles_from_desc(
             eq, n_knots=n_knots, degree=degree
         )
 
@@ -696,8 +698,8 @@ class DescOptimizable(Optimizable):
 
         Args:
             filename (str): File path.
-            *args: Arguments to VMECIO.write_vmec_input.
-            **kwargs: Keyword arguments VMECIO.to write_vmec_input.
+            *args: Positional arguments passed to Equilibrium.save().
+            **kwargs: Keyword arguments passed to Equilibrium.save().
 
         Returns:
             None

--- a/src/simsopt/mhd/desc.py
+++ b/src/simsopt/mhd/desc.py
@@ -30,7 +30,6 @@ from typing import Protocol, runtime_checkable, Any, Optional
 
 try:
     from desc.equilibrium import Equilibrium as DescEquilibrium
-    from desc.geometry import FourierRZToroidalSurface as DescFourierRZToroidalSurface
     from desc.profiles import (
         SplineProfile as DescSplineProfile,
         PowerSeriesProfile as DescPowerSeriesProfile,

--- a/src/simsopt/mhd/desc.py
+++ b/src/simsopt/mhd/desc.py
@@ -543,14 +543,27 @@ class Desc(Optimizable):
         self.eq.solve(*args, **kwargs)
         self.need_to_run_code = False
 
-    def to_vmec(self, **kwargs):
+    def to_vmec(self, vmec_options={}, **kwargs):
         """Convert equilibrium to a Vmec object.
-        There are no gaurantees that Vmec will be able to run the equilibrium.
+        There are no gaurantees that Vmec will be able to evaluate the equilibrium.
 
         Args:
-            kwargs: Keyword arguments to be passed to the Vmec constructor, such as
-                `mpi` or `verbose`, using e.g. `vmec = Vmec(**kwargs)`.
-                See the documentation of Vmec for an up to date list of the keyword arguments.
+            vmec_options (dict, optional): Dictionary of vmec.indata fields to override
+                the defaults. Supported keys and their defaults:
+                - ``mpol`` (int): Poloidal mode number. Defaults to ``max(boundary.mpol, 10)``.
+                - ``ntor`` (int): Toroidal mode number. Defaults to ``max(boundary.ntor, 10)``.
+                - ``ntheta`` (int): Poloidal grid points. Defaults to ``2 * mpol + 6``.
+                - ``nzeta`` (int): Toroidal grid points. Defaults to ``2 * ntor + 4``.
+                - ``delt`` (float): Time step. Defaults to ``0.5``.
+                - ``nstep`` (int): Number of steps per call. Defaults to ``200``.
+                - ``ns_array`` (list): Radial grid sizes. Defaults to ``[16, 32, 64, 101, 0]``.
+                - ``niter_array`` (list): Iteration limits per grid. Defaults to ``[1000, 2000, 3000, 10000, 0]``.
+                - ``ftol_array`` (list): Force tolerances per grid. Defaults to ``[1e-16, 1e-16, 1e-16, 1e-13, 0.0]``.
+                - ``lfreeb`` (bool): Free-boundary flag. Defaults to ``False``.
+                - ``pres_scale`` (float): Pressure scaling factor. Defaults to ``1.0``.
+                Any remaining keys are applied directly to ``vmec.indata``.
+            kwargs: Keyword arguments passed to the Vmec constructor, such as
+                ``mpi`` or ``verbose``. See the Vmec documentation for available options.
 
         Returns:
             Vmec: Vmec object representing the equilibrium.
@@ -565,39 +578,43 @@ class Desc(Optimizable):
         vmec.indata.lasym = not self.boundary.stellsym
         vmec.indata.nfp = self.boundary.nfp
 
-        mpol = boundary_rz.mpol
-        ntor = boundary_rz.ntor
-        vmec.indata.mpol = mpol
-        vmec.indata.ntor = ntor
+        vmec.indata.mpol = vmec_options.pop("mpol", max(boundary_rz.mpol, 10))
+        vmec.indata.ntor = vmec_options.pop("ntor", max(boundary_rz.ntor, 10))
 
         # Vmec default
-        vmec.indata.ntheta = 2 * mpol + 6
-        vmec.indata.nzeta = 2 * ntor + 4
+        vmec.indata.ntheta = vmec_options.pop("ntheta", 2 * vmec.indata.mpol + 6)
+        vmec.indata.nzeta = vmec_options.pop("nzeta", 2 * vmec.indata.ntor + 4)
 
-        vmec.indata.delt = 0.5
-        vmec.indata.nstep = 200
-        vmec.indata.ns_array[:5] = [16, 32, 64, 101, 0]
-        vmec.indata.niter_array[:5] = [1000, 2000, 3000, 10000, 0]
-        vmec.indata.ftol_array[:5] = [1.0e-16, 1.0e-16, 1.0e-16, 1.0e-13, 0.0]
+        vmec.indata.delt = vmec_options.pop('delt', 0.5)
+        vmec.indata.nstep = vmec_options.pop('nstep', 200)
+        ns_array = vmec_options.pop("ns_array", [16, 32, 64, 101, 0])
+        vmec.indata.ns_array[:len(ns_array)] = ns_array 
+        niter_array = vmec_options.pop("niter_array", [1000, 2000, 3000, 10000, 0])
+        vmec.indata.niter_array[:len(niter_array)] = niter_array 
+        ftol_array = vmec_options.pop("ftol_array", [1.0e-16, 1.0e-16, 1.0e-16, 1.0e-13, 0.0])
+        vmec.indata.ftol_array[:len(ftol_array)] = ftol_array
 
-        vmec.indata.lfreeb = False
+        vmec.indata.lfreeb = vmec_options.pop('lfreeb', False)
 
         vmec.pressure_profile = self.pressure_profile
         if isinstance(self.pressure_profile, ProfileSpline):
             vmec.indata.pmass_type = "cubic_spline"
-        vmec.indata.pres_scale = 1.0
+        vmec.indata.pres_scale = vmec_options.pop('pres_scale', 1.0)
 
         use_current = self._determine_which_profile()
         if use_current:
             if isinstance(self.current_profile, ProfileSpline):
                 vmec.indata.pcurr_type = "cubic_spline_i"
             vmec.current_profile = self.current_profile
-            vmec.indata.ncurr = 1
+            vmec.indata.ncurr = 1.0
         else:
             vmec.iota_profile = self.iota_profile
             if isinstance(self.iota_profile, ProfileSpline):
                 vmec.indata.piota_type = "cubic_spline"
             vmec.indata.ncurr = 0
+        
+        for k, v in vmec_options.items():
+            eval(f"vmec.indata.{k} = {v}")
 
         return vmec
 

--- a/src/simsopt/mhd/desc.py
+++ b/src/simsopt/mhd/desc.py
@@ -1,0 +1,722 @@
+import logging
+import os
+import re
+import shutil
+import tempfile
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+from simsopt.mhd import ProfileSpline, ProfilePolynomial, Vmec
+from simsopt._core import Optimizable
+from constellaration.geometry.surface_utils_desc import (
+    to_desc_fourier_rz_toroidal_surface,
+    from_desc_fourier_rz_toroidal_surface,
+)
+from constellaration.geometry.surface_rz_fourier import to_simsopt, from_simsopt
+
+from typing import Protocol, runtime_checkable, Any
+from desc.equilibrium import Equilibrium as DescEquilibrium
+from desc.geometry import FourierRZToroidalSurface as DescFourierRZToroidalSurface
+from desc.profiles import (
+    SplineProfile as DescSplineProfile,
+    PowerSeriesProfile as DescPowerSeriesProfile,
+)
+from desc.vmec import VMECIO
+from desc.compat import rescale as desc_rescale
+
+
+@runtime_checkable
+class DescEquilibriumProtocol(Protocol):
+    """A Protocol for desc.equilibrium.Equilibrium objects. This Protocol determines
+    the basic set of attributes and methods that a DESC Equilibrium must have in order
+    to be used within Simsopt.
+
+    Running,
+        ```
+        from desc.equilibrium import Equilibrium
+        eq = Equilibrium(...)
+        isinstance(eq, DescEquilibriumProtocol)
+        ```
+    will check the DESC Equilibrium object has the attributes and methods defined by the DescEquilibriumProtocol.
+    If False, then `eq` does not have the necessary structure to be used within Simsopt.
+    This check should be implemented by all methods that rely directly (though not indirectly)
+    on the DESC Equilibrium object.
+    """
+
+    surface: DescFourierRZToroidalSurface
+    pressure: Any
+    current: Any
+    iota: Any
+    Psi: float
+
+    def solve(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    def compute(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+
+class DescOptimizable(Optimizable):
+    """An Optimizable object for interfacing with the DESC code to solve Ideal MHD equilibria.
+
+    In addition to passing in a Surface object representing the plasma boundary, the edge toroidal
+    flux, the pressure profile, and one of the iota or current profile should be prescribed. Both
+    rotational transform and current profiles can be passed in. When solve() is called, one of the
+    profiles must be chosen to be used.
+
+    The profiles should represent p(rho), I(rho) (or iota(rho)) where rho is Desc's normalized radial
+    coordinate; the profiles should not represent derivatives such as p'(rho), I'(rho). rho
+    relates to toroidal flux psi as rho = (psi / psi_edge)^2, so it is standard for profiles
+    to be even functions of rho, such as p(rho) = p0 + p2 * rho^2 + ...
+
+    The degrees of freedom are psi and any dofs associated to the boundary and profiles.
+
+    Example:
+        boundary = SurfaceRZFourier().make_rotating_ellipse(major_radius=1,
+            minor_radius=0.1, elongation=1.2)
+        # p(rho) = p0 - p2 * rho^2
+        pressure_profile = ProfilePolynomial([1e4, 0.0, -1e4])
+        # I(rho) = 0
+        current_profile = ProfilePolynomial([0.0])
+        psi = 5.0
+        eq = DescOptimizable(boundary,
+                            psi=psi,
+                            pressure_profile=pressure_profile,
+                            current_profile=current_profile)
+        eq.solve()
+
+
+    Args:
+        boundary (Surface): Surface object representing the plasma boundary.
+        psi (float, optional): Edge toroidal flux [Webers]. Defaults to 1.0.
+        pressure_profile (Profile, optional): Pressure profile. Defaults to None.
+        iota_profile (Profile, optional):  Rotational transform profile. Defaults to None.
+        current_profile (Profile, optional):  Current profile. Defaults to None.
+        which_profile (str): One of ["current", "iota"].
+            Specify which profile to use as the second profile (current or iota) during
+            equilibrium solves. Using "auto" will choose whichever profile is not None,
+            and will default to using the current profile if both profiles are not None.
+            This attribute can be updated at any time using e.g. `eq.which_profile = "iota"`.
+        n_knots (int, optional): Number of knots to use in spline profile interpolation. Defaults to 20.
+        degree (int, optional): Degree of spline profile interpolants. Defaults to 3.
+        eq (Equilibrium, optional): Optionally pass in a Desc Equilibrium object which will be used
+            for evaluation etc. Default to None.
+        **kwargs: Keyword arguments passed to DESC Equilibrium() constructor. See the documentation of
+            Equilibium object for an up to date list of the keyword arguments.
+    """
+
+    def __init__(
+        self,
+        boundary,
+        psi=1.0,
+        pressure_profile=None,
+        current_profile=None,
+        iota_profile=None,
+        which_profile="auto",
+        n_knots=20,
+        degree=3,
+        eq=None,
+        **kwargs,
+    ) -> None:
+
+        if pressure_profile is None:
+            raise ValueError("pressure_profile is a required input.")
+        if current_profile is None and iota_profile is None:
+            raise ValueError("One of current_profile or iota_profile is required.")
+
+        self._boundary = boundary
+        self._pressure_profile = pressure_profile
+        self._current_profile = current_profile
+        self._iota_profile = iota_profile
+        self._which_profile = which_profile
+        self.need_to_run_code = True
+
+        self.n_knots = n_knots
+        self.degree = degree
+
+        x0 = np.array([psi])
+        names = ["psi"]
+        depends_on = [boundary, pressure_profile]
+        if current_profile is not None:
+            depends_on.append(current_profile)
+        if iota_profile is not None:
+            depends_on.append(iota_profile)
+        Optimizable.__init__(
+            self,
+            x0=x0,
+            names=names,
+            depends_on=depends_on,
+        )
+
+        self._init_desc_equilibrium(eq=eq, **kwargs)
+
+    @property
+    def which_profile(self):
+        return self._which_profile
+
+    @which_profile.setter
+    def which_profile(self, which_profile):
+        which_profile_options = ["auto", "current", "iota"]
+        if which_profile not in which_profile_options:
+            raise ValueError(f"which_profile must be one of {which_profile_options}")
+        self._which_profile = which_profile
+
+    @property
+    def boundary(self):
+        return self._boundary
+
+    @boundary.setter
+    def boundary(self, boundary):
+        if boundary is not self._boundary:
+            logger.debug("Replacing surface in boundary setter")
+            self.remove_parent(self._boundary)
+            self._boundary = boundary
+            self.append_parent(boundary)
+            self.need_to_run_code = True
+
+    @property
+    def pressure_profile(self):
+        return self._pressure_profile
+
+    @pressure_profile.setter
+    def pressure_profile(self, pressure_profile):
+        if pressure_profile is not self._pressure_profile:
+            logger.debug("Replacing pressure_profile in setter")
+            if self._pressure_profile is not None:
+                self.remove_parent(self._pressure_profile)
+            self._pressure_profile = pressure_profile
+            if pressure_profile is not None:
+                self.append_parent(pressure_profile)
+                self.need_to_run_code = True
+
+    @property
+    def current_profile(self):
+        return self._current_profile
+
+    @current_profile.setter
+    def current_profile(self, current_profile):
+        if current_profile is not self._current_profile:
+            logger.debug("Replacing current_profile in setter")
+            if self._current_profile is not None:
+                self.remove_parent(self._current_profile)
+            self._current_profile = current_profile
+            if current_profile is not None:
+                self.append_parent(current_profile)
+                self.need_to_run_code = True
+
+    @property
+    def iota_profile(self):
+        return self._iota_profile
+
+    @iota_profile.setter
+    def iota_profile(self, iota_profile):
+        if iota_profile is not self._iota_profile:
+            logger.debug("Replacing iota_profile in setter")
+            if self._iota_profile is not None:
+                self.remove_parent(self._iota_profile)
+            self._iota_profile = iota_profile
+            if iota_profile is not None:
+                self.append_parent(iota_profile)
+                self.need_to_run_code = True
+
+    def recompute_bell(self, parent=None):
+        """Flag that the equilibrium needs to be recomputed.
+
+        Args:
+            parent: Parent object (optional).
+        """
+        self.need_to_run_code = True
+
+    @staticmethod
+    def surface_to_desc(surface):
+        """Convert any Simsopt Surface to a DESC FourierRZToroidalSurface.
+
+        Args:
+            surface (Surface): A Simsopt Surface.
+
+        Returns:
+            FourierRZToroidalSurface: boundary shape for DESC.
+        """
+        boundary_rz = surface.to_RZFourier()
+        boundary_constellaration = from_simsopt(boundary_rz)
+        return to_desc_fourier_rz_toroidal_surface(boundary_constellaration)
+
+    @staticmethod
+    def surface_from_desc(eq):
+        """Get a SurfaceRZFourier object from a DESC equilibrium.
+
+        Args:
+            eq (Equilibrium): a DESC equilibrium object.
+
+        Returns:
+            SurfaceRZFourier: boundary shape as a SurfaceRZFourier.
+        """
+        boundary_constellaration = from_desc_fourier_rz_toroidal_surface(eq.surface)
+        boundary = to_simsopt(boundary_constellaration)
+        return boundary
+
+    def profiles_for_eq(self):
+        """Convert simsopt profiles to DESC Profile objects.
+
+        Returns:
+            tuple: (pressure, current, iota) of Desc Profile objects (or None).
+        """
+        pressure = self._profile_to_desc(self.pressure_profile)
+
+        if self.current_profile is not None:
+            current = self._profile_to_desc(self.current_profile)
+        else:
+            current = None
+
+        if self.iota_profile is not None:
+            iota = self._profile_to_desc(self.iota_profile)
+        else:
+            iota = None
+        return pressure, current, iota
+
+    @classmethod
+    def extract_profiles_from_eq(cls, eq, n_knots=20, degree=3):
+        """
+        Convert the profiles of the Equilibrium object to Simsopt profiles.
+
+        Args:
+            n_knots (int, optional): number of knots to use in splines. defaults to 20.
+            degree (int, optional): degree of splines. defaults to 3.
+
+        Returns:
+            tuple: (pressure_profile, current_profile, iota_profile) of Simsopt Profile objects (or None).
+        """
+        pressure_profile = cls._profile_from_desc(
+            eq.pressure, n_knots=n_knots, degree=degree
+        )
+
+        if eq.current is not None:
+            current_profile = cls._profile_from_desc(
+                eq.current, n_knots=n_knots, degree=degree
+            )
+        else:
+            current_profile = None
+
+        if eq.iota is not None:
+            iota_profile = cls._profile_from_desc(
+                eq.iota, n_knots=n_knots, degree=degree
+            )
+        else:
+            iota_profile = None
+
+        return pressure_profile, current_profile, iota_profile
+
+    @staticmethod
+    def _profile_to_desc(prof):
+        """Convert a Simsopt ProfileSpline or ProfilePolynomial to a DESC Profile.
+
+        Args:
+            prof (Profile): Simsopt Profile object (ProfileSpline or ProfilePolynomial).
+
+        Returns:
+            DESC Profile object (DescSplineProfile or DescPowerSeriesProfile).
+
+        Raises:
+            ValueError: If profile type is not ProfileSpline or ProfilePolynomial.
+        """
+        if isinstance(prof, ProfilePolynomial):
+            prof_desc = DescPowerSeriesProfile(params=prof.local_full_x)
+        elif isinstance(prof, ProfileSpline):
+            if prof.degree == 1:
+                method = "linear"
+            else:
+                method = "cubic2"
+            # TODO: prof.s is not a supported attribute of ProfileSpline
+            rho = prof.s
+            prof_desc = DescSplineProfile(
+                values=prof.local_full_x, knots=rho, method=method
+            )
+        else:
+            raise ValueError(
+                "Profile must be one of ProfileSpline or ProfilePolynomial."
+            )
+        return prof_desc
+
+    @staticmethod
+    def _profile_from_desc(prof_desc, n_knots=20, degree=3):
+        """Convert a DESC Profile to a Simsopt Profile.
+
+        If prof_desc is a PowerSeriesProfile, returns a ProfilePolynomial.
+        Otherwise, returns a ProfileSpline in rho-space.
+
+        Args:
+            prof_desc (DESC Profile): A DESC Profile object.
+            n_knots (int, optional): Number of knots in the spline. Defaults to 20.
+                Only used if prof_desc is not a PowerSeriesProfile.
+            degree (int, optional): Degree of the spline. Defaults to 3.
+                Only used if prof_desc is not a PowerSeriesProfile.
+
+        Returns:
+            Profile: A ProfilePolynomial or ProfileSpline in rho-space.
+        """
+        if isinstance(prof_desc, DescPowerSeriesProfile):
+            # Extract polynomial coefficients
+            params = np.copy(prof_desc.params)
+            if prof_desc.sym:
+                coeffs = np.zeros(2 * len(params) - 1)
+                coeffs[::2] = params
+            else:
+                coeffs = np.copy(params)
+            prof = ProfilePolynomial(coeffs)
+        else:
+            # Convert to spline in rho-space
+            rho_knots = np.linspace(0, 1, n_knots)
+            prof_spl = prof_desc.to_spline(knots=rho_knots, method="cubic2")
+            prof = ProfileSpline(rho_knots, np.array(prof_spl.params), degree=degree)
+        return prof
+
+    def _init_desc_equilibrium(self, eq=None, **kwargs):
+        """Create a DESC equilibrium from given information.
+
+        Raises:
+            TypeError: Desc Equilibrium must be an instance of DescEquilibriumProtocol.
+
+        Args:
+            eq (Equilibrium, optional): Optionally pass in a Desc Equilibrium object which will be used
+                for evaluation etc. If None, a new Equilibrium object will be created. Defaults to None.
+            **kwargs: Keyword arguments passed to DESC Equilibrium() constructor. See the documentation of
+                Equilibium object for an up to date list of the keyword arguments.
+
+        Return:
+            None
+        """
+
+        boundary_desc = self.surface_to_desc(self.boundary)
+        pressure, current, iota = self.profiles_for_eq()
+
+        if eq is None:
+            # Determine which profile to use at initialization
+            use_current = self._determine_which_profile()
+            if use_current:
+                iota = None
+            else:
+                current = None
+
+            eq = DescEquilibrium(
+                surface=boundary_desc,
+                pressure=pressure,
+                current=current,
+                iota=iota,
+                Psi=self.get("psi"),
+                **kwargs,
+            )
+
+        # check protocal
+        if not isinstance(eq, DescEquilibriumProtocol):
+            raise TypeError("DESC Equilibrium does not match DescEquilibriumProtocol.")
+
+        self.eq = eq
+
+        return
+
+    def _determine_which_profile(self):
+        """Determine which profile to use: current or iota.
+
+        Returns:
+            bool: If True, use current profile. Otherwise use iota profile.
+        """
+
+        if self.which_profile == "auto":
+            if self.current_profile is not None:
+                use_current = True
+            else:
+                use_current = False
+        else:
+            use_current = self.which_profile == "current"
+        return use_current
+
+    def update_desc_equilibrium(self):
+        """
+        Update a DESC equilibrium with current (boundary, profiles, psi).
+
+        Return:
+            None
+        """
+        if not self.need_to_run_code:
+            # dont update unless (boundary, profiles, psi) have changed
+            return
+
+        boundary_desc = self.surface_to_desc(self.boundary)
+        pressure, current, iota = self.profiles_for_eq()
+
+        self.eq.surface = boundary_desc
+        self.eq.pressure = pressure
+        self.eq.Psi = self.get("psi")
+
+        use_current = self._determine_which_profile()
+        if use_current:
+            self.eq.current = current
+            self.eq.iota = None
+        else:
+            self.eq.current = None
+            self.eq.iota = iota
+
+        return
+
+    def rescale(self, **kwargs):
+        """Rescale the Desc Equilibium using desc.compat.rescale.
+        The Optimizable boundary, profiles, and psi will be scaled accordingly.
+
+        Example:
+            desc_eq = DescOptimizable(...)
+            desc_eq.rescale(L=("a", 1.0), B=("<B>", 1.0), scale_pressure=True)
+
+        Args:
+            **kwargs: Keyword arguments passed to desc.compat.rescale. See the documentation of
+                desc.compat.rescale for an up to date list of the keyword arguments.
+
+        Return:
+            None
+        """
+        eq = desc_rescale(self.eq, **kwargs)
+
+        # get scaled variables
+        psi = eq.Psi
+        boundary = self.surface_from_desc(eq)
+        pressure_profile, current_profile, iota_profile = self.extract_profiles_from_eq(
+            eq, n_knots=self.n_knots, degree=self.degree
+        )
+
+        # update dofs
+        self.boundary = boundary
+        self.pressure_profile = pressure_profile
+        self.current_profile = current_profile
+        self.iota_profile = iota_profile
+        self.set("psi", psi)
+        self.eq = eq
+
+        scale_pressure = kwargs.get("scale_pressure", False)
+        if not scale_pressure:
+            self.need_to_run_code = True
+
+        return
+
+    def solve(self, *args, **kwargs):
+        """Call the Equilibium.solve() method of the Desc Equilibrium
+        Any args, kwargs will be passed to the solve() method.
+
+        Args:
+            **args: Arguments passed to solve(). See the documentation of
+                Equilibium.solve for an up to date list of the keyword arguments.
+            **kwargs: Keyword arguments passed to Equilibium.solve(). See the documentation of
+                Equilibium.solve() for an up to date list of the keyword arguments.
+
+        Return:
+            None
+        """
+        if not self.need_to_run_code:
+            return
+        self.update_desc_equilibrium()
+        self.eq.solve(*args, **kwargs)
+        self.need_to_run_code = False
+
+    def to_vmec(self, **kwargs):
+        """Convert equilibrium to a Vmec object.
+        There are no gaurantees that Vmec will be able to run the equilibrium.
+
+        Args:
+            kwargs: Keyword arguments to be passed to the Vmec constructor, such as
+                `mpi` or `verbose`, using e.g. `vmec = Vmec(**kwargs)`.
+                See the documentation of Vmec for an up to date list of the keyword arguments.
+
+        Returns:
+            Vmec: Vmec object representing the equilibrium.
+
+        """
+        vmec = Vmec(**kwargs)
+
+        vmec.boundary = self.boundary
+        boundary_rz = self.boundary.to_RZFourier()
+
+        vmec.indata.phiedge = self.get("psi")
+        vmec.indata.lasym = not self.boundary.stellsym
+        vmec.indata.nfp = self.boundary.nfp
+
+        mpol = boundary_rz.mpol
+        ntor = boundary_rz.ntor
+        vmec.indata.mpol = mpol
+        vmec.indata.ntor = ntor
+
+        # Vmec default
+        vmec.indata.ntheta = 2 * mpol + 6
+        vmec.indata.nzeta = 2 * ntor + 4
+
+        vmec.indata.delt = 0.5
+        vmec.indata.nstep = 200
+        vmec.indata.ns_array[:5] = [16, 32, 64, 101, 0]
+        vmec.indata.niter_array[:5] = [1000, 2000, 3000, 10000, 0]
+        vmec.indata.ftol_array[:5] = [1.0e-16, 1.0e-16, 1.0e-16, 1.0e-13, 0.0]
+
+        vmec.indata.lfreeb = False
+
+        vmec.pressure_profile = self.pressure_profile
+        if isinstance(self.pressure_profile, ProfileSpline):
+            vmec.indata.pmass_type = "cubic_spline"
+        vmec.indata.pres_scale = 1.0
+
+        use_current = self._determine_which_profile()
+        if use_current:
+            if isinstance(self.current_profile, ProfileSpline):
+                vmec.indata.pcurr_type = "cubic_spline_i"
+            vmec.current_profile = self.current_profile
+            vmec.indata.ncurr = 1
+        else:
+            vmec.iota_profile = self.iota_profile
+            if isinstance(self.iota_profile, ProfileSpline):
+                vmec.indata.piota_type = "cubic_spline"
+            vmec.indata.ncurr = 0
+
+        return vmec
+
+    @classmethod
+    def from_eq(cls, eq, n_knots=20, degree=3):
+        """Build a DescOptimizable object from a Desc Equilibrium object.
+        The profiles are interpolated to spline profiles. The equilibrium object
+        will used for evaluation etc.
+
+        Args:
+            eq (Equilibrium): a Desc Equilibrium
+            n_knots (str): Number of knots to use in interpolating the profile.
+            degree (str): Degree of the spline to use for the profiles.
+
+        Returns:
+            DescOptimizable: Optimizable object representing the equilibrium.
+        """
+        # check protocal
+        if not isinstance(eq, DescEquilibriumProtocol):
+            raise TypeError("DESC Equilibrium does not match DescEquilibriumProtocol.")
+
+        boundary = cls.surface_from_desc(eq)
+
+        pressure_profile, current_profile, iota_profile = cls.extract_profiles_from_eq(
+            eq, n_knots=n_knots, degree=degree
+        )
+
+        psi = eq.Psi
+
+        return cls(
+            boundary=boundary,
+            psi=psi,
+            pressure_profile=pressure_profile,
+            current_profile=current_profile,
+            iota_profile=iota_profile,
+            n_knots=n_knots,
+            degree=degree,
+            eq=eq,
+        )
+
+    @classmethod
+    def from_input_file(cls, filename, n_knots=20, degree=3, **kwargs):
+        """Build a DescOptimizable object from a Desc or Vmec *input* file.
+        The profiles are interpolated to spline profiles.
+
+        Example:
+            eq = DescOptimizable.from_input_file("input.precise_QA")
+
+        Args:
+            filename (str): Name of the input file to load.
+            n_knots (str): Number of knots to use in interpolating the profile.
+            degree (str): Degree of the spline to use for the profiles.
+            kwargs: Key-word arguments to pass to the Equilibrium object, such as L or M.
+
+        Return:
+            DescOptimizable: Optimizable object representing the equilibrium.
+        """
+        # DESC writes a `<filename>_desc` sidecar file when loading a VMEC input.
+        # Copy to a temp dir so we don't need write access to the source directory.
+        with open(filename, "r") as f:
+            header = f.read(8192)
+        is_vmec = bool(re.search(r"&INDATA", header, re.IGNORECASE))
+
+        if is_vmec:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                tmp_path = os.path.join(tmpdir, os.path.basename(filename))
+                shutil.copy2(filename, tmp_path)
+                eq = DescEquilibrium.from_input_file(tmp_path, **kwargs)
+        else:
+            eq = DescEquilibrium.from_input_file(filename, **kwargs)
+
+        return cls.from_eq(eq, n_knots=n_knots, degree=degree)
+
+    @classmethod
+    def from_file(cls, filename, n_knots=20, degree=3):
+        """Build a DescOptimizable object from a Desc hdf5 or pickle file,
+        using the eq.load(filename) method. The profiles are interpolated
+        to spline profiles.
+
+        Example:
+            eq = DescOptimizable.from_file("saved_equilibrium.hdf5")
+
+        Args:
+            filename (str): Name of the file to load.
+            n_knots (str): Number of knots to use in interpolating the profile.
+            degree (str): Degree of the spline to use for the profiles.
+
+        Return:
+            DescOptimizable: Optimizable object representing the equilibrium.
+        """
+        eq = DescEquilibrium.load(filename)
+        return cls.from_eq(eq, n_knots=n_knots, degree=degree)
+
+    def to_wout(self, filename):
+        """Write a Vmec style wout (Net-CDF) file from the DESC equilibrium.
+
+        Args:
+            filename (str): File path of output data.
+
+        Returns:
+            None
+        """
+        self.update_desc_equilibrium()
+        VMECIO.save(self.eq, filename)
+
+    def to_vmec_input(self, filename, *args, **kwargs):
+        """Write a Vmec input file from the DESC equilibrium.
+
+        Args:
+            filename (str): File path.
+            *args: Arguments to VMECIO.write_vmec_input.
+            **kwargs: Keyword arguments VMECIO.to write_vmec_input.
+
+        Returns:
+            None
+        """
+        self.update_desc_equilibrium()
+        VMECIO.write_vmec_input(self.eq, filename, *args, **kwargs)
+
+    def save_equilibrium(self, filename, *args, **kwargs):
+        """Save the Desc equilibrum using the Equilibrium.save() method.
+
+        Args:
+            filename (str): File path.
+            *args: Arguments to VMECIO.write_vmec_input.
+            **kwargs: Keyword arguments VMECIO.to write_vmec_input.
+
+        Returns:
+            None
+        """
+        self.update_desc_equilibrium()
+        self.eq.save(filename, *args, **kwargs)
+
+    def compute(self, *args, **kwargs):
+        """Compute requested quantities from the equilibrium using the eq.compute() method.
+            Equilibrium will be solved prior to calling compute(), if necessary.
+
+        Args:
+            *args: Positional arguments passed to DESC Equilibrium.compute().
+            **kwargs: Keyword arguments passed to DESC Equilibrium.compute(). See the
+                documentation of Equilibrium.compute() for available options.
+
+        Returns:
+            dict: Result of eq.compute(*args, **kwargs).
+        """
+
+        self.solve()
+        return self.eq.compute(*args, **kwargs)

--- a/src/simsopt/mhd/desc.py
+++ b/src/simsopt/mhd/desc.py
@@ -114,7 +114,7 @@ class Desc(Optimizable):
         pressure_profile (Profile, optional): Pressure profile. Defaults to None.
         iota_profile (Profile, optional):  Rotational transform profile. Defaults to None.
         current_profile (Profile, optional):  Current profile. Defaults to None.
-        which_profile (str): One of ["current", "iota"].
+        which_profile (str): One of ["auto", "current", "iota"].
             Specify which profile to use as the second profile (current or iota) during
             equilibrium solves. Using "auto" will choose whichever profile is not None,
             and will default to using the current profile if both profiles are not None.

--- a/tests/mhd/test_desc.py
+++ b/tests/mhd/test_desc.py
@@ -1,0 +1,1149 @@
+import unittest
+import tempfile
+import numpy as np
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from simsopt.mhd import ProfilePolynomial, ProfileSpline
+from simsopt.geo import SurfaceRZFourier
+from simsopt.mhd.desc import DescOptimizable, DescEquilibriumProtocol
+
+
+class TestProfilesToDesc(unittest.TestCase):
+    """Test conversion from simsopt to DESC profiles."""
+
+    def test_polynomial_profile_values_match(self):
+        """Test ProfilePolynomial conversion preserves values at key points in rho-space."""
+        # Create polynomial in rho-space: f(rho) = 1 - rho^2 (symmetric/even powers only)
+        prof = ProfilePolynomial([1.0, 0.0, -1.0])
+
+        # Convert to DESC
+        prof_desc = DescOptimizable._profile_to_desc(prof)
+
+        # Check values at several rho points
+        rho_test = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+
+        # Original polynomial values in rho-space
+        original_values = prof(rho_test)
+
+        # DESC profile values (also in rho-space)
+        desc_values = prof_desc(rho_test)
+
+        np.testing.assert_allclose(original_values, desc_values, rtol=1e-10)
+
+    def test_spline_profile_values_match(self):
+        """Test ProfileSpline conversion preserves values at key points in rho-space."""
+        # Create spline with a few knots in rho-space
+        rho_knots = np.linspace(0, 1, 4)
+        f_values = 1 - rho_knots
+        prof = ProfileSpline(rho_knots, f_values, degree=3)
+
+        # Convert to DESC
+        prof_desc = DescOptimizable._profile_to_desc(prof)
+
+        # Check values at rho test points
+        rho_test = np.linspace(0, 1, 5)
+
+        original_values = prof(rho_test)
+        desc_values = prof_desc(rho_test)
+
+        np.testing.assert_allclose(original_values, desc_values, rtol=1e-6, atol=1e-12)
+
+
+class TestProfilesFromDesc(unittest.TestCase):
+    """Test roundtrip conversion: simsopt -> DESC -> simsopt."""
+
+    def test_polynomial_roundtrip(self):
+        """Test polynomial -> DESC -> polynomial roundtrip in rho-space."""
+        # Create polynomial in rho-space: f(rho) = 1 - rho^2 + 0.5*rho^4 (even powers only)
+        prof_orig = ProfilePolynomial([1.0, 0.0, -1.0, 0.0, 0.5])
+
+        # Convert: simsopt -> DESC
+        prof_desc = DescOptimizable._profile_to_desc(prof_orig)
+
+        # Convert back: DESC -> simsopt
+        prof_simsopt = DescOptimizable._profile_from_desc(
+            prof_desc, n_knots=10, degree=3
+        )
+
+        # Should return a ProfilePolynomial, not a spline
+        self.assertIsInstance(prof_simsopt, ProfilePolynomial)
+
+        # Check values at test points in rho-space
+        rho_test = np.linspace(0, 1, 20)
+        original_values = prof_orig(rho_test)
+        roundtrip_values = prof_simsopt(rho_test)
+
+        # Exact tolerance since polynomial roundtrips should be exact
+        np.testing.assert_allclose(original_values, roundtrip_values, atol=1e-12)
+
+    def test_spline_roundtrip(self):
+        """Test spline -> DESC -> spline roundtrip in rho-space."""
+        n_pts = 6
+        rho_knots = np.linspace(0.0, 1.0, n_pts)
+        f_values = 1.0 - rho_knots**2  # Profile f(rho) = 1 - rho^2
+        prof_orig = ProfileSpline(rho_knots, f_values, degree=3)
+
+        # Roundtrip conversion
+        prof_desc = DescOptimizable._profile_to_desc(prof_orig)
+        prof_simsopt = DescOptimizable._profile_from_desc(
+            prof_desc, n_knots=n_pts, degree=3
+        )
+
+        # Check values in rho-space
+        rho_test = np.linspace(0, 1, 20)
+        original_values = prof_orig(rho_test)
+        roundtrip_values = prof_simsopt(rho_test)
+
+        np.testing.assert_allclose(original_values, roundtrip_values, atol=1e-12)
+
+
+class TestBoundaryToDesc(unittest.TestCase):
+    """Test conversion of plasma boundary surface to DESC format."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Load test boundary once for all tests in this class."""
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        cls.boundary = SurfaceRZFourier.from_vmec_input(input_file)
+
+    def test_nfp_preserved(self):
+        """Test that NFP is preserved in boundary conversion."""
+        desc_surface = DescOptimizable.surface_to_desc(self.boundary)
+
+        self.assertEqual(desc_surface.NFP, self.boundary.nfp)
+        self.assertEqual(desc_surface.NFP, 2)  # input.vacuum_template has NFP=2
+
+    def test_major_radius_preserved(self):
+        """Test that the (0,0) Fourier mode (major radius) is approximately preserved."""
+        boundary_rz = self.boundary.to_RZFourier()
+        desc_surface = DescOptimizable.surface_to_desc(boundary_rz)
+
+        # Get the R(0,0) coefficient, which is the major radius
+        R_00, _ = desc_surface.get_coeffs(0, 0)
+
+        # From input.vacuum_template: RBC(0,0) = 1.0
+        self.assertAlmostEqual(R_00, 1.0, places=12)
+
+    def test_roundtrip_to_desc_and_back(self):
+        """Test surface_to_desc followed by surface_from_desc roundtrip."""
+        from desc.equilibrium import Equilibrium as DescEquilibrium
+
+        # Convert surface to DESC format
+        desc_surface = DescOptimizable.surface_to_desc(self.boundary)
+
+        # Create a minimal DESC equilibrium with just the surface
+        eq = DescEquilibrium(surface=desc_surface)
+
+        # Convert back to simsopt surface
+        boundary_from_desc = DescOptimizable.surface_from_desc(eq)
+        boundary_roundtrip = boundary_from_desc.copy(
+            quadpoints_phi=self.boundary.quadpoints_phi,
+            quadpoints_theta=self.boundary.quadpoints_theta,
+        )
+
+        # Check key properties are preserved
+        self.assertEqual(boundary_roundtrip.nfp, self.boundary.nfp)
+        self.assertEqual(boundary_roundtrip.stellsym, self.boundary.stellsym)
+
+        # Check metric/geometry is preserved via gamma
+        gamma_flat = self.boundary.gamma().reshape((-1, 3))
+        gamma_rt_flat = boundary_roundtrip.gamma().reshape((-1, 3))
+        from scipy.spatial.distance import cdist
+
+        distances = cdist(gamma_flat, gamma_rt_flat)
+        gamma_err = np.max(np.min(distances, axis=1))
+        self.assertAlmostEqual(gamma_err, 0.0, places=12)
+
+
+class TestBuildDescEquilibrium(unittest.TestCase):
+    """Test building a DESC equilibrium from DescOptimizable."""
+
+    def setUp(self):
+        """Create a simple test equilibrium."""
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+
+        # Create simple profiles
+        # Symmetric polynomials (even powers only): f(rho) = c0 + c2*rho^2 + c4*rho^4 + ...
+        pressure = ProfilePolynomial([1e4, 0.0, -1e4])  # f(rho) = 1e4 * (1 - rho^2)
+        iota = ProfilePolynomial([0.4, 0.0, 0.1])  # f(rho) = 0.4 + 0.1 * rho^2
+
+        self.psi = 1.0
+        self.desc_opt = DescOptimizable(
+            boundary=boundary,
+            psi=self.psi,
+            pressure_profile=pressure,
+            iota_profile=iota,
+        )
+
+    def test_returns_protocol_instance(self):
+        """Test that the equilibrium is a valid protocol instance."""
+        self.assertIsInstance(self.desc_opt.eq, DescEquilibriumProtocol)
+
+    def test_psi_preserved(self):
+        """Test that the edge toroidal flux is preserved."""
+        self.assertAlmostEqual(self.desc_opt.eq.Psi, self.psi, places=10)
+
+    def test_nfp_preserved_in_equilibrium(self):
+        """Test that NFP is preserved in the equilibrium surface."""
+        self.assertEqual(self.desc_opt.eq.surface.NFP, 2)
+
+
+class TestDescOptimizableDOFs(unittest.TestCase):
+    """Test degrees of freedom (DOFs) of DescOptimizable."""
+
+    def setUp(self):
+        """Create a test DescOptimizable."""
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        self.psi = 2.5
+        self.desc_opt = DescOptimizable(
+            boundary=boundary,
+            psi=self.psi,
+            pressure_profile=pressure,
+            iota_profile=iota,
+        )
+
+    def test_get_dofs_returns_psi(self):
+        """Test that get returns the PSI value."""
+        dofs = self.desc_opt.local_full_x
+        self.assertEqual(len(dofs), 1)
+        self.assertAlmostEqual(dofs[0], self.psi, places=10)
+
+    def test_set_dofs_updates_psi(self):
+        """Test that set_dofs correctly updates the PSI value."""
+        new_psi = 5.0
+        self.desc_opt.need_to_run_code = False
+        self.desc_opt.set("psi", new_psi)
+
+        # Check that psi was updated
+        self.assertAlmostEqual(self.desc_opt.get("psi"), new_psi, places=10)
+        self.assertAlmostEqual(self.desc_opt.need_to_run_code, True, places=10)
+
+
+class TestFromFile(unittest.TestCase):
+    """Test the from_file classmethod for loading saved equilibria."""
+
+    def setUp(self):
+        """Create and save a test equilibrium."""
+        input_file = "ml_fast_ion/vmec_input_files/input.padidar_A"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+
+        pressure = ProfilePolynomial([1e1, 0.0, -1e1])
+        iota = ProfilePolynomial([0.4, 0.0, 0.1])
+
+        self.psi = 1.0
+        self.nfp = boundary.nfp
+
+        # Create and build equilibrium
+        self.desc_opt_orig = DescOptimizable(
+            boundary=boundary,
+            psi=self.psi,
+            pressure_profile=pressure,
+            iota_profile=iota,
+        )
+        self.eq_orig = self.desc_opt_orig.eq
+
+    def test_from_file_roundtrip(self):
+        """Test saving and loading an equilibrium."""
+        # Save to a temporary file
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        # Save the equilibrium
+        self.eq_orig.save(tmp_path)
+
+        # Load it back
+        desc_opt_loaded = DescOptimizable.from_file(tmp_path)
+
+        # compare boundaries
+        boundary_orig = self.desc_opt_orig.boundary
+        boundary_loaded = desc_opt_loaded.boundary
+        gamma_err = np.max(np.abs(boundary_loaded.gamma() - boundary_orig.gamma()))
+        self.assertAlmostEqual(gamma_err, 0.0, places=13)
+
+        # compare profiles in rho-space
+        rho_test = np.linspace(0, 1, 30)
+        pressure_orig = self.desc_opt_orig.pressure_profile
+        pressure_loaded = desc_opt_loaded.pressure_profile
+        pressure_err = np.max(
+            np.abs(pressure_loaded(rho_test) - pressure_orig(rho_test))
+        )
+        self.assertAlmostEqual(pressure_err, 0.0, places=13)
+        iota_orig = self.desc_opt_orig.iota_profile
+        iota_loaded = desc_opt_loaded.iota_profile
+        iota_err = np.max(np.abs(iota_loaded(rho_test) - iota_orig(rho_test)))
+        self.assertAlmostEqual(iota_err, 0.0, places=13)
+
+        # Check that key properties match
+        self.assertEqual(desc_opt_loaded.boundary.nfp, self.nfp)
+        self.assertAlmostEqual(desc_opt_loaded.get("psi"), self.psi, places=10)
+
+        # Check surface parameters
+        self.assertEqual(desc_opt_loaded.eq.surface.NFP, self.nfp)
+
+        # Clean up
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+class TestFromEq(unittest.TestCase):
+    """Test the from_eq classmethod for creating from DESC Equilibrium objects."""
+
+    def setUp(self):
+        """Create a test DESC Equilibrium."""
+        from desc.equilibrium import Equilibrium as DescEquilibrium
+
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+
+        # Create a DescOptimizable to get a DESC Equilibrium
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        self.desc_opt_orig = DescOptimizable(
+            boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
+        )
+        self.eq = self.desc_opt_orig.eq
+
+    def test_from_eq_creates_optimizable(self):
+        """Test that from_eq creates a valid DescOptimizable from a DESC Equilibrium."""
+        desc_opt = DescOptimizable.from_eq(self.eq)
+
+        # Check that basic properties are preserved
+        self.assertIsNotNone(desc_opt.boundary)
+        self.assertIsNotNone(desc_opt.eq)
+        self.assertEqual(desc_opt.eq, self.eq)  # Should use the same equilibrium
+        self.assertAlmostEqual(desc_opt.get("psi"), self.eq.Psi, places=10)
+
+    def test_from_eq_preserves_boundary(self):
+        """Test that from_eq preserves boundary properties."""
+        desc_opt = DescOptimizable.from_eq(self.eq)
+
+        self.assertEqual(desc_opt.boundary.nfp, self.desc_opt_orig.boundary.nfp)
+        self.assertEqual(
+            desc_opt.boundary.stellsym, self.desc_opt_orig.boundary.stellsym
+        )
+
+    def test_from_eq_preserves_profiles(self):
+        """Test that from_eq interpolates profiles correctly."""
+        desc_opt = DescOptimizable.from_eq(self.eq)
+
+        s_test = np.linspace(0, 1, 10)
+        pressure_orig = self.desc_opt_orig.pressure_profile(s_test)
+        pressure_loaded = desc_opt.pressure_profile(s_test)
+
+        np.testing.assert_allclose(pressure_loaded, pressure_orig, rtol=1e-6)
+
+
+class TestFromInputFile(unittest.TestCase):
+    """Test the from_input_file classmethod for loading VMEC/DESC input files."""
+
+    def setUp(self):
+        """Create test data and save to a VMEC input file."""
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        self.desc_opt_orig = DescOptimizable(
+            boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
+        )
+        self.nfp = boundary.nfp
+
+        # Create a temporary VMEC input file
+        with tempfile.NamedTemporaryFile(
+            suffix="", delete=False, prefix="input."
+        ) as tmp:
+            self.input_file_path = tmp.name
+
+        self.desc_opt_orig.to_vmec_input(self.input_file_path)
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        Path(self.input_file_path).unlink(missing_ok=True)
+
+    def test_from_input_file_loads_vmec(self):
+        """Test that from_input_file can load a VMEC input file."""
+        desc_opt = DescOptimizable.from_input_file(self.input_file_path)
+
+        self.assertIsNotNone(desc_opt.boundary)
+        self.assertIsNotNone(desc_opt.eq)
+
+    def test_from_input_file_preserves_nfp(self):
+        """Test that from_input_file preserves NFP."""
+        desc_opt = DescOptimizable.from_input_file(self.input_file_path)
+
+        self.assertEqual(desc_opt.boundary.nfp, self.nfp)
+
+    def test_from_input_file_creates_optimizable(self):
+        """Test that from_input_file creates a valid DescOptimizable."""
+        desc_opt = DescOptimizable.from_input_file(self.input_file_path)
+
+        # The eq should be a valid DESC Equilibrium
+        self.assertIsNotNone(desc_opt.eq)
+        self.assertIsInstance(desc_opt.eq, DescEquilibriumProtocol)
+
+    def test_from_input_file_with_custom_knots(self):
+        """Test that from_input_file respects custom knot parameters."""
+        n_knots = 15
+        degree = 2
+        desc_opt = DescOptimizable.from_input_file(
+            self.input_file_path, n_knots=n_knots, degree=degree
+        )
+
+        self.assertEqual(desc_opt.n_knots, n_knots)
+        self.assertEqual(desc_opt.degree, degree)
+
+
+class TestFromFileMethod(unittest.TestCase):
+    """Test the from_file classmethod for loading HDF5/pickle files."""
+
+    def setUp(self):
+        """Create test data and save to an HDF5 file."""
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        self.psi = 1.0
+        self.nfp = boundary.nfp
+
+        self.desc_opt_orig = DescOptimizable(
+            boundary=boundary,
+            psi=self.psi,
+            pressure_profile=pressure,
+            iota_profile=iota,
+        )
+
+        # Create a temporary HDF5 file
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=False) as tmp:
+            self.hdf5_file_path = tmp.name
+
+        self.desc_opt_orig.eq.save(self.hdf5_file_path)
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        Path(self.hdf5_file_path).unlink(missing_ok=True)
+
+    def test_from_file_loads_hdf5(self):
+        """Test that from_file can load an HDF5 file."""
+        desc_opt = DescOptimizable.from_file(self.hdf5_file_path)
+
+        self.assertIsNotNone(desc_opt.boundary)
+        self.assertIsNotNone(desc_opt.eq)
+
+    def test_from_file_preserves_boundary(self):
+        """Test that from_file preserves boundary properties."""
+        desc_opt = DescOptimizable.from_file(self.hdf5_file_path)
+
+        # Check NFP and stellsym are preserved
+        self.assertEqual(desc_opt.boundary.nfp, self.desc_opt_orig.boundary.nfp)
+        self.assertEqual(
+            desc_opt.boundary.stellsym, self.desc_opt_orig.boundary.stellsym
+        )
+
+    def test_from_file_preserves_psi(self):
+        """Test that from_file preserves psi."""
+        desc_opt = DescOptimizable.from_file(self.hdf5_file_path)
+
+        self.assertAlmostEqual(desc_opt.get("psi"), self.psi, places=10)
+
+    def test_from_file_with_custom_knots(self):
+        """Test that from_file respects custom knot parameters."""
+        n_knots = 15
+        degree = 2
+        desc_opt = DescOptimizable.from_file(
+            self.hdf5_file_path, n_knots=n_knots, degree=degree
+        )
+
+        self.assertEqual(desc_opt.n_knots, n_knots)
+        self.assertEqual(desc_opt.degree, degree)
+
+
+class TestSurfaceFromDesc(unittest.TestCase):
+    """Test the surface_from_desc static method."""
+
+    def test_surface_from_desc_roundtrip(self):
+        """Test that surface_from_desc correctly converts DESC surface back to simsopt."""
+        from desc.equilibrium import Equilibrium as DescEquilibrium
+
+        input_file = "ml_fast_ion/vmec_input_files/input.padidar_A"
+        boundary_orig = SurfaceRZFourier.from_vmec_input(input_file)
+
+        # Convert to DESC and back
+        desc_surface = DescOptimizable.surface_to_desc(boundary_orig)
+        eq = DescEquilibrium(surface=desc_surface)
+        boundary_roundtrip = DescOptimizable.surface_from_desc(eq)
+        boundary_from_desc = boundary_roundtrip.copy(
+            quadpoints_phi=boundary_orig.quadpoints_phi,
+            quadpoints_theta=boundary_orig.quadpoints_theta,
+        )
+
+        # Check NFP and stellsym are preserved
+        self.assertEqual(boundary_from_desc.nfp, boundary_orig.nfp)
+        self.assertEqual(boundary_from_desc.stellsym, boundary_orig.stellsym)
+
+        # Check geometry is preserved via gamma
+        # Check metric/geometry is preserved via gamma
+        gamma_flat = boundary_orig.gamma().reshape((-1, 3))
+        gamma_rt_flat = boundary_from_desc.gamma().reshape((-1, 3))
+        from scipy.spatial.distance import cdist
+
+        distances = cdist(gamma_flat, gamma_rt_flat)
+        gamma_err = np.max(np.min(distances, axis=1))
+        self.assertAlmostEqual(gamma_err, 0.0, places=12)
+
+
+class TestToWout(unittest.TestCase):
+    """Test the to_wout method."""
+
+    def test_to_wout_creates_file(self):
+        """Test that to_wout creates a valid VMEC output file."""
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        desc_opt = DescOptimizable(
+            boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
+        )
+
+        # Write to temporary file
+        with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            # Call to_wout
+            desc_opt.to_wout(tmp_path)
+
+            # Check that file was created
+            self.assertTrue(Path(tmp_path).exists())
+            # Check file size is reasonable (not empty)
+            self.assertGreater(Path(tmp_path).stat().st_size, 0)
+        finally:
+            # Clean up
+            Path(tmp_path).unlink(missing_ok=True)
+
+
+class TestToVmecInput(unittest.TestCase):
+    """Test the to_vmec_input method."""
+
+    def test_to_vmec_input_creates_file(self):
+        """Test that to_vmec_input creates a VMEC input file."""
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        desc_opt = DescOptimizable(
+            boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
+        )
+
+        # Write to temporary file
+        with tempfile.NamedTemporaryFile(
+            suffix="", delete=False, prefix="input."
+        ) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            # Call to_vmec_input
+            desc_opt.to_vmec_input(tmp_path)
+
+            # Check that file was created
+            self.assertTrue(Path(tmp_path).exists())
+            # Check file size is reasonable (not empty)
+            self.assertGreater(Path(tmp_path).stat().st_size, 0)
+        finally:
+            # Clean up
+            Path(tmp_path).unlink(missing_ok=True)
+
+    def test_vmec_input_contains_boundary_data(self):
+        """Test that to_vmec_input file contains boundary Fourier coefficients."""
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        desc_opt = DescOptimizable(
+            boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
+        )
+
+        # Write to temporary file
+        with tempfile.NamedTemporaryFile(
+            suffix="", delete=False, prefix="input."
+        ) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            # Save via to_vmec_input
+            desc_opt.to_vmec_input(tmp_path)
+
+            # Read and verify the file contains boundary data
+            with open(tmp_path, "r") as f:
+                content = f.read()
+
+            # Check for key VMEC parameters
+            self.assertIn("&INDATA", content)
+            self.assertIn("RBC", content)
+            self.assertIn("ZBS", content)
+            self.assertIn("NFP", content)
+            self.assertIn("AM", content)  # Pressure coefficients
+            self.assertIn("AI", content)  # Iota coefficients
+        finally:
+            # Clean up
+            Path(tmp_path).unlink(missing_ok=True)
+
+
+class TestToVmec(unittest.TestCase):
+    """Test the to_vmec method."""
+
+    def _create_mock_vmec(self):
+        """Create a mock Vmec object with proper support for nested attributes."""
+        from unittest.mock import MagicMock
+
+        mock_vmec = MagicMock()
+        mock_vmec.indata.ns_array = [16, 32, 64, 101]
+        mock_vmec.indata.niter_array = [1000, 2000, 3000, 10000]
+        mock_vmec.indata.ftol_array = [1.0e-16, 1.0e-16, 1.0e-16, 1.0e-13]
+        return mock_vmec
+
+    @patch("ml_fast_ion.desc_optimizable.Vmec")
+    def test_to_vmec_returns_vmec_object(self, mock_vmec_class):
+        """Test that to_vmec returns a Vmec object."""
+        mock_vmec = self._create_mock_vmec()
+        mock_vmec_class.return_value = mock_vmec
+
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        desc_opt = DescOptimizable(
+            boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
+        )
+
+        vmec = desc_opt.to_vmec()
+        self.assertEqual(vmec, mock_vmec)
+
+    @patch("ml_fast_ion.desc_optimizable.Vmec")
+    def test_to_vmec_preserves_boundary(self, mock_vmec_class):
+        """Test that to_vmec preserves the boundary."""
+        mock_vmec = self._create_mock_vmec()
+        mock_vmec_class.return_value = mock_vmec
+
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        desc_opt = DescOptimizable(
+            boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
+        )
+
+        vmec = desc_opt.to_vmec()
+        self.assertEqual(mock_vmec.boundary, boundary)
+
+    @patch("ml_fast_ion.desc_optimizable.Vmec")
+    def test_to_vmec_preserves_psi(self, mock_vmec_class):
+        """Test that to_vmec preserves psi (phiedge)."""
+        mock_vmec = self._create_mock_vmec()
+        mock_vmec_class.return_value = mock_vmec
+
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+        psi = 2.5
+
+        desc_opt = DescOptimizable(
+            boundary=boundary, psi=psi, pressure_profile=pressure, iota_profile=iota
+        )
+
+        vmec = desc_opt.to_vmec()
+        self.assertAlmostEqual(mock_vmec.indata.phiedge, psi)
+
+    @patch("ml_fast_ion.desc_optimizable.Vmec")
+    def test_to_vmec_preserves_nfp(self, mock_vmec_class):
+        """Test that to_vmec preserves nfp."""
+        mock_vmec = self._create_mock_vmec()
+        mock_vmec_class.return_value = mock_vmec
+
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        desc_opt = DescOptimizable(
+            boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
+        )
+
+        vmec = desc_opt.to_vmec()
+        self.assertEqual(mock_vmec.indata.nfp, boundary.nfp)
+
+    @patch("ml_fast_ion.desc_optimizable.Vmec")
+    def test_to_vmec_sets_pressure_profile(self, mock_vmec_class):
+        """Test that to_vmec sets the pressure profile."""
+        mock_vmec = self._create_mock_vmec()
+        mock_vmec_class.return_value = mock_vmec
+
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        desc_opt = DescOptimizable(
+            boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
+        )
+
+        vmec = desc_opt.to_vmec()
+        self.assertEqual(mock_vmec.pressure_profile, pressure)
+
+    @patch("ml_fast_ion.desc_optimizable.Vmec")
+    def test_to_vmec_sets_iota_profile_when_auto(self, mock_vmec_class):
+        """Test that to_vmec sets iota profile when only iota is provided."""
+        mock_vmec = self._create_mock_vmec()
+        mock_vmec_class.return_value = mock_vmec
+
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        desc_opt = DescOptimizable(
+            boundary=boundary,
+            psi=1.0,
+            pressure_profile=pressure,
+            iota_profile=iota,
+            which_profile="auto",
+        )
+
+        vmec = desc_opt.to_vmec()
+        self.assertEqual(mock_vmec.iota_profile, iota)
+        self.assertEqual(mock_vmec.indata.ncurr, 0)
+
+    @patch("ml_fast_ion.desc_optimizable.Vmec")
+    def test_to_vmec_sets_current_profile_when_auto(self, mock_vmec_class):
+        """Test that to_vmec sets current profile when current is available."""
+        mock_vmec = self._create_mock_vmec()
+        mock_vmec_class.return_value = mock_vmec
+
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        current = ProfilePolynomial([1e5, -1e5])
+
+        desc_opt = DescOptimizable(
+            boundary=boundary,
+            psi=1.0,
+            pressure_profile=pressure,
+            current_profile=current,
+            which_profile="auto",
+        )
+
+        vmec = desc_opt.to_vmec()
+        self.assertEqual(mock_vmec.current_profile, current)
+        self.assertEqual(mock_vmec.indata.ncurr, 1)
+
+
+class TestToDescProfiles(unittest.TestCase):
+    """Test the profiles_for_eq method."""
+
+    def test_to_desc_profiles_with_iota(self):
+        """Test profiles_for_eq returns correct tuple with iota profile."""
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        desc_opt = DescOptimizable(
+            boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
+        )
+
+        # Get the converted profiles
+        pressure_desc, current_desc, iota_desc = desc_opt.profiles_for_eq()
+
+        # Check that pressure and iota are converted, current is None
+        self.assertIsNotNone(pressure_desc)
+        self.assertIsNone(current_desc)
+        self.assertIsNotNone(iota_desc)
+
+        # Check that the converted profiles are DESC profile objects
+        from desc.profiles import PowerSeriesProfile, SplineProfile
+
+        self.assertIsInstance(pressure_desc, (PowerSeriesProfile, SplineProfile))
+        self.assertIsInstance(iota_desc, (PowerSeriesProfile, SplineProfile))
+
+    def test_to_desc_profiles_with_current(self):
+        """Test profiles_for_eq returns correct tuple with current profile."""
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        current = ProfilePolynomial([0.0, 0.0, 1e5])  # symmetric: c2*rho^2
+
+        desc_opt = DescOptimizable(
+            boundary=boundary,
+            psi=1.0,
+            pressure_profile=pressure,
+            current_profile=current,
+        )
+
+        # Get the converted profiles
+        pressure_desc, current_desc, iota_desc = desc_opt.profiles_for_eq()
+
+        # Check that pressure and current are converted, iota is None
+        self.assertIsNotNone(pressure_desc)
+        self.assertIsNotNone(current_desc)
+        self.assertIsNone(iota_desc)
+
+        # Check that the converted profiles are DESC profile objects
+        from desc.profiles import PowerSeriesProfile, SplineProfile
+
+        self.assertIsInstance(pressure_desc, (PowerSeriesProfile, SplineProfile))
+        self.assertIsInstance(current_desc, (PowerSeriesProfile, SplineProfile))
+
+
+class TestRescale(unittest.TestCase):
+    """Test the rescale method."""
+
+    def setUp(self):
+        """Create a test DescOptimizable for rescaling."""
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        iota = ProfilePolynomial([0.4, 0.1])
+
+        self.desc_opt = DescOptimizable(
+            boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
+        )
+
+    def test_rescale_updates_simsopt_state(self):
+        """Test that rescale updates the simsopt surface, psi, and profiles correctly."""
+        # Record original values before rescaling
+        psi_orig = self.desc_opt.get("psi")
+        s_test = np.linspace(0, 1, 10)
+
+        # Rescale
+        self.desc_opt.rescale(L=("a", 1.2325), B=("<B>", np.pi))
+
+        # Check that psi is synced between simsopt and DESC
+        psi_new = self.desc_opt.get("psi")
+        eq_psi = self.desc_opt.eq.Psi
+        self.assertAlmostEqual(psi_new, eq_psi, places=10)
+        # Verify that rescaling actually changed values
+        # (rescaling with L=1.0, B=1.0 should change psi, and likely other properties)
+        self.assertNotAlmostEqual(psi_orig, psi_new, places=5)
+
+        # Check that boundary is synced: simsopt boundary should match eq surface
+        boundary_from_eq = DescOptimizable.surface_from_desc(self.desc_opt.eq).copy(
+            quadpoints_phi=self.desc_opt.boundary.quadpoints_phi,
+            quadpoints_theta=self.desc_opt.boundary.quadpoints_theta,
+        )
+        gamma_new = self.desc_opt.boundary.gamma()
+        gamma_from_eq = boundary_from_eq.gamma()
+        np.testing.assert_allclose(gamma_new, gamma_from_eq, rtol=1e-10)
+
+        # Check that pressure profile is synced
+        pressure_from_eq = DescOptimizable._profile_from_desc(
+            self.desc_opt.eq.pressure,
+            n_knots=self.desc_opt.n_knots,
+            degree=self.desc_opt.degree,
+        )(s_test)
+        pressure_new = self.desc_opt.pressure_profile(s_test)
+        np.testing.assert_allclose(pressure_new, pressure_from_eq, rtol=1e-10)
+
+        # Check that iota profile is synced
+        iota_from_eq = DescOptimizable._profile_from_desc(
+            self.desc_opt.eq.iota,
+            n_knots=self.desc_opt.n_knots,
+            degree=self.desc_opt.degree,
+        )(s_test)
+        iota_new = self.desc_opt.iota_profile(s_test)
+        np.testing.assert_allclose(iota_new, iota_from_eq, rtol=1e-10)
+
+    def test_rescale_with_current_profile(self):
+        """Test rescale with a current profile instead of iota profile."""
+        # Create DescOptimizable with current profile
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        current = ProfilePolynomial([0.0, 0.0, 1e5])  # symmetric: c2*rho^2
+
+        desc_opt = DescOptimizable(
+            boundary=boundary,
+            psi=1.0,
+            pressure_profile=pressure,
+            current_profile=current,
+        )
+
+        # Record original values before rescaling
+        psi_orig = desc_opt.get("psi")
+        s_test = np.linspace(0, 1, 10)
+
+        # Rescale
+        desc_opt.rescale(L=("a", 1.2325), B=("<B>", np.pi))
+
+        # Check that psi is synced between simsopt and DESC
+        psi_new = desc_opt.get("psi")
+        eq_psi = desc_opt.eq.Psi
+        self.assertAlmostEqual(psi_new, eq_psi, places=10)
+
+        # Verify that rescaling actually changed values
+        self.assertNotAlmostEqual(psi_orig, psi_new, places=5)
+
+        # Check that boundary is synced
+        boundary_from_eq = DescOptimizable.surface_from_desc(desc_opt.eq).copy(
+            quadpoints_phi=desc_opt.boundary.quadpoints_phi,
+            quadpoints_theta=desc_opt.boundary.quadpoints_theta,
+        )
+        gamma_new = desc_opt.boundary.gamma()
+        gamma_from_eq = boundary_from_eq.gamma()
+        np.testing.assert_allclose(gamma_new, gamma_from_eq, rtol=1e-10)
+
+        # Check that pressure profile is synced
+        pressure_from_eq = DescOptimizable._profile_from_desc(
+            desc_opt.eq.pressure,
+            n_knots=desc_opt.n_knots,
+            degree=desc_opt.degree,
+        )(s_test)
+        pressure_new = desc_opt.pressure_profile(s_test)
+        np.testing.assert_allclose(pressure_new, pressure_from_eq, rtol=1e-10)
+
+        # Check that current profile is synced
+        current_from_eq = DescOptimizable._profile_from_desc(
+            desc_opt.eq.current,
+            n_knots=desc_opt.n_knots,
+            degree=desc_opt.degree,
+        )(s_test)
+        current_new = desc_opt.current_profile(s_test)
+        np.testing.assert_allclose(current_new, current_from_eq, rtol=1e-10)
+
+    def test_rescale_vacuum_equilibrium(self):
+        """Test rescale with vacuum (zero pressure and current)."""
+        # Create DescOptimizable with vacuum profiles
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([0.0, 0.0])  # vacuum: p = 0
+        current = ProfilePolynomial([0.0, 0.0])  # vacuum: I = 0
+
+        desc_opt = DescOptimizable(
+            boundary=boundary,
+            psi=1.0,
+            pressure_profile=pressure,
+            current_profile=current,
+        )
+
+        # Record original values before rescaling
+        psi_orig = desc_opt.get("psi")
+        s_test = np.linspace(0, 1, 10)
+
+        # Rescale
+        desc_opt.rescale(L=("a", 1.2325), B=("<B>", np.pi))
+
+        # Check that psi is synced between simsopt and DESC
+        psi_new = desc_opt.get("psi")
+        eq_psi = desc_opt.eq.Psi
+        self.assertAlmostEqual(psi_new, eq_psi, places=10)
+
+        # Verify that rescaling actually changed values
+        self.assertNotAlmostEqual(psi_orig, psi_new, places=5)
+
+        # Check that boundary is synced
+        boundary_from_eq = DescOptimizable.surface_from_desc(desc_opt.eq).copy(
+            quadpoints_phi=desc_opt.boundary.quadpoints_phi,
+            quadpoints_theta=desc_opt.boundary.quadpoints_theta,
+        )
+        gamma_new = desc_opt.boundary.gamma()
+        gamma_from_eq = boundary_from_eq.gamma()
+        np.testing.assert_allclose(gamma_new, gamma_from_eq, rtol=1e-10)
+
+        # Check that pressure profile is synced (should be zero)
+        pressure_from_eq = DescOptimizable._profile_from_desc(
+            desc_opt.eq.pressure,
+            n_knots=desc_opt.n_knots,
+            degree=desc_opt.degree,
+        )(s_test)
+        pressure_new = desc_opt.pressure_profile(s_test)
+        np.testing.assert_allclose(pressure_new, pressure_from_eq, rtol=1e-10)
+        np.testing.assert_allclose(pressure_new, 0.0, atol=1e-12)
+
+        # Check that current profile is synced (should be zero)
+        current_from_eq = DescOptimizable._profile_from_desc(
+            desc_opt.eq.current,
+            n_knots=desc_opt.n_knots,
+            degree=desc_opt.degree,
+        )(s_test)
+        current_new = desc_opt.current_profile(s_test)
+        np.testing.assert_allclose(current_new, current_from_eq, rtol=1e-10)
+        np.testing.assert_allclose(current_new, 0.0, atol=1e-12)
+
+
+class TestComputeMethod(unittest.TestCase):
+    """Test the compute method of DescOptimizable."""
+
+    def setUp(self):
+        """Create a test DescOptimizable."""
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        pressure = ProfilePolynomial([1e4, -1e4])
+        current = ProfilePolynomial([0.0])
+
+        self.desc_opt = DescOptimizable(
+            boundary=boundary,
+            psi=1.0,
+            pressure_profile=pressure,
+            current_profile=current,
+        )
+
+    def test_compute_runs_and_returns_dict(self):
+        """Test that compute() runs and returns a dict."""
+        from desc.grid import LinearGrid
+
+        # Create a simple 1D grid in rho for computing on
+        grid = LinearGrid(rho=np.linspace(0, 1, 5))
+
+        # Request computation of some basic quantities
+        result = self.desc_opt.compute(grid=grid, names=["R", "Z"])
+
+        # Check that result is a dict
+        self.assertIsInstance(result, dict)
+
+        # Check that requested quantities are in the result
+        self.assertIn("R", result)
+        self.assertIn("Z", result)
+
+    def test_compute_quasisymmetry_metric(self):
+        """Test that compute() can calculate quasisymmetry metrics."""
+        from desc.grid import LinearGrid
+
+        # Create a simple 1D grid in rho for computing on
+        grid = LinearGrid(rho=np.linspace(0, 1, 5))
+
+        # Compute magnetic field strength (key QS metric) and rotational transform
+        result = self.desc_opt.compute(grid=grid, names=["B", "iota", "f_C"])
+
+        # Check that result is a dict
+        self.assertIsInstance(result, dict)
+
+        # Check that requested quantities were computed
+        self.assertIn("f_C", result)
+        self.assertIn("iota", result)
+
+
+class TestDetermineWhichProfile(unittest.TestCase):
+    """Test the _determine_which_profile method."""
+
+    def setUp(self):
+        """Create test DescOptimizable objects with different profile configurations."""
+        input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
+        self.boundary = SurfaceRZFourier.from_vmec_input(input_file)
+        self.pressure = ProfilePolynomial([1e4, -1e4])
+        self.iota = ProfilePolynomial([0.4, 0.1])
+        self.current = ProfilePolynomial([1e5, 0.0, -1e5])  # symmetric: c0 + c2*rho^2
+
+    def test_auto_with_current_only(self):
+        """Test that 'auto' defaults to current when only current is provided."""
+        desc_opt = DescOptimizable(
+            boundary=self.boundary,
+            psi=1.0,
+            pressure_profile=self.pressure,
+            current_profile=self.current,
+            which_profile="auto",
+        )
+        result = desc_opt._determine_which_profile()
+        self.assertTrue(result)
+
+    def test_auto_with_iota_only(self):
+        """Test that 'auto' uses iota when only iota is provided."""
+        desc_opt = DescOptimizable(
+            boundary=self.boundary,
+            psi=1.0,
+            pressure_profile=self.pressure,
+            iota_profile=self.iota,
+            which_profile="auto",
+        )
+        result = desc_opt._determine_which_profile()
+        self.assertFalse(result)
+
+    def test_auto_with_both_profiles(self):
+        """Test that 'auto' defaults to current when both profiles are provided."""
+        desc_opt = DescOptimizable(
+            boundary=self.boundary,
+            psi=1.0,
+            pressure_profile=self.pressure,
+            current_profile=self.current,
+            iota_profile=self.iota,
+            which_profile="auto",
+        )
+        result = desc_opt._determine_which_profile()
+        self.assertTrue(result)
+
+    def test_explicit_current(self):
+        """Test that explicitly setting which_profile to 'current' works."""
+        desc_opt = DescOptimizable(
+            boundary=self.boundary,
+            psi=1.0,
+            pressure_profile=self.pressure,
+            current_profile=self.current,
+            iota_profile=self.iota,
+            which_profile="current",
+        )
+        result = desc_opt._determine_which_profile()
+        self.assertTrue(result)
+
+    def test_explicit_iota(self):
+        """Test that explicitly setting which_profile to 'iota' works."""
+        desc_opt = DescOptimizable(
+            boundary=self.boundary,
+            psi=1.0,
+            pressure_profile=self.pressure,
+            current_profile=self.current,
+            iota_profile=self.iota,
+            which_profile="iota",
+        )
+        result = desc_opt._determine_which_profile()
+        self.assertFalse(result)
+
+    def test_invalid_which_profile(self):
+        """Test that invalid which_profile value raises ValueError."""
+        desc_opt = DescOptimizable(
+            boundary=self.boundary,
+            psi=1.0,
+            pressure_profile=self.pressure,
+            current_profile=self.current,
+            which_profile="auto",
+        )
+        # Try to set an invalid value through the property setter
+        with self.assertRaises(ValueError):
+            desc_opt.which_profile = "invalid_option"
+
+    def test_which_profile_property_setter(self):
+        """Test that the which_profile property can be updated."""
+        desc_opt = DescOptimizable(
+            boundary=self.boundary,
+            psi=1.0,
+            pressure_profile=self.pressure,
+            current_profile=self.current,
+            iota_profile=self.iota,
+            which_profile="auto",
+        )
+        # Initially should be auto, determining to current
+        self.assertEqual(desc_opt.which_profile, "auto")
+        self.assertTrue(desc_opt._determine_which_profile())
+
+        # Update to iota
+        desc_opt.which_profile = "iota"
+        self.assertEqual(desc_opt.which_profile, "iota")
+        self.assertFalse(desc_opt._determine_which_profile())
+
+        # Update back to auto
+        desc_opt.which_profile = "auto"
+        self.assertEqual(desc_opt.which_profile, "auto")
+        self.assertTrue(desc_opt._determine_which_profile())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mhd/test_desc.py
+++ b/tests/mhd/test_desc.py
@@ -2,11 +2,11 @@ import unittest
 import tempfile
 import numpy as np
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from simsopt.mhd import ProfilePolynomial, ProfileSpline
 from simsopt.geo import SurfaceRZFourier
-from simsopt.mhd.desc import DescOptimizable, DescEquilibriumProtocol
+from simsopt.mhd.desc import Desc, DescEquilibriumProtocol
 
 
 class TestProfilesToDesc(unittest.TestCase):
@@ -18,7 +18,7 @@ class TestProfilesToDesc(unittest.TestCase):
         prof = ProfilePolynomial([1.0, 0.0, -1.0])
 
         # Convert to DESC
-        prof_desc = DescOptimizable._profile_to_desc(prof)
+        prof_desc = Desc._profile_to_desc(prof)
 
         # Check values at several rho points
         rho_test = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
@@ -39,7 +39,7 @@ class TestProfilesToDesc(unittest.TestCase):
         prof = ProfileSpline(rho_knots, f_values, degree=3)
 
         # Convert to DESC
-        prof_desc = DescOptimizable._profile_to_desc(prof)
+        prof_desc = Desc._profile_to_desc(prof)
 
         # Check values at rho test points
         rho_test = np.linspace(0, 1, 5)
@@ -59,10 +59,10 @@ class TestProfilesFromDesc(unittest.TestCase):
         prof_orig = ProfilePolynomial([1.0, 0.0, -1.0, 0.0, 0.5])
 
         # Convert: simsopt -> DESC
-        prof_desc = DescOptimizable._profile_to_desc(prof_orig)
+        prof_desc = Desc._profile_to_desc(prof_orig)
 
         # Convert back: DESC -> simsopt
-        prof_simsopt = DescOptimizable._profile_from_desc(
+        prof_simsopt = Desc._profile_from_desc(
             prof_desc, n_knots=10, degree=3
         )
 
@@ -85,8 +85,8 @@ class TestProfilesFromDesc(unittest.TestCase):
         prof_orig = ProfileSpline(rho_knots, f_values, degree=3)
 
         # Roundtrip conversion
-        prof_desc = DescOptimizable._profile_to_desc(prof_orig)
-        prof_simsopt = DescOptimizable._profile_from_desc(
+        prof_desc = Desc._profile_to_desc(prof_orig)
+        prof_simsopt = Desc._profile_from_desc(
             prof_desc, n_knots=n_pts, degree=3
         )
 
@@ -109,7 +109,7 @@ class TestBoundaryToDesc(unittest.TestCase):
 
     def test_nfp_preserved(self):
         """Test that NFP is preserved in boundary conversion."""
-        desc_surface = DescOptimizable.surface_to_desc(self.boundary)
+        desc_surface = Desc.surface_to_desc(self.boundary)
 
         self.assertEqual(desc_surface.NFP, self.boundary.nfp)
         self.assertEqual(desc_surface.NFP, 2)  # input.vacuum_template has NFP=2
@@ -117,7 +117,7 @@ class TestBoundaryToDesc(unittest.TestCase):
     def test_major_radius_preserved(self):
         """Test that the (0,0) Fourier mode (major radius) is approximately preserved."""
         boundary_rz = self.boundary.to_RZFourier()
-        desc_surface = DescOptimizable.surface_to_desc(boundary_rz)
+        desc_surface = Desc.surface_to_desc(boundary_rz)
 
         # Get the R(0,0) coefficient, which is the major radius
         R_00, _ = desc_surface.get_coeffs(0, 0)
@@ -130,13 +130,13 @@ class TestBoundaryToDesc(unittest.TestCase):
         from desc.equilibrium import Equilibrium as DescEquilibrium
 
         # Convert surface to DESC format
-        desc_surface = DescOptimizable.surface_to_desc(self.boundary)
+        desc_surface = Desc.surface_to_desc(self.boundary)
 
         # Create a minimal DESC equilibrium with just the surface
         eq = DescEquilibrium(surface=desc_surface)
 
         # Convert back to simsopt surface
-        boundary_from_desc = DescOptimizable.surface_from_desc(eq)
+        boundary_from_desc = Desc.surface_from_desc(eq)
         boundary_roundtrip = boundary_from_desc.copy(
             quadpoints_phi=self.boundary.quadpoints_phi,
             quadpoints_theta=self.boundary.quadpoints_theta,
@@ -157,7 +157,7 @@ class TestBoundaryToDesc(unittest.TestCase):
 
 
 class TestBuildDescEquilibrium(unittest.TestCase):
-    """Test building a DESC equilibrium from DescOptimizable."""
+    """Test building a DESC equilibrium from Desc."""
 
     def setUp(self):
         """Create a simple test equilibrium."""
@@ -170,7 +170,7 @@ class TestBuildDescEquilibrium(unittest.TestCase):
         iota = ProfilePolynomial([0.4, 0.0, 0.1])  # f(rho) = 0.4 + 0.1 * rho^2
 
         self.psi = 1.0
-        self.desc_opt = DescOptimizable(
+        self.desc_opt = Desc(
             boundary=boundary,
             psi=self.psi,
             pressure_profile=pressure,
@@ -190,18 +190,18 @@ class TestBuildDescEquilibrium(unittest.TestCase):
         self.assertEqual(self.desc_opt.eq.surface.NFP, 2)
 
 
-class TestDescOptimizableDOFs(unittest.TestCase):
-    """Test degrees of freedom (DOFs) of DescOptimizable."""
+class TestDescDOFs(unittest.TestCase):
+    """Test degrees of freedom (DOFs) of Desc."""
 
     def setUp(self):
-        """Create a test DescOptimizable."""
+        """Create a test Desc."""
         input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
         boundary = SurfaceRZFourier.from_vmec_input(input_file)
         pressure = ProfilePolynomial([1e4, -1e4])
         iota = ProfilePolynomial([0.4, 0.1])
 
         self.psi = 2.5
-        self.desc_opt = DescOptimizable(
+        self.desc_opt = Desc(
             boundary=boundary,
             psi=self.psi,
             pressure_profile=pressure,
@@ -240,7 +240,7 @@ class TestFromFile(unittest.TestCase):
         self.nfp = boundary.nfp
 
         # Create and build equilibrium
-        self.desc_opt_orig = DescOptimizable(
+        self.desc_opt_orig = Desc(
             boundary=boundary,
             psi=self.psi,
             pressure_profile=pressure,
@@ -258,7 +258,7 @@ class TestFromFile(unittest.TestCase):
         self.eq_orig.save(tmp_path)
 
         # Load it back
-        desc_opt_loaded = DescOptimizable.from_file(tmp_path)
+        desc_opt_loaded = Desc.from_file(tmp_path)
 
         # compare boundaries
         boundary_orig = self.desc_opt_orig.boundary
@@ -295,23 +295,22 @@ class TestFromEq(unittest.TestCase):
 
     def setUp(self):
         """Create a test DESC Equilibrium."""
-        from desc.equilibrium import Equilibrium as DescEquilibrium
 
         input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
         boundary = SurfaceRZFourier.from_vmec_input(input_file)
 
-        # Create a DescOptimizable to get a DESC Equilibrium
+        # Create a Desc to get a DESC Equilibrium
         pressure = ProfilePolynomial([1e4, -1e4])
         iota = ProfilePolynomial([0.4, 0.1])
 
-        self.desc_opt_orig = DescOptimizable(
+        self.desc_opt_orig = Desc(
             boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
         )
         self.eq = self.desc_opt_orig.eq
 
     def test_from_eq_creates_optimizable(self):
-        """Test that from_eq creates a valid DescOptimizable from a DESC Equilibrium."""
-        desc_opt = DescOptimizable.from_eq(self.eq)
+        """Test that from_eq creates a valid Desc from a DESC Equilibrium."""
+        desc_opt = Desc.from_eq(self.eq)
 
         # Check that basic properties are preserved
         self.assertIsNotNone(desc_opt.boundary)
@@ -321,7 +320,7 @@ class TestFromEq(unittest.TestCase):
 
     def test_from_eq_preserves_boundary(self):
         """Test that from_eq preserves boundary properties."""
-        desc_opt = DescOptimizable.from_eq(self.eq)
+        desc_opt = Desc.from_eq(self.eq)
 
         self.assertEqual(desc_opt.boundary.nfp, self.desc_opt_orig.boundary.nfp)
         self.assertEqual(
@@ -330,7 +329,7 @@ class TestFromEq(unittest.TestCase):
 
     def test_from_eq_preserves_profiles(self):
         """Test that from_eq interpolates profiles correctly."""
-        desc_opt = DescOptimizable.from_eq(self.eq)
+        desc_opt = Desc.from_eq(self.eq)
 
         s_test = np.linspace(0, 1, 10)
         pressure_orig = self.desc_opt_orig.pressure_profile(s_test)
@@ -349,7 +348,7 @@ class TestFromInputFile(unittest.TestCase):
         pressure = ProfilePolynomial([1e4, -1e4])
         iota = ProfilePolynomial([0.4, 0.1])
 
-        self.desc_opt_orig = DescOptimizable(
+        self.desc_opt_orig = Desc(
             boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
         )
         self.nfp = boundary.nfp
@@ -368,20 +367,20 @@ class TestFromInputFile(unittest.TestCase):
 
     def test_from_input_file_loads_vmec(self):
         """Test that from_input_file can load a VMEC input file."""
-        desc_opt = DescOptimizable.from_input_file(self.input_file_path)
+        desc_opt = Desc.from_input_file(self.input_file_path)
 
         self.assertIsNotNone(desc_opt.boundary)
         self.assertIsNotNone(desc_opt.eq)
 
     def test_from_input_file_preserves_nfp(self):
         """Test that from_input_file preserves NFP."""
-        desc_opt = DescOptimizable.from_input_file(self.input_file_path)
+        desc_opt = Desc.from_input_file(self.input_file_path)
 
         self.assertEqual(desc_opt.boundary.nfp, self.nfp)
 
     def test_from_input_file_creates_optimizable(self):
-        """Test that from_input_file creates a valid DescOptimizable."""
-        desc_opt = DescOptimizable.from_input_file(self.input_file_path)
+        """Test that from_input_file creates a valid Desc."""
+        desc_opt = Desc.from_input_file(self.input_file_path)
 
         # The eq should be a valid DESC Equilibrium
         self.assertIsNotNone(desc_opt.eq)
@@ -391,7 +390,7 @@ class TestFromInputFile(unittest.TestCase):
         """Test that from_input_file respects custom knot parameters."""
         n_knots = 15
         degree = 2
-        desc_opt = DescOptimizable.from_input_file(
+        desc_opt = Desc.from_input_file(
             self.input_file_path, n_knots=n_knots, degree=degree
         )
 
@@ -412,7 +411,7 @@ class TestFromFileMethod(unittest.TestCase):
         self.psi = 1.0
         self.nfp = boundary.nfp
 
-        self.desc_opt_orig = DescOptimizable(
+        self.desc_opt_orig = Desc(
             boundary=boundary,
             psi=self.psi,
             pressure_profile=pressure,
@@ -431,14 +430,14 @@ class TestFromFileMethod(unittest.TestCase):
 
     def test_from_file_loads_hdf5(self):
         """Test that from_file can load an HDF5 file."""
-        desc_opt = DescOptimizable.from_file(self.hdf5_file_path)
+        desc_opt = Desc.from_file(self.hdf5_file_path)
 
         self.assertIsNotNone(desc_opt.boundary)
         self.assertIsNotNone(desc_opt.eq)
 
     def test_from_file_preserves_boundary(self):
         """Test that from_file preserves boundary properties."""
-        desc_opt = DescOptimizable.from_file(self.hdf5_file_path)
+        desc_opt = Desc.from_file(self.hdf5_file_path)
 
         # Check NFP and stellsym are preserved
         self.assertEqual(desc_opt.boundary.nfp, self.desc_opt_orig.boundary.nfp)
@@ -448,7 +447,7 @@ class TestFromFileMethod(unittest.TestCase):
 
     def test_from_file_preserves_psi(self):
         """Test that from_file preserves psi."""
-        desc_opt = DescOptimizable.from_file(self.hdf5_file_path)
+        desc_opt = Desc.from_file(self.hdf5_file_path)
 
         self.assertAlmostEqual(desc_opt.get("psi"), self.psi, places=10)
 
@@ -456,7 +455,7 @@ class TestFromFileMethod(unittest.TestCase):
         """Test that from_file respects custom knot parameters."""
         n_knots = 15
         degree = 2
-        desc_opt = DescOptimizable.from_file(
+        desc_opt = Desc.from_file(
             self.hdf5_file_path, n_knots=n_knots, degree=degree
         )
 
@@ -475,9 +474,9 @@ class TestSurfaceFromDesc(unittest.TestCase):
         boundary_orig = SurfaceRZFourier.from_vmec_input(input_file)
 
         # Convert to DESC and back
-        desc_surface = DescOptimizable.surface_to_desc(boundary_orig)
+        desc_surface = Desc.surface_to_desc(boundary_orig)
         eq = DescEquilibrium(surface=desc_surface)
-        boundary_roundtrip = DescOptimizable.surface_from_desc(eq)
+        boundary_roundtrip = Desc.surface_from_desc(eq)
         boundary_from_desc = boundary_roundtrip.copy(
             quadpoints_phi=boundary_orig.quadpoints_phi,
             quadpoints_theta=boundary_orig.quadpoints_theta,
@@ -508,7 +507,7 @@ class TestToWout(unittest.TestCase):
         pressure = ProfilePolynomial([1e4, -1e4])
         iota = ProfilePolynomial([0.4, 0.1])
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
         )
 
@@ -539,7 +538,7 @@ class TestToVmecInput(unittest.TestCase):
         pressure = ProfilePolynomial([1e4, -1e4])
         iota = ProfilePolynomial([0.4, 0.1])
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
         )
 
@@ -568,7 +567,7 @@ class TestToVmecInput(unittest.TestCase):
         pressure = ProfilePolynomial([1e4, -1e4])
         iota = ProfilePolynomial([0.4, 0.1])
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
         )
 
@@ -622,7 +621,7 @@ class TestToVmec(unittest.TestCase):
         pressure = ProfilePolynomial([1e4, -1e4])
         iota = ProfilePolynomial([0.4, 0.1])
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
         )
 
@@ -640,7 +639,7 @@ class TestToVmec(unittest.TestCase):
         pressure = ProfilePolynomial([1e4, -1e4])
         iota = ProfilePolynomial([0.4, 0.1])
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
         )
 
@@ -659,7 +658,7 @@ class TestToVmec(unittest.TestCase):
         iota = ProfilePolynomial([0.4, 0.1])
         psi = 2.5
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary, psi=psi, pressure_profile=pressure, iota_profile=iota
         )
 
@@ -677,7 +676,7 @@ class TestToVmec(unittest.TestCase):
         pressure = ProfilePolynomial([1e4, -1e4])
         iota = ProfilePolynomial([0.4, 0.1])
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
         )
 
@@ -695,7 +694,7 @@ class TestToVmec(unittest.TestCase):
         pressure = ProfilePolynomial([1e4, -1e4])
         iota = ProfilePolynomial([0.4, 0.1])
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
         )
 
@@ -713,7 +712,7 @@ class TestToVmec(unittest.TestCase):
         pressure = ProfilePolynomial([1e4, -1e4])
         iota = ProfilePolynomial([0.4, 0.1])
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary,
             psi=1.0,
             pressure_profile=pressure,
@@ -736,7 +735,7 @@ class TestToVmec(unittest.TestCase):
         pressure = ProfilePolynomial([1e4, -1e4])
         current = ProfilePolynomial([1e5, -1e5])
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary,
             psi=1.0,
             pressure_profile=pressure,
@@ -759,7 +758,7 @@ class TestToDescProfiles(unittest.TestCase):
         pressure = ProfilePolynomial([1e4, -1e4])
         iota = ProfilePolynomial([0.4, 0.1])
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
         )
 
@@ -784,7 +783,7 @@ class TestToDescProfiles(unittest.TestCase):
         pressure = ProfilePolynomial([1e4, -1e4])
         current = ProfilePolynomial([0.0, 0.0, 1e5])  # symmetric: c2*rho^2
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary,
             psi=1.0,
             pressure_profile=pressure,
@@ -810,13 +809,13 @@ class TestRescale(unittest.TestCase):
     """Test the rescale method."""
 
     def setUp(self):
-        """Create a test DescOptimizable for rescaling."""
+        """Create a test Desc for rescaling."""
         input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
         boundary = SurfaceRZFourier.from_vmec_input(input_file)
         pressure = ProfilePolynomial([1e4, -1e4])
         iota = ProfilePolynomial([0.4, 0.1])
 
-        self.desc_opt = DescOptimizable(
+        self.desc_opt = Desc(
             boundary=boundary, psi=1.0, pressure_profile=pressure, iota_profile=iota
         )
 
@@ -838,7 +837,7 @@ class TestRescale(unittest.TestCase):
         self.assertNotAlmostEqual(psi_orig, psi_new, places=5)
 
         # Check that boundary is synced: simsopt boundary should match eq surface
-        boundary_from_eq = DescOptimizable.surface_from_desc(self.desc_opt.eq).copy(
+        boundary_from_eq = Desc.surface_from_desc(self.desc_opt.eq).copy(
             quadpoints_phi=self.desc_opt.boundary.quadpoints_phi,
             quadpoints_theta=self.desc_opt.boundary.quadpoints_theta,
         )
@@ -847,7 +846,7 @@ class TestRescale(unittest.TestCase):
         np.testing.assert_allclose(gamma_new, gamma_from_eq, rtol=1e-10)
 
         # Check that pressure profile is synced
-        pressure_from_eq = DescOptimizable._profile_from_desc(
+        pressure_from_eq = Desc._profile_from_desc(
             self.desc_opt.eq.pressure,
             n_knots=self.desc_opt.n_knots,
             degree=self.desc_opt.degree,
@@ -856,7 +855,7 @@ class TestRescale(unittest.TestCase):
         np.testing.assert_allclose(pressure_new, pressure_from_eq, rtol=1e-10)
 
         # Check that iota profile is synced
-        iota_from_eq = DescOptimizable._profile_from_desc(
+        iota_from_eq = Desc._profile_from_desc(
             self.desc_opt.eq.iota,
             n_knots=self.desc_opt.n_knots,
             degree=self.desc_opt.degree,
@@ -866,13 +865,13 @@ class TestRescale(unittest.TestCase):
 
     def test_rescale_with_current_profile(self):
         """Test rescale with a current profile instead of iota profile."""
-        # Create DescOptimizable with current profile
+        # Create Desc with current profile
         input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
         boundary = SurfaceRZFourier.from_vmec_input(input_file)
         pressure = ProfilePolynomial([1e4, -1e4])
         current = ProfilePolynomial([0.0, 0.0, 1e5])  # symmetric: c2*rho^2
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary,
             psi=1.0,
             pressure_profile=pressure,
@@ -895,7 +894,7 @@ class TestRescale(unittest.TestCase):
         self.assertNotAlmostEqual(psi_orig, psi_new, places=5)
 
         # Check that boundary is synced
-        boundary_from_eq = DescOptimizable.surface_from_desc(desc_opt.eq).copy(
+        boundary_from_eq = Desc.surface_from_desc(desc_opt.eq).copy(
             quadpoints_phi=desc_opt.boundary.quadpoints_phi,
             quadpoints_theta=desc_opt.boundary.quadpoints_theta,
         )
@@ -904,7 +903,7 @@ class TestRescale(unittest.TestCase):
         np.testing.assert_allclose(gamma_new, gamma_from_eq, rtol=1e-10)
 
         # Check that pressure profile is synced
-        pressure_from_eq = DescOptimizable._profile_from_desc(
+        pressure_from_eq = Desc._profile_from_desc(
             desc_opt.eq.pressure,
             n_knots=desc_opt.n_knots,
             degree=desc_opt.degree,
@@ -913,7 +912,7 @@ class TestRescale(unittest.TestCase):
         np.testing.assert_allclose(pressure_new, pressure_from_eq, rtol=1e-10)
 
         # Check that current profile is synced
-        current_from_eq = DescOptimizable._profile_from_desc(
+        current_from_eq = Desc._profile_from_desc(
             desc_opt.eq.current,
             n_knots=desc_opt.n_knots,
             degree=desc_opt.degree,
@@ -923,13 +922,13 @@ class TestRescale(unittest.TestCase):
 
     def test_rescale_vacuum_equilibrium(self):
         """Test rescale with vacuum (zero pressure and current)."""
-        # Create DescOptimizable with vacuum profiles
+        # Create Desc with vacuum profiles
         input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
         boundary = SurfaceRZFourier.from_vmec_input(input_file)
         pressure = ProfilePolynomial([0.0, 0.0])  # vacuum: p = 0
         current = ProfilePolynomial([0.0, 0.0])  # vacuum: I = 0
 
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=boundary,
             psi=1.0,
             pressure_profile=pressure,
@@ -952,7 +951,7 @@ class TestRescale(unittest.TestCase):
         self.assertNotAlmostEqual(psi_orig, psi_new, places=5)
 
         # Check that boundary is synced
-        boundary_from_eq = DescOptimizable.surface_from_desc(desc_opt.eq).copy(
+        boundary_from_eq = Desc.surface_from_desc(desc_opt.eq).copy(
             quadpoints_phi=desc_opt.boundary.quadpoints_phi,
             quadpoints_theta=desc_opt.boundary.quadpoints_theta,
         )
@@ -961,7 +960,7 @@ class TestRescale(unittest.TestCase):
         np.testing.assert_allclose(gamma_new, gamma_from_eq, rtol=1e-10)
 
         # Check that pressure profile is synced (should be zero)
-        pressure_from_eq = DescOptimizable._profile_from_desc(
+        pressure_from_eq = Desc._profile_from_desc(
             desc_opt.eq.pressure,
             n_knots=desc_opt.n_knots,
             degree=desc_opt.degree,
@@ -971,7 +970,7 @@ class TestRescale(unittest.TestCase):
         np.testing.assert_allclose(pressure_new, 0.0, atol=1e-12)
 
         # Check that current profile is synced (should be zero)
-        current_from_eq = DescOptimizable._profile_from_desc(
+        current_from_eq = Desc._profile_from_desc(
             desc_opt.eq.current,
             n_knots=desc_opt.n_knots,
             degree=desc_opt.degree,
@@ -982,16 +981,16 @@ class TestRescale(unittest.TestCase):
 
 
 class TestComputeMethod(unittest.TestCase):
-    """Test the compute method of DescOptimizable."""
+    """Test the compute method of Desc."""
 
     def setUp(self):
-        """Create a test DescOptimizable."""
+        """Create a test Desc."""
         input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
         boundary = SurfaceRZFourier.from_vmec_input(input_file)
         pressure = ProfilePolynomial([1e4, -1e4])
         current = ProfilePolynomial([0.0])
 
-        self.desc_opt = DescOptimizable(
+        self.desc_opt = Desc(
             boundary=boundary,
             psi=1.0,
             pressure_profile=pressure,
@@ -1037,7 +1036,7 @@ class TestDetermineWhichProfile(unittest.TestCase):
     """Test the _determine_which_profile method."""
 
     def setUp(self):
-        """Create test DescOptimizable objects with different profile configurations."""
+        """Create test Desc objects with different profile configurations."""
         input_file = "ml_fast_ion/vmec_input_files/input.vacuum_template"
         self.boundary = SurfaceRZFourier.from_vmec_input(input_file)
         self.pressure = ProfilePolynomial([1e4, -1e4])
@@ -1046,7 +1045,7 @@ class TestDetermineWhichProfile(unittest.TestCase):
 
     def test_auto_with_current_only(self):
         """Test that 'auto' defaults to current when only current is provided."""
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=self.boundary,
             psi=1.0,
             pressure_profile=self.pressure,
@@ -1058,7 +1057,7 @@ class TestDetermineWhichProfile(unittest.TestCase):
 
     def test_auto_with_iota_only(self):
         """Test that 'auto' uses iota when only iota is provided."""
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=self.boundary,
             psi=1.0,
             pressure_profile=self.pressure,
@@ -1070,7 +1069,7 @@ class TestDetermineWhichProfile(unittest.TestCase):
 
     def test_auto_with_both_profiles(self):
         """Test that 'auto' defaults to current when both profiles are provided."""
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=self.boundary,
             psi=1.0,
             pressure_profile=self.pressure,
@@ -1083,7 +1082,7 @@ class TestDetermineWhichProfile(unittest.TestCase):
 
     def test_explicit_current(self):
         """Test that explicitly setting which_profile to 'current' works."""
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=self.boundary,
             psi=1.0,
             pressure_profile=self.pressure,
@@ -1096,7 +1095,7 @@ class TestDetermineWhichProfile(unittest.TestCase):
 
     def test_explicit_iota(self):
         """Test that explicitly setting which_profile to 'iota' works."""
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=self.boundary,
             psi=1.0,
             pressure_profile=self.pressure,
@@ -1109,7 +1108,7 @@ class TestDetermineWhichProfile(unittest.TestCase):
 
     def test_invalid_which_profile(self):
         """Test that invalid which_profile value raises ValueError."""
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=self.boundary,
             psi=1.0,
             pressure_profile=self.pressure,
@@ -1122,7 +1121,7 @@ class TestDetermineWhichProfile(unittest.TestCase):
 
     def test_which_profile_property_setter(self):
         """Test that the which_profile property can be updated."""
-        desc_opt = DescOptimizable(
+        desc_opt = Desc(
             boundary=self.boundary,
             psi=1.0,
             pressure_profile=self.pressure,


### PR DESCRIPTION
This PR adds a Simsopt interface for the [DESC](https://desc-docs.readthedocs.io/) ideal MHD equilibrium code.
One new file is introduced, `simsopt/mhd/desc.py`, with unit tests `tests/mhd/test_desc.py`.

DESC is integrated through a runtime_checkable Python Protocol that specifies the minimum interface a DESC Equilibrium object must satisfy to be used within Simsopt (attributes `surface, pressure, current, iota, Psi`, and methods `solve`/`compute`). This allows duck-typing checks (`isinstance(eq, DescEquilibriumProtocol)`) without hard-coupling to a specific DESC version.

A Simsopt Optimizable, `DescOptimizable`, wraps a DESC Equilibrium and exposes it to the Simsopt optimization framework. 

All child-object DOFs flow through Simsopt's standard depends_on / recompute_bell mechanism, so any change to boundary shape or profiles automatically flags the equilibrium as stale. The class also provides utilities for converting between Simsopt and DESC surface/profile representations, loading from DESC/VMEC input and HDF5 files, rescaling equilibria, and exporting to VMEC (`to_vmec, to_wout, to_vmec_input`).