### PR TITLE
SurfaceRZFourier conversion to Desc format

### DIFF
--- a/.github/workflows/extensive_test.yml
+++ b/.github/workflows/extensive_test.yml
@@ -129,6 +129,9 @@ jobs:
     - name: Install virtual_casing
       run: python -m pip install -v git+https://github.com/hiddenSymmetries/virtual-casing
 
+    - name: Install desc-opt
+      run: python -m pip install desc-opt
+
     # See https://github.community/t/best-way-to-clone-a-private-repo-during-script-run-of-private-github-action/16116/7
     # https://stackoverflow.com/questions/57612428/cloning-private-github-repository-within-organisation-in-actions
     # https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,6 +111,9 @@ jobs:
     - name: Install virtual_casing
       run: pip install -v git+https://github.com/hiddenSymmetries/virtual-casing
 
+    - name: Install desc-opt
+      run: pip install desc-opt
+
     # 2025-11-28: Temporarily disabling SPEC due to github issue #561
     # # See https://github.community/t/best-way-to-clone-a-private-repo-during-script-run-of-private-github-action/16116/7
     # # https://stackoverflow.com/questions/57612428/cloning-private-github-repository-within-organisation-in-actions

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -649,13 +649,13 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
             poloidal_modes, toroidal_modes, s=zmns, c=zmnc
         )
 
-        surface_parameters = np.vstack((np.zeros_like(m), m, n, r_lmn, z_lmn)).T
+        modes = np.column_stack([m, n]).astype(int)
 
         return DescFourierRZToroidalSurface(
-            R_lmn=surface_parameters[:, 3],
-            Z_lmn=surface_parameters[:, 4],
-            modes_R=surface_parameters[:, 1:3].astype(int),
-            modes_Z=surface_parameters[:, 1:3].astype(int),
+            R_lmn=r_lmn.flatten(),
+            Z_lmn=z_lmn.flatten(),
+            modes_R=modes,
+            modes_Z=modes,
             NFP=n_field_periods,
             sym=is_stellarator_symmetric,
             check_orientation=False,

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -24,6 +24,12 @@ try:
 except ImportError:
     Qsc = None
 
+try:
+    from desc.geometry import FourierRZToroidalSurface as DescFourierRZToroidalSurface
+    from desc import vmec_utils as desc_vmec_utils
+except ImportError:
+    DescFourierRZToroidalSurface = None
+
 logger = logging.getLogger(__name__)
 
 __all__ = ['SurfaceRZFourier', 'SurfaceRZPseudospectral', 'plot_spectral_condensation']
@@ -516,7 +522,209 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
 
         surf.local_full_x = surf.get_dofs()
         return surf
+    
+    @classmethod
+    @SimsoptRequires(DescFourierRZToroidalSurface is not None, "from_desc method requires Desc module")
+    def from_desc(cls, surface: DescFourierRZToroidalSurface):
+        r"""Converts a DESC FourierRZToroidalSurface (parameterized with coefficients of a
+        Double Fourier Series basis [1]) into a SurfaceRZFourier (Parameterized with Fourier
+        coefficients in cylindrical coordinates).
 
+        Specifically, this function takes the **double-Fourier** representation
+        from DESC:
+
+        .. math::
+
+        R( \theta, \phi) \;=\;\sum_k R_k \,\cos\bigl(\,m_k\,\theta
+            \;-\; n_k\,(\mathrm{NFP})\,\phi\bigr),
+        \\
+        Z(\theta, \phi) \;=\;\sum_k Z_k \,\sin\bigl(\,m_k\,\theta
+            \;-\; n_k\,(\mathrm{NFP})\,\phi\bigr),
+
+        where :math:`m_k` and :math:`n_k` are the poloidal/toroidal integers stored in
+        the DESC surface bases, and produces *pure* cylindrical expansions:
+
+        .. math::
+        R(\theta, \phi)
+        \;=\;
+        \sum_{m,n}\Bigl(\,
+            R_{m,n}^{(\cos)}\,\cos(m\,\theta - n\,\phi)
+            \;+\;
+            R_{m,n}^{(\sin)}\,\sin(m\,\theta - n\,\phi)\Bigr),
+        \\
+        Z(\theta, \phi)
+        \;=\;
+        \sum_{m,n}\Bigl(\,
+            Z_{m,n}^{(\cos)}\,\cos(m\,\theta - n\,\phi)
+            \;+\;
+            Z_{m,n}^{(\sin)}\,\sin(m\,\theta - n\,\phi)\Bigr).
+
+        We use the ``ptolemy_identity_rev`` helper to reorganize
+        :math:`\cos(m\,\theta - n\,(\mathrm{NFP})\,\phi) \leftrightarrow \cos(m\,\theta)\,\cos(n\,\phi) \pm \dots`
+        into single-angle “cos/sin” expansions. For a surface with **stellarator symmetry**,
+        the typical result is that :math:`R(\theta,\phi)` only has nonzero “cos” modes,
+        and :math:`Z(\theta,\phi)` has only “sin” modes (but any small asymmetry
+        yields nonzero extra terms).
+
+        Args:
+            surface (FourierRZToroidalSurface): A DESC FourierRZToroidalSurface object.
+
+        Returns:
+            (SurfaceRZFourier): A SurfaceRZFourier object.
+
+        References
+        .. [1] `DESC Double-Fourier Series Documentation
+        <https://desc-docs.readthedocs.io/en/stable/notebooks/basis_grid.html#Double-Fourier-Series>`_
+        """
+        n_field_periods = surface.NFP
+
+        # ------------------ R expansions ------------------
+        # "DESC" style has poloidal modes: R_basis.modes[:, 1] => m
+        # toroidal modes: R_basis.modes[:, 2] => n
+        # but the actual function is cos(mθ - n*(NFP)*φ).
+        poloidal_modes_r = surface.R_basis.modes[:, 1]
+        toroidal_modes_r = surface.R_basis.modes[:, 2]
+
+        # R_lmn are the double-Fourier coefficients in DESC
+        # shape => (num_modes,). ptolemy_identity_rev expects shape (n_surfs, num_modes)
+        # but here we have only "one" surface => put them in a row
+        r_array = np.expand_dims(surface.R_lmn, axis=0)
+
+        # Convert to "cos(mθ - n(NFP)φ), sin(mθ - n(NFP)φ)" expansions
+        m_out_r, n_out_r, sin_r, cos_r = desc_vmec_utils.ptolemy_identity_rev(
+            m_1=poloidal_modes_r, n_1=toroidal_modes_r, x=r_array
+        )
+
+        # cos_R, sin_R have shape => (1, num_modes)
+        rmnc = cos_r[0, :]  # cos expansions => "R_{m,n} cos(mθ - n(NFP)φ)"
+        rmns = sin_r[0, :]  # sin expansions => "R_{m,n} sin(mθ - n(NFP)φ)"
+
+        # ------------------ Z expansions ------------------
+        poloidal_modes_z = surface.Z_basis.modes[:, 1]
+        toroidal_modes_z = surface.Z_basis.modes[:, 2]
+
+        z_array = np.expand_dims(surface.Z_lmn, axis=0)
+        m_out_z, n_out_z, sin_z, cos_z = desc_vmec_utils.ptolemy_identity_rev(
+            m_1=poloidal_modes_z, n_1=toroidal_modes_z, x=z_array
+        )
+
+        zmnc = cos_z[0, :]
+        zmns = sin_z[0, :]
+
+        # ------------------ convert ------------------
+
+        is_stellarator_symmetric = surface.sym
+        max_toroidal_mode = np.max(np.concatenate((n_out_r, n_out_z)))
+        max_poloidal_mode = np.max(np.concatenate((m_out_r, m_out_z)))
+
+        simsopt_surface = cls(
+            nfp=n_field_periods,
+            stellsym=is_stellarator_symmetric,
+            mpol=max_poloidal_mode,
+            ntor=max_toroidal_mode,
+        )
+
+        for m, n, value in zip(m_out_r, n_out_r, rmnc):
+            simsopt_surface.set_rc(m, n, value)
+
+        for m, n, value in zip(m_out_z, n_out_z, zmns):
+            simsopt_surface.set_zs(m, n, value)
+
+        if not is_stellarator_symmetric:
+            for m, n, value in zip(m_out_r, n_out_r, rmns):
+                simsopt_surface.set_rs(m, n, value)
+
+            for m, n, value in zip(m_out_z, n_out_z, zmnc):
+                simsopt_surface.set_zc(m, n, value)
+
+        return simsopt_surface
+    
+    @SimsoptRequires(DescFourierRZToroidalSurface is not None, "to_desc method requires Desc module")
+    def to_desc(self) -> DescFourierRZToroidalSurface:
+        r"""Converts a SurfaceRZFourier into a DESC FourierRZToroidalSurface (parameterized with
+        coefficients of a Double Fourier Series basis [1]).
+
+        Specifically, this function produces the **double-Fourier** representation from DESC:
+
+        .. math::
+
+        R( \theta, \phi) \;=\;\sum_k R_k \,\cos\bigl(\,m_k\,\theta
+            \;-\; n_k\,(\mathrm{NFP})\,\phi\bigr),
+        \\
+        Z(\theta, \phi) \;=\;\sum_k Z_k \,\sin\
+                \bigl(\,m_k\,\theta \;-\; n_k\,(\mathrm{NFP})\,\phi\bigr),
+
+        where :math:`m_k` and :math:`n_k` are the poloidal/toroidal integers stored in
+        the DESC surface bases.
+
+
+        Args:
+            surface (SurfaceRZFourier): A SurfaceRZFourier object.
+
+        Returns
+            A DESC FourierRZToroidalSurface object.
+
+
+        References
+
+        .. [1] `DESC Double-Fourier Series Documentation
+        <https://desc-docs.readthedocs.io/en/stable/notebooks/basis_grid.html#Double-Fourier-Series>`_
+        """
+
+        rmnc = self.rc.ravel()
+        zmns = self.zs.ravel()
+        rmns = self.rs.ravel() if self.rs is not None else np.zeros_like(rmnc)
+        zmnc = self.zc.ravel() if self.zc is not None else np.zeros_like(zmns)
+
+        n_poloidal_modes = np.shape(self.rc)[0]
+        n_toroidal_modes = np.shape(self.rc)[1]
+        max_toroidal_mode = (n_toroidal_modes - 1) // 2
+        poloidal_modes = np.broadcast_to(
+            np.arange(n_poloidal_modes)[:, None],
+            (n_poloidal_modes, n_toroidal_modes),
+        )
+        toroidal_modes = np.broadcast_to(
+            np.arange(-max_toroidal_mode, max_toroidal_mode + 1),
+            (n_poloidal_modes, n_toroidal_modes),
+        )
+        poloidal_modes = poloidal_modes.ravel().astype(int)
+        toroidal_modes = toroidal_modes.ravel().astype(int)
+
+
+        is_stellarator_symmetric = self.stellsym
+        n_field_periods = self.nfp
+
+        if is_stellarator_symmetric:
+            inds = np.where(np.logical_and(poloidal_modes == 0, toroidal_modes < 0))[0]
+            poloidal_modes = np.delete(poloidal_modes, inds)
+            toroidal_modes = np.delete(toroidal_modes, inds)
+            rmnc = np.delete(rmnc, inds)
+            zmns = np.delete(zmns, inds)
+            rmns = np.delete(rmns, inds)
+            zmnc = np.delete(zmnc, inds)
+
+        # R
+        m, n, r_lmn = desc_vmec_utils.ptolemy_identity_fwd(
+            poloidal_modes, toroidal_modes, s=rmns, c=rmnc
+        )
+
+        # Z
+        m, n, z_lmn = desc_vmec_utils.ptolemy_identity_fwd(
+            poloidal_modes, toroidal_modes, s=zmns, c=zmnc
+        )
+
+        surface_parameters = np.vstack((np.zeros_like(m), m, n, r_lmn, z_lmn)).T
+
+        return DescFourierRZToroidalSurface(
+            R_lmn=surface_parameters[:, 3],
+            Z_lmn=surface_parameters[:, 4],
+            modes_R=surface_parameters[:, 1:3].astype(int),
+            modes_Z=surface_parameters[:, 1:3].astype(int),
+            NFP=n_field_periods,
+            sym=is_stellarator_symmetric,
+            check_orientation=False,
+        )
+    
     def copy(self, **kwargs):
         """
         Return a copy of the ``SurfaceRZFourier`` object. 

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -534,49 +534,30 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
         Returns:
             (``SurfaceRZFourier``): A ``SurfaceRZFourier`` object.
         """
-        n_field_periods = surface.NFP
-
-        # ------------------ R expansions ------------------
-        # "DESC" style has poloidal modes: R_basis.modes[:, 1] => m
-        # toroidal modes: R_basis.modes[:, 2] => n
-        # but the actual function is cos(mθ - n*(NFP)*φ).
+        # Convert R from DESC double-Fourier to VMEC double-angle form
         poloidal_modes_r = surface.R_basis.modes[:, 1]
         toroidal_modes_r = surface.R_basis.modes[:, 2]
-
-        # R_lmn are the double-Fourier coefficients in DESC
-        # shape => (num_modes,). ptolemy_identity_rev expects shape (n_surfs, num_modes)
-        # but here we have only "one" surface => put them in a row
-        r_array = np.expand_dims(surface.R_lmn, axis=0)
-
-        # Convert to "cos(mθ - n(NFP)φ), sin(mθ - n(NFP)φ)" expansions
         m_out_r, n_out_r, sin_r, cos_r = desc_vmec_utils.ptolemy_identity_rev(
-            m_1=poloidal_modes_r, n_1=toroidal_modes_r, x=r_array
+            m_1=poloidal_modes_r, n_1=toroidal_modes_r, x=surface.R_lmn[np.newaxis, :]
         )
+        rmnc = cos_r[0, :]
+        rmns = sin_r[0, :]
 
-        # cos_R, sin_R have shape => (1, num_modes)
-        rmnc = cos_r[0, :]  # cos expansions => "R_{m,n} cos(mθ - n(NFP)φ)"
-        rmns = sin_r[0, :]  # sin expansions => "R_{m,n} sin(mθ - n(NFP)φ)"
-
-        # ------------------ Z expansions ------------------
+        # Convert Z from DESC double-Fourier to VMEC double-angle form
         poloidal_modes_z = surface.Z_basis.modes[:, 1]
         toroidal_modes_z = surface.Z_basis.modes[:, 2]
-
-        z_array = np.expand_dims(surface.Z_lmn, axis=0)
         m_out_z, n_out_z, sin_z, cos_z = desc_vmec_utils.ptolemy_identity_rev(
-            m_1=poloidal_modes_z, n_1=toroidal_modes_z, x=z_array
+            m_1=poloidal_modes_z, n_1=toroidal_modes_z, x=surface.Z_lmn[np.newaxis, :]
         )
-
         zmnc = cos_z[0, :]
         zmns = sin_z[0, :]
-
-        # ------------------ convert ------------------
 
         is_stellarator_symmetric = surface.sym
         max_toroidal_mode = np.max(np.abs(np.concatenate((n_out_r, n_out_z))))
         max_poloidal_mode = np.max(np.abs(np.concatenate((m_out_r, m_out_z))))
 
         simsopt_surface = cls(
-            nfp=n_field_periods,
+            nfp=surface.NFP,
             stellsym=is_stellarator_symmetric,
             mpol=max_poloidal_mode,
             ntor=max_toroidal_mode,
@@ -624,10 +605,6 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
         poloidal_modes = poloidal_modes.ravel().astype(int)
         toroidal_modes = toroidal_modes.ravel().astype(int)
 
-
-        is_stellarator_symmetric = self.stellsym
-        n_field_periods = self.nfp
-
         # Remove m=0, n<0 modes: these are always redundant because
         # cos(0·θ − n·φ) = cos(0·θ − (−n)·φ) and sin(0·θ − n·φ) = −sin(0·θ − (−n)·φ)
         # Keeping both positive and negative n at m=0 produces a singular system.
@@ -656,8 +633,8 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
             Z_lmn=z_lmn.flatten(),
             modes_R=modes,
             modes_Z=modes,
-            NFP=n_field_periods,
-            sym=is_stellarator_symmetric,
+            NFP=self.nfp,
+            sym=self.stellsym,
             check_orientation=False,
         )
     

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -628,14 +628,16 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
         is_stellarator_symmetric = self.stellsym
         n_field_periods = self.nfp
 
-        if is_stellarator_symmetric:
-            inds = np.where(np.logical_and(poloidal_modes == 0, toroidal_modes < 0))[0]
-            poloidal_modes = np.delete(poloidal_modes, inds)
-            toroidal_modes = np.delete(toroidal_modes, inds)
-            rmnc = np.delete(rmnc, inds)
-            zmns = np.delete(zmns, inds)
-            rmns = np.delete(rmns, inds)
-            zmnc = np.delete(zmnc, inds)
+        # Remove m=0, n<0 modes: these are always redundant because
+        # cos(0·θ − n·φ) = cos(0·θ − (−n)·φ) and sin(0·θ − n·φ) = −sin(0·θ − (−n)·φ)
+        # Keeping both positive and negative n at m=0 produces a singular system.
+        inds = np.where(np.logical_and(poloidal_modes == 0, toroidal_modes < 0))[0]
+        poloidal_modes = np.delete(poloidal_modes, inds)
+        toroidal_modes = np.delete(toroidal_modes, inds)
+        rmnc = np.delete(rmnc, inds)
+        zmns = np.delete(zmns, inds)
+        rmns = np.delete(rmns, inds)
+        zmnc = np.delete(zmnc, inds)
 
         # R
         m, n, r_lmn = desc_vmec_utils.ptolemy_identity_fwd(

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -579,8 +579,14 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
         return simsopt_surface
     
     @SimsoptRequires(DescFourierRZToroidalSurface is not None, "to_desc method requires Desc module")
-    def to_desc(self) -> DescFourierRZToroidalSurface:
+    def to_desc(self, check_orientation: bool = False) -> DescFourierRZToroidalSurface:
         r"""Convert a ``SurfaceRZFourier`` object into a DESC ``FourierRZToroidalSurface`` object.
+
+        Args:
+            check_orientation: If ``True``, DESC reverses the sign of :math:`\theta`
+              for surfaces it considers left-handed. The default
+              ``False`` leaves the coefficients unaltered, so that
+              ``from_desc(to_desc(surf))`` is the identity map.
 
         Returns:
             A DESC ``FourierRZToroidalSurface`` object.
@@ -635,7 +641,7 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
             modes_Z=modes,
             NFP=self.nfp,
             sym=self.stellsym,
-            check_orientation=False,
+            check_orientation=check_orientation,
         )
     
     def copy(self, **kwargs):

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -526,55 +526,13 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
     @classmethod
     @SimsoptRequires(DescFourierRZToroidalSurface is not None, "from_desc method requires Desc module")
     def from_desc(cls, surface: DescFourierRZToroidalSurface):
-        r"""Converts a DESC FourierRZToroidalSurface (parameterized with coefficients of a
-        Double Fourier Series basis [1]) into a SurfaceRZFourier (Parameterized with Fourier
-        coefficients in cylindrical coordinates).
-
-        Specifically, this function takes the **double-Fourier** representation
-        from DESC:
-
-        .. math::
-
-        R( \theta, \phi) \;=\;\sum_k R_k \,\cos\bigl(\,m_k\,\theta
-            \;-\; n_k\,(\mathrm{NFP})\,\phi\bigr),
-        \\
-        Z(\theta, \phi) \;=\;\sum_k Z_k \,\sin\bigl(\,m_k\,\theta
-            \;-\; n_k\,(\mathrm{NFP})\,\phi\bigr),
-
-        where :math:`m_k` and :math:`n_k` are the poloidal/toroidal integers stored in
-        the DESC surface bases, and produces *pure* cylindrical expansions:
-
-        .. math::
-        R(\theta, \phi)
-        \;=\;
-        \sum_{m,n}\Bigl(\,
-            R_{m,n}^{(\cos)}\,\cos(m\,\theta - n\,\phi)
-            \;+\;
-            R_{m,n}^{(\sin)}\,\sin(m\,\theta - n\,\phi)\Bigr),
-        \\
-        Z(\theta, \phi)
-        \;=\;
-        \sum_{m,n}\Bigl(\,
-            Z_{m,n}^{(\cos)}\,\cos(m\,\theta - n\,\phi)
-            \;+\;
-            Z_{m,n}^{(\sin)}\,\sin(m\,\theta - n\,\phi)\Bigr).
-
-        We use the ``ptolemy_identity_rev`` helper to reorganize
-        :math:`\cos(m\,\theta - n\,(\mathrm{NFP})\,\phi) \leftrightarrow \cos(m\,\theta)\,\cos(n\,\phi) \pm \dots`
-        into single-angle “cos/sin” expansions. For a surface with **stellarator symmetry**,
-        the typical result is that :math:`R(\theta,\phi)` only has nonzero “cos” modes,
-        and :math:`Z(\theta,\phi)` has only “sin” modes (but any small asymmetry
-        yields nonzero extra terms).
+        r"""Build a ``SurfaceRZFourier`` from a DESC ``FourierRZToroidalSurface``.
 
         Args:
-            surface (FourierRZToroidalSurface): A DESC FourierRZToroidalSurface object.
+            surface (``FourierRZToroidalSurface``): A DESC ``FourierRZToroidalSurface`` object.
 
         Returns:
-            (SurfaceRZFourier): A SurfaceRZFourier object.
-
-        References
-        .. [1] `DESC Double-Fourier Series Documentation
-        <https://desc-docs.readthedocs.io/en/stable/notebooks/basis_grid.html#Double-Fourier-Series>`_
+            (``SurfaceRZFourier``): A ``SurfaceRZFourier`` object.
         """
         n_field_periods = surface.NFP
 
@@ -641,34 +599,10 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
     
     @SimsoptRequires(DescFourierRZToroidalSurface is not None, "to_desc method requires Desc module")
     def to_desc(self) -> DescFourierRZToroidalSurface:
-        r"""Converts a SurfaceRZFourier into a DESC FourierRZToroidalSurface (parameterized with
-        coefficients of a Double Fourier Series basis [1]).
+        r"""Convert a ``SurfaceRZFourier`` object into a DESC ``FourierRZToroidalSurface`` object.
 
-        Specifically, this function produces the **double-Fourier** representation from DESC:
-
-        .. math::
-
-        R( \theta, \phi) \;=\;\sum_k R_k \,\cos\bigl(\,m_k\,\theta
-            \;-\; n_k\,(\mathrm{NFP})\,\phi\bigr),
-        \\
-        Z(\theta, \phi) \;=\;\sum_k Z_k \,\sin\
-                \bigl(\,m_k\,\theta \;-\; n_k\,(\mathrm{NFP})\,\phi\bigr),
-
-        where :math:`m_k` and :math:`n_k` are the poloidal/toroidal integers stored in
-        the DESC surface bases.
-
-
-        Args:
-            surface (SurfaceRZFourier): A SurfaceRZFourier object.
-
-        Returns
-            A DESC FourierRZToroidalSurface object.
-
-
-        References
-
-        .. [1] `DESC Double-Fourier Series Documentation
-        <https://desc-docs.readthedocs.io/en/stable/notebooks/basis_grid.html#Double-Fourier-Series>`_
+        Returns:
+            A DESC ``FourierRZToroidalSurface`` object.
         """
 
         rmnc = self.rc.ravel()

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -572,8 +572,8 @@ class SurfaceRZFourier(sopp.SurfaceRZFourier, Surface):
         # ------------------ convert ------------------
 
         is_stellarator_symmetric = surface.sym
-        max_toroidal_mode = np.max(np.concatenate((n_out_r, n_out_z)))
-        max_poloidal_mode = np.max(np.concatenate((m_out_r, m_out_z)))
+        max_toroidal_mode = np.max(np.abs(np.concatenate((n_out_r, n_out_z))))
+        max_poloidal_mode = np.max(np.abs(np.concatenate((m_out_r, m_out_z))))
 
         simsopt_surface = cls(
             nfp=n_field_periods,

--- a/src/simsopt/geo/surfacerzfourier.py
+++ b/src/simsopt/geo/surfacerzfourier.py
@@ -27,7 +27,7 @@ except ImportError:
 try:
     from desc.geometry import FourierRZToroidalSurface as DescFourierRZToroidalSurface
     from desc import vmec_utils as desc_vmec_utils
-except ImportError:
+except ImportError:  # pragma: no cover
     DescFourierRZToroidalSurface = None
 
 logger = logging.getLogger(__name__)

--- a/tests/geo/test_surface_rzfourier.py
+++ b/tests/geo/test_surface_rzfourier.py
@@ -17,6 +17,11 @@ try:
 except ImportError:
     vmec = None
 
+try:
+    from desc.geometry import FourierRZToroidalSurface as DescFourierRZToroidalSurface
+except ImportError:
+    DescFourierRZToroidalSurface = None
+
 from simsopt.mhd import Vmec
 
 TEST_DIR = Path(__file__).parent / ".." / "test_files"
@@ -517,6 +522,39 @@ class SurfaceRZFourierTests(unittest.TestCase):
 
         np.testing.assert_allclose(full_torus.rc, full_period.rc)
         np.testing.assert_allclose(full_torus.zs, full_period.zs)
+
+    @unittest.skipIf(DescFourierRZToroidalSurface is None, "desc python extension is not installed")
+    def test_surface_from_desc_roundtrip(self):
+        """Test that surface_from_desc correctly converts DESC surface back to simsopt."""
+        import os
+        from scipy.spatial.distance import cdist
+
+        filelist = ["input.rotating_ellipse", 'input.LandremanPaul2021_QH_reactorScale_lowres', "input.ITERModel", "input.li383_low_res"]
+
+        for ff in filelist:
+            # input_file = str(TEST_DIR / 'input.LandremanPaul2021_QH_reactorScale_lowres')
+            input_file = os.path.join(TEST_DIR, ff)
+            surface_orig = SurfaceRZFourier.from_vmec_input(input_file)
+
+            # Convert to DESC and back
+            desc_surface = surface_orig.to_desc()
+            boundary_roundtrip = SurfaceRZFourier.from_desc(desc_surface)
+            boundary_from_desc = boundary_roundtrip.copy(
+                quadpoints_phi=surface_orig.quadpoints_phi,
+                quadpoints_theta=surface_orig.quadpoints_theta,
+            )
+
+            # Check NFP and stellsym are preserved
+            self.assertEqual(boundary_from_desc.nfp, surface_orig.nfp)
+            self.assertEqual(boundary_from_desc.stellsym, surface_orig.stellsym)
+
+            # Check geometry is preserved via gamma
+            gamma_flat = surface_orig.gamma().reshape((-1, 3))
+            gamma_rt_flat = boundary_from_desc.gamma().reshape((-1, 3))
+            distances = cdist(gamma_flat, gamma_rt_flat)
+            gamma_err = np.max(np.min(distances, axis=1))
+            self.assertAlmostEqual(gamma_err, 0.0, places=12)
+
 
     def test_change_resolution(self):
         """

--- a/tests/geo/test_surface_rzfourier.py
+++ b/tests/geo/test_surface_rzfourier.py
@@ -527,9 +527,8 @@ class SurfaceRZFourierTests(unittest.TestCase):
     def test_to_from_desc_roundtrip(self):
         """Test that to_desc and from_desc correctly converts DESC surface back to simsopt."""
         import os
-        from scipy.spatial.distance import cdist
 
-        filelist = ["input.rotating_ellipse", 'input.LandremanPaul2021_QH_reactorScale_lowres', "input.ITERModel", "input.li383_low_res"]
+        filelist = ["input.rotating_ellipse", 'input.LandremanPaul2021_QH_reactorScale_lowres', "input.ITERModel", "input.li383_low_res", "input.basic_non_stellsym"]
 
         for ff in filelist:
             # input_file = str(TEST_DIR / 'input.LandremanPaul2021_QH_reactorScale_lowres')

--- a/tests/geo/test_surface_rzfourier.py
+++ b/tests/geo/test_surface_rzfourier.py
@@ -1,4 +1,6 @@
+import os
 import unittest
+import warnings
 from pathlib import Path
 
 from qsc import Qsc
@@ -526,12 +528,9 @@ class SurfaceRZFourierTests(unittest.TestCase):
     @unittest.skipIf(DescFourierRZToroidalSurface is None, "desc python extension is not installed")
     def test_to_from_desc_roundtrip(self):
         """Test that to_desc and from_desc correctly converts DESC surface back to simsopt."""
-        import os
-
         filelist = ["input.rotating_ellipse", 'input.LandremanPaul2021_QH_reactorScale_lowres', "input.ITERModel", "input.li383_low_res", "input.basic_non_stellsym"]
 
         for ff in filelist:
-            # input_file = str(TEST_DIR / 'input.LandremanPaul2021_QH_reactorScale_lowres')
             input_file = os.path.join(TEST_DIR, ff)
             surface_orig = SurfaceRZFourier.from_vmec_input(input_file)
 
@@ -548,10 +547,7 @@ class SurfaceRZFourierTests(unittest.TestCase):
             self.assertEqual(boundary_from_desc.stellsym, surface_orig.stellsym)
 
             # Check geometry is preserved via gamma
-            gamma_flat = surface_orig.gamma().reshape((-1, 3))
-            gamma_rt_flat = boundary_from_desc.gamma().reshape((-1, 3))
-            gamma_err = np.max(np.linalg.norm(gamma_flat - gamma_rt_flat, axis=-1))
-            self.assertAlmostEqual(gamma_err, 0.0, places=12)
+            np.testing.assert_allclose(surface_orig.gamma(), boundary_from_desc.gamma(), atol=1e-12)
 
             # check the modes are preserved
             np.testing.assert_allclose(boundary_from_desc.rc, surface_orig.rc, atol=1e-12)
@@ -565,7 +561,7 @@ class SurfaceRZFourierTests(unittest.TestCase):
         surface_orig = SurfaceRZFourier(mpol=2, ntor=0, nfp=1, stellsym=True)
         surface_orig.set_rc(0, 0, 1.0)
         surface_orig.set_rc(1, 0, 0.1)
-        surface_orig.set_zs(1, 0, 0.1)
+        surface_orig.set_zs(1, 0, 0.13)
 
         desc_surface = surface_orig.to_desc()
         boundary_from_desc = SurfaceRZFourier.from_desc(desc_surface).copy(
@@ -573,11 +569,7 @@ class SurfaceRZFourierTests(unittest.TestCase):
             quadpoints_theta=surface_orig.quadpoints_theta,
         )
 
-        gamma_err = np.max(np.linalg.norm(
-            surface_orig.gamma().reshape((-1, 3)) - boundary_from_desc.gamma().reshape((-1, 3)),
-            axis=-1,
-        ))
-        self.assertAlmostEqual(gamma_err, 0.0, places=12)
+        np.testing.assert_allclose(surface_orig.gamma(), boundary_from_desc.gamma(), atol=1e-12)
 
     @unittest.skipIf(DescFourierRZToroidalSurface is None, "desc python extension is not installed")
     def test_from_desc_known_coefficients(self):
@@ -586,7 +578,7 @@ class SurfaceRZFourierTests(unittest.TestCase):
         # check_orientation=False prevents DESC from flipping Z_lmn sign.
         desc_surface = DescFourierRZToroidalSurface(
             R_lmn=np.array([1.0, 0.1]),
-            Z_lmn=np.array([0.1]),
+            Z_lmn=np.array([0.13]),
             modes_R=np.array([[0, 0], [1, 0]]),
             modes_Z=np.array([[-1, 0]]),
             NFP=2,
@@ -599,7 +591,24 @@ class SurfaceRZFourierTests(unittest.TestCase):
         self.assertTrue(s.stellsym)
         self.assertAlmostEqual(s.get_rc(0, 0), 1.0, places=12)
         self.assertAlmostEqual(s.get_rc(1, 0), 0.1, places=12)
-        self.assertAlmostEqual(s.get_zs(1, 0), 0.1, places=12)
+        self.assertAlmostEqual(s.get_zs(1, 0), 0.13, places=12)
+
+    @unittest.skipIf(DescFourierRZToroidalSurface is None, "desc python extension is not installed")
+    def test_to_desc_check_orientation(self):
+        """The check_orientation kwarg only affects mode signs, never the shape."""
+        surface_orig = SurfaceRZFourier(mpol=2, ntor=1, nfp=2, stellsym=True)
+        surface_orig.set_rc(0, 0, 1.0)
+        surface_orig.set_rc(1, 0, 0.1)
+        surface_orig.set_zs(1, 0, 0.13)
+
+        desc_unchecked = surface_orig.to_desc(check_orientation=False)
+        with warnings.catch_warnings():
+            # DESC warns when it flips the sign of theta
+            warnings.simplefilter("ignore")
+            desc_checked = surface_orig.to_desc(check_orientation=True)
+
+        np.testing.assert_allclose(np.abs(desc_checked.R_lmn), np.abs(desc_unchecked.R_lmn), atol=1e-12)
+        np.testing.assert_allclose(np.abs(desc_checked.Z_lmn), np.abs(desc_unchecked.Z_lmn), atol=1e-12)
 
     def test_change_resolution(self):
         """

--- a/tests/geo/test_surface_rzfourier.py
+++ b/tests/geo/test_surface_rzfourier.py
@@ -21,8 +21,10 @@ except ImportError:
 
 try:
     from desc.geometry import FourierRZToroidalSurface as DescFourierRZToroidalSurface
+    from desc.grid import LinearGrid as DescLinearGrid
 except ImportError:
     DescFourierRZToroidalSurface = None
+    DescLinearGrid = None
 
 from simsopt.mhd import Vmec
 
@@ -32,6 +34,25 @@ stellsym_list = [True, False]
 
 
 class SurfaceRZFourierTests(unittest.TestCase):
+
+    def _assert_simsopt_surface_matches_desc_xyz(self, simsopt_surface, desc_surface, atol=1e-12):
+        """Compare simsopt gamma() xyz coordinates to DESC compute('x')."""
+        # Compare on one field period so DESC's toroidal coordinate wrapping does not
+        # reorder full-torus grids before evaluation.
+        simsopt_eval_surface = simsopt_surface.copy(nphi=12, ntheta=13, range="field period")
+
+        theta = 2 * np.pi * simsopt_eval_surface.quadpoints_theta
+        zeta = 2 * np.pi * simsopt_eval_surface.quadpoints_phi
+        desc_grid = DescLinearGrid(
+            rho=1.0,
+            theta=theta,
+            zeta=zeta,
+            NFP=desc_surface.NFP,
+        )
+        desc_xyz = np.asarray(desc_surface.compute("x", grid=desc_grid, basis="xyz")["x"])
+        # DESC meshgrid_reshape returns (rho, theta, zeta, ...). simsopt gamma is (phi, theta, ...).
+        desc_xyz = np.asarray(desc_grid.meshgrid_reshape(desc_xyz, "rtz"))[0].transpose(1, 0, 2)
+        np.testing.assert_allclose(simsopt_eval_surface.gamma(), desc_xyz, atol=atol)
 
     def test_aspect_ratio(self):
         """
@@ -549,6 +570,10 @@ class SurfaceRZFourierTests(unittest.TestCase):
             # Check geometry is preserved via gamma
             np.testing.assert_allclose(surface_orig.gamma(), boundary_from_desc.gamma(), atol=1e-12)
 
+            # Check xyz coordinates against DESC-computed xyz on a matching grid.
+            self._assert_simsopt_surface_matches_desc_xyz(surface_orig, desc_surface, atol=1e-12)
+            self._assert_simsopt_surface_matches_desc_xyz(boundary_from_desc, desc_surface, atol=1e-12)
+
             # check the modes are preserved
             np.testing.assert_allclose(boundary_from_desc.rc, surface_orig.rc, atol=1e-12)
             np.testing.assert_allclose(boundary_from_desc.zs, surface_orig.zs, atol=1e-12)
@@ -570,6 +595,8 @@ class SurfaceRZFourierTests(unittest.TestCase):
         )
 
         np.testing.assert_allclose(surface_orig.gamma(), boundary_from_desc.gamma(), atol=1e-12)
+        self._assert_simsopt_surface_matches_desc_xyz(surface_orig, desc_surface, atol=1e-12)
+        self._assert_simsopt_surface_matches_desc_xyz(boundary_from_desc, desc_surface, atol=1e-12)
 
     @unittest.skipIf(DescFourierRZToroidalSurface is None, "desc python extension is not installed")
     def test_from_desc_known_coefficients(self):
@@ -592,6 +619,7 @@ class SurfaceRZFourierTests(unittest.TestCase):
         self.assertAlmostEqual(s.get_rc(0, 0), 1.0, places=12)
         self.assertAlmostEqual(s.get_rc(1, 0), 0.1, places=12)
         self.assertAlmostEqual(s.get_zs(1, 0), 0.13, places=12)
+        self._assert_simsopt_surface_matches_desc_xyz(s, desc_surface, atol=1e-12)
 
     @unittest.skipIf(DescFourierRZToroidalSurface is None, "desc python extension is not installed")
     def test_to_desc_check_orientation(self):

--- a/tests/geo/test_surface_rzfourier.py
+++ b/tests/geo/test_surface_rzfourier.py
@@ -559,6 +559,48 @@ class SurfaceRZFourierTests(unittest.TestCase):
             np.testing.assert_allclose(boundary_from_desc.rs, surface_orig.rs, atol=1e-12)
             np.testing.assert_allclose(boundary_from_desc.zc, surface_orig.zc, atol=1e-12)
 
+    @unittest.skipIf(DescFourierRZToroidalSurface is None, "desc python extension is not installed")
+    def test_to_from_desc_ntor0(self):
+        """Roundtrip with ntor=0 (no toroidal modes — mode deletion path is a no-op)."""
+        surface_orig = SurfaceRZFourier(mpol=2, ntor=0, nfp=1, stellsym=True)
+        surface_orig.set_rc(0, 0, 1.0)
+        surface_orig.set_rc(1, 0, 0.1)
+        surface_orig.set_zs(1, 0, 0.1)
+
+        desc_surface = surface_orig.to_desc()
+        boundary_from_desc = SurfaceRZFourier.from_desc(desc_surface).copy(
+            quadpoints_phi=surface_orig.quadpoints_phi,
+            quadpoints_theta=surface_orig.quadpoints_theta,
+        )
+
+        gamma_err = np.max(np.linalg.norm(
+            surface_orig.gamma().reshape((-1, 3)) - boundary_from_desc.gamma().reshape((-1, 3)),
+            axis=-1,
+        ))
+        self.assertAlmostEqual(gamma_err, 0.0, places=12)
+
+    @unittest.skipIf(DescFourierRZToroidalSurface is None, "desc python extension is not installed")
+    def test_from_desc_known_coefficients(self):
+        """from_desc with a hand-built DESC surface whose simsopt output is known."""
+        # DESC sym=True convention: R uses positive m, Z uses negative m.
+        # check_orientation=False prevents DESC from flipping Z_lmn sign.
+        desc_surface = DescFourierRZToroidalSurface(
+            R_lmn=np.array([1.0, 0.1]),
+            Z_lmn=np.array([0.1]),
+            modes_R=np.array([[0, 0], [1, 0]]),
+            modes_Z=np.array([[-1, 0]]),
+            NFP=2,
+            sym=True,
+            check_orientation=False,
+        )
+        s = SurfaceRZFourier.from_desc(desc_surface)
+
+        self.assertEqual(s.nfp, 2)
+        self.assertTrue(s.stellsym)
+        self.assertAlmostEqual(s.get_rc(0, 0), 1.0, places=12)
+        self.assertAlmostEqual(s.get_rc(1, 0), 0.1, places=12)
+        self.assertAlmostEqual(s.get_zs(1, 0), 0.1, places=12)
+
     def test_change_resolution(self):
         """
         Check that we can change mpol and ntor.

--- a/tests/geo/test_surface_rzfourier.py
+++ b/tests/geo/test_surface_rzfourier.py
@@ -524,8 +524,8 @@ class SurfaceRZFourierTests(unittest.TestCase):
         np.testing.assert_allclose(full_torus.zs, full_period.zs)
 
     @unittest.skipIf(DescFourierRZToroidalSurface is None, "desc python extension is not installed")
-    def test_surface_from_desc_roundtrip(self):
-        """Test that surface_from_desc correctly converts DESC surface back to simsopt."""
+    def test_to_from_desc_roundtrip(self):
+        """Test that to_desc and from_desc correctly converts DESC surface back to simsopt."""
         import os
         from scipy.spatial.distance import cdist
 
@@ -551,10 +551,14 @@ class SurfaceRZFourierTests(unittest.TestCase):
             # Check geometry is preserved via gamma
             gamma_flat = surface_orig.gamma().reshape((-1, 3))
             gamma_rt_flat = boundary_from_desc.gamma().reshape((-1, 3))
-            distances = cdist(gamma_flat, gamma_rt_flat)
-            gamma_err = np.max(np.min(distances, axis=1))
+            gamma_err = np.max(np.linalg.norm(gamma_flat - gamma_rt_flat, axis=-1))
             self.assertAlmostEqual(gamma_err, 0.0, places=12)
 
+            # check the modes are preserved
+            np.testing.assert_allclose(boundary_from_desc.rc, surface_orig.rc, atol=1e-12)
+            np.testing.assert_allclose(boundary_from_desc.zs, surface_orig.zs, atol=1e-12)
+            np.testing.assert_allclose(boundary_from_desc.rs, surface_orig.rs, atol=1e-12)
+            np.testing.assert_allclose(boundary_from_desc.zc, surface_orig.zc, atol=1e-12)
 
     def test_change_resolution(self):
         """


### PR DESCRIPTION
**Summary**
This PR introduces new methods to convert `SurfaceRZFourier` objects to and from the equivalent Desc format, `FourierRZToroidalSurface`. The methods are covered by unit tests which convert stellarator-symmetric and non-stellarator symmetric surfaces.

**New Methods**
Two new methods have been added to the `SurfaceRZFourier` class:
- `to_desc`:  converts an instance of a surface to the Desc format,
- `from_desc`:  a _class method_ that builds a `SurfaceRZFourier` object from an existing Desc `FourierRZToroidalSurface`.
 