### PR TITLE
Address dictionary-like naming of ancestors

### DIFF
--- a/src/simsopt/_core/optimizable.py
+++ b/src/simsopt/_core/optimizable.py
@@ -47,7 +47,7 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
-__all__ = ['Optimizable', 'make_optimizable', 'natural_key', 'load', 'save',
+__all__ = ['Optimizable', 'make_optimizable', 'load', 'save',
            'OptimizableSum', 'ScaledOptimizable']
 
 
@@ -917,9 +917,23 @@ class Optimizable(ABC_Callable, Hashable, GSONable, metaclass=OptimizableMeta):
         for parent in self.parents:
             ancestors += parent.ancestors
         ancestors += self.parents
+
+        def _natural_key(text):
+            """
+            Return a key to be used in natural sorting of strings containing
+            integers.
+            Args:
+                s:
+                    String, containing integers
+            Returns:
+                Key string
+            """
+            return [int(s) if s.isdigit() else s.lower()
+                    for s in re.split(r'(\d+)', text)]
+
         return sorted(
             dict.fromkeys(ancestors),
-            key=lambda a: natural_key(a.name)
+            key=lambda a: _natural_key(a.name)
         )
 
     @property
@@ -1614,18 +1628,6 @@ class Optimizable(ABC_Callable, Hashable, GSONable, metaclass=OptimizableMeta):
                 contents = f.read()
             return cls.from_str(contents, fmt="json")
 
-def natural_key(text):
-    """
-    Return a key to be used in natural sorting of strings containing
-    integers.
-    Args:
-        s:
-            String, containing integers
-    Returns:
-        Key string
-    """
-    return [int(s) if s.isdigit() else s.lower()
-            for s in re.split(r'(\d+)', text)]
 
 
 def load(filename, *args, **kwargs):

--- a/src/simsopt/_core/optimizable.py
+++ b/src/simsopt/_core/optimizable.py
@@ -47,7 +47,7 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
-__all__ = ['Optimizable', 'make_optimizable', 'load', 'save',
+__all__ = ['Optimizable', 'make_optimizable', 'natural_key', 'load', 'save',
            'OptimizableSum', 'ScaledOptimizable']
 
 
@@ -1614,7 +1614,7 @@ class Optimizable(ABC_Callable, Hashable, GSONable, metaclass=OptimizableMeta):
                 contents = f.read()
             return cls.from_str(contents, fmt="json")
 
-def natural_key(s):
+def natural_key(text):
     """
     Return a key to be used in natural sorting of strings containing
     integers.
@@ -1624,8 +1624,9 @@ def natural_key(s):
     Returns:
         Key string
     """
-    return [int(text) if text.isdigit() else text.lower()
-            for text in re.split(r'(\d+)', s)]
+    return [int(s) if s.isdigit() else s.lower()
+            for s in re.split(r'(\d+)', text)]
+
 
 def load(filename, *args, **kwargs):
     """

--- a/src/simsopt/_core/optimizable.py
+++ b/src/simsopt/_core/optimizable.py
@@ -19,6 +19,7 @@ import logging
 import json
 from pathlib import Path
 from fnmatch import fnmatch
+import re
 
 import numpy as np
 from monty.io import zopen
@@ -916,7 +917,10 @@ class Optimizable(ABC_Callable, Hashable, GSONable, metaclass=OptimizableMeta):
         for parent in self.parents:
             ancestors += parent.ancestors
         ancestors += self.parents
-        return sorted(dict.fromkeys(ancestors), key=lambda a: a.name)
+        return sorted(
+            dict.fromkeys(ancestors),
+            key=lambda a: natural_key(a.name)
+        )
 
     @property
     def unique_dof_lineage(self):
@@ -1610,6 +1614,18 @@ class Optimizable(ABC_Callable, Hashable, GSONable, metaclass=OptimizableMeta):
                 contents = f.read()
             return cls.from_str(contents, fmt="json")
 
+def natural_key(s):
+    """
+    Return a key to be used in natural sorting of strings containing
+    integers.
+    Args:
+        s:
+            String, containing integers
+    Returns:
+        Key string
+    """
+    return [int(text) if text.isdigit() else text.lower()
+            for text in re.split(r'(\d+)', s)]
 
 def load(filename, *args, **kwargs):
     """

--- a/tests/core/test_optimizable.py
+++ b/tests/core/test_optimizable.py
@@ -930,28 +930,33 @@ class OptimizableTests(unittest.TestCase):
 
         ## Check natural sorting of optimizable dof names
     
-        # Check at parent level
+        # Checking at ancestor level
         identity_list = [Identity() for i in range(11)]
         adder_list = [Adder(n=11) for i in range(11)]
         test_obj3 = OptClassWithParents(val=10, depends_on= (identity_list + adder_list))
+        # scraping all integers from the dof name list of test_obj3 into a list of lists in each name
         dofs_names_ints = [list(map(int, re.findall(r'\d+', s))) for s in test_obj3.dof_names]
+        # creating list of unique ancestor names (['Adder6', 'Adder7', ..., 'Identity3', ...)
         unique_ancestor_namelist = []    
         for dof_name in test_obj3.dof_names:
             ancestor_name = re.split(':', dof_name)[0]
             if ancestor_name not in unique_ancestor_namelist:
                 unique_ancestor_namelist.append(ancestor_name)
+        # ensuring that ancestors of a given type (Adder or Identity) are in ascending numerical order respectively
         adder_number_list = [int(re.search(r'\d+', name).group()) for name in unique_ancestor_namelist if 'Adder' in name]
         identity_number_list = [int(re.search(r'\d+', name).group()) for name in unique_ancestor_namelist if 'Identity' in name]
         self.assertTrue(adder_number_list == sorted(adder_number_list))
         self.assertTrue(identity_number_list == sorted(identity_number_list))
         
-        # Checking at ancestor level
+        # Checking at ancestor.dofs level
         for unique_ancestor in unique_ancestor_namelist:
             ancestor_dof_numbers = []
+            # for a specific ancestor, list all dofs (which for these cases, are only of one 
+            # name/kind (i.e., Adder_.x_ or Identity_.x0 or OptClassWithParents.val) and
+            # check that dependent dofs are in ascending numerical order
             for i, dof_name in enumerate(test_obj3.dof_names):
                 if unique_ancestor in dof_name:
                     ancestor_dof_numbers.append(dofs_names_ints[i][-1])
-            print(ancestor_dof_numbers)
             self.assertTrue(ancestor_dof_numbers == sorted(ancestor_dof_numbers))
                     
     def test_local_dof_names(self):

--- a/tests/core/test_optimizable.py
+++ b/tests/core/test_optimizable.py
@@ -928,6 +928,32 @@ class OptimizableTests(unittest.TestCase):
         for name in test_obj2.full_dof_names:
             self.assertTrue(comb_patt.match(name))
 
+        ## Check natural sorting of optimizable dof names
+    
+        # Check at parent level
+        identity_list = [Identity() for i in range(11)]
+        adder_list = [Adder(n=11) for i in range(11)]
+        test_obj3 = OptClassWithParents(val=10, depends_on= (identity_list + adder_list))
+        dofs_names_ints = [list(map(int, re.findall(r'\d+', s))) for s in test_obj3.dof_names]
+        unique_ancestor_namelist = []    
+        for dof_name in test_obj3.dof_names:
+            ancestor_name = re.split(':', dof_name)[0]
+            if ancestor_name not in unique_ancestor_namelist:
+                unique_ancestor_namelist.append(ancestor_name)
+        adder_number_list = [int(re.search(r'\d+', name).group()) for name in unique_ancestor_namelist if 'Adder' in name]
+        identity_number_list = [int(re.search(r'\d+', name).group()) for name in unique_ancestor_namelist if 'Identity' in name]
+        self.assertTrue(adder_number_list == sorted(adder_number_list))
+        self.assertTrue(identity_number_list == sorted(identity_number_list))
+        
+        # Checking at ancestor level
+        for unique_ancestor in unique_ancestor_namelist:
+            ancestor_dof_numbers = []
+            for i, dof_name in enumerate(test_obj3.dof_names):
+                if unique_ancestor in dof_name:
+                    ancestor_dof_numbers.append(dofs_names_ints[i][-1])
+            print(ancestor_dof_numbers)
+            self.assertTrue(ancestor_dof_numbers == sorted(ancestor_dof_numbers))
+                    
     def test_local_dof_names(self):
         # Test in DOFs class is sufficient
         pass


### PR DESCRIPTION
Addressing issue #625

For an `Optimizable` that inherits from multiple ancestors of the same class, the order of the DOFs (i.e., the order of DOF names in `Optimizable.dof_names` follows dictionary-like/lexographic ordering (i.e., a10 would precede a9). This is harmful when more than 10 ancestors of the same type in total are created, particularly when accessing `Optimizable.x` to set variables: 

```Python
from simsopt.geo import CurveXYZFourier
from simsopt._core import Optimizable

class BunchOfCurves(Optimizable):
    """
    Create an optimizable set of curves, given a list of the orders
    of each curve, or a list of curves. 
    """
    def __init__(self, order_list, curve_list=None):
        if curve_list is None:
            curve_list=[]
            for order in order_list:
                curve = CurveXYZFourier(quadpoints=30, order=order)
                curve_list.append(curve)
        Optimizable.__init__(self, depends_on=curve_list)

orderlist = [1, 2, 2, 2, 1]
curveset0 = BunchOfCurves(order_list=orderlist) #['CurveXYZFourier1:...', ... , 'CurveXYZFourier5:...']
curveset1 = BunchOfCurves(order_list=orderlist) #['CurveXYZFourier10:...', 'CurveXYZFourier6:...', ... , 'CurveXYZFourier9:...']
curveset1.x = curveset0.x # does not set curve DOFs in ascending order!
```
The above example features a class `BunchOfCurves` containing `CurveXYZFourier`s of different resolution; the resolutions are specified with the list `order_list`. In the final line, `CurveXYZFourier10` in `curveset1` would get the DOFs of `CurveXYZFourier1` from `curveset0`, and 'CurveXYZFourier6' would get values from (the starting half of) 'CurveXYZFourier2'. More intuitive behaviour would be if all of the DOFs were assigned in ascending order. 