### PR TITLE
Profile conversions to Desc profiles

### DIFF
--- a/.github/workflows/extensive_test.yml
+++ b/.github/workflows/extensive_test.yml
@@ -129,6 +129,9 @@ jobs:
     - name: Install virtual_casing
       run: python -m pip install -v git+https://github.com/hiddenSymmetries/virtual-casing
 
+    - name: Install desc-opt
+      run: python -m pip install desc-opt
+
     # See https://github.community/t/best-way-to-clone-a-private-repo-during-script-run-of-private-github-action/16116/7
     # https://stackoverflow.com/questions/57612428/cloning-private-github-repository-within-organisation-in-actions
     # https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,6 +111,9 @@ jobs:
     - name: Install virtual_casing
       run: pip install -v git+https://github.com/hiddenSymmetries/virtual-casing
 
+    - name: Install desc-opt
+      run: pip install desc-opt
+
     # 2025-11-28: Temporarily disabling SPEC due to github issue #561
     # # See https://github.community/t/best-way-to-clone-a-private-repo-during-script-run-of-private-github-action/16116/7
     # # https://stackoverflow.com/questions/57612428/cloning-private-github-repository-within-organisation-in-actions

--- a/src/simsopt/mhd/profiles.py
+++ b/src/simsopt/mhd/profiles.py
@@ -175,10 +175,10 @@ class ProfilePolynomial(Profile):
 
     @classmethod
     @SimsoptRequires(DescPowerSeriesProfile is not None, "from_desc method requires Desc module")
-    def from_desc(self, desc_profile):
+    def from_desc(cls, desc_profile):
         """Initialize an instance of the ProfilePolynomial from a Desc PowerSeriesProfile. Desc profiles
         are functions of ``rho=sqrt(s)``, so if the Desc profile has odd modes, then the new instance may not exactly reproduce
-        the Desc profile, 
+        the Desc profile.
 
         Args:
             desc_profile (PowerSeriesProfile): A Desc PowerSeriesProfile.
@@ -192,10 +192,14 @@ class ProfilePolynomial(Profile):
         if desc_profile.sym:
             coeffs = np.copy(params)
         else:
+            logger.warning(
+                "from_desc: DESC profile has odd-power (sym=False) terms which cannot be "
+                "represented as a polynomial in s. Odd-power terms will be dropped."
+            )
             coeffs = np.copy(params[::2])
-        return ProfilePolynomial(coeffs)
+        return cls(coeffs)
     
-    @SimsoptRequires(DescPowerSeriesProfile is not None, "from_desc method requires Desc module")
+    @SimsoptRequires(DescPowerSeriesProfile is not None, "to_desc method requires Desc module")
     def to_desc(self):
         """Return an equivalent Desc PowerSeriesProfile. Note that Desc profiles are functions
         of ``rho``.
@@ -294,7 +298,7 @@ class ProfileSpline(Profile):
 
     @classmethod
     @SimsoptRequires(DescSplineProfile is not None, "from_desc method requires Desc module")
-    def from_desc(self, desc_profile, degree=3):
+    def from_desc(cls, desc_profile, degree=3):
         """Initialize an instance of the ProfileSpline from a Desc SplineProfile. Desc profiles
         are functions of ``rho=sqrt(s)``, so the Simsopt profile may not interpolate them exactly
         if the profile has components that depend on odd powers of ``rho``.
@@ -309,22 +313,24 @@ class ProfileSpline(Profile):
         if not isinstance(desc_profile, DescSplineProfile):
             raise TypeError(f"Expected a Desc SplineProfile, got {type(desc_profile)}")
         rho_knots = np.array(desc_profile.knots)
-        return ProfileSpline(rho_knots**2, np.array(desc_profile.params), degree=degree)
+        return cls(rho_knots**2, np.array(desc_profile.params), degree=degree)
     
-    @SimsoptRequires(DescSplineProfile is not None, "from_desc method requires Desc module")
+    @SimsoptRequires(DescSplineProfile is not None, "to_desc method requires Desc module")
     def to_desc(self):
         """Return an equivalent Desc SplineProfile. Note that Desc profiles are functions
-        of ``rho``. If ``degree`` is anything other than ``1``, then the Desc profile will use
-        cubic splines.
+        of ``rho``. Only ``degree`` 1 (linear) and 3 (cubic) are supported.
 
         Returns:
             DescSplineProfile: A Desc SplineProfile.
         """
         if self.degree == 1:
             method = "linear"
-        else:
+        elif self.degree == 3:
             method = "cubic2"
-        
+        else:
+            raise ValueError(
+                f"to_desc only supports spline degree 1 (linear) or 3 (cubic), got {self.degree}"
+            )
         rho = np.sqrt(self.s)
         return DescSplineProfile(values=self.local_full_x, knots=rho, method=method)
 

--- a/src/simsopt/mhd/profiles.py
+++ b/src/simsopt/mhd/profiles.py
@@ -23,7 +23,7 @@ try:
         SplineProfile as DescSplineProfile,
         PowerSeriesProfile as DescPowerSeriesProfile,
     )
-except ImportError:
+except ImportError:  # pragma: no cover
     DescPowerSeriesProfile = None
     DescSplineProfile = None
 

--- a/src/simsopt/mhd/profiles.py
+++ b/src/simsopt/mhd/profiles.py
@@ -16,6 +16,16 @@ import numbers
 
 from .._core.optimizable import Optimizable
 from .._core.descriptor import PositiveInteger
+from .._core.dev import SimsoptRequires
+
+try:
+    from desc.profiles import (
+        SplineProfile as DescSplineProfile,
+        PowerSeriesProfile as DescPowerSeriesProfile,
+    )
+except ImportError:
+    DescPowerSeriesProfile = None
+    DescSplineProfile = None
 
 __all__ = ['Profile', 'ProfilePolynomial', 'ProfileScaled', 'ProfileSpline',
            'ProfilePressure', 'ProfileSpec']
@@ -163,6 +173,35 @@ class ProfilePolynomial(Profile):
         """ Return the d/ds derivative of the profile at specified points in s. """
         return poly.polyval(s, poly.polyder(self.local_full_x))
 
+    @classmethod
+    @SimsoptRequires(DescPowerSeriesProfile is not None, "from_desc method requires Desc module")
+    def from_desc(self, desc_profile):
+        """Initialize an instance of the ProfilePolynomial from a Desc PowerSeriesProfile. Desc profiles
+        are functions of ``rho=sqrt(s)``, so if the Desc profile has odd modes, then the new instance may not exactly reproduce
+        the Desc profile, 
+
+        Args:
+            desc_profile (PowerSeriesProfile): A Desc PowerSeriesProfile.
+
+        Returns:
+            ProfilePolynomial: A simsopt ProfilePolynomial.
+        """
+        params = desc_profile.params
+        if desc_profile.sym:
+            coeffs = np.copy(params)
+        else:
+            coeffs = np.copy(params[::2])
+        return ProfilePolynomial(coeffs)
+    
+    @SimsoptRequires(DescPowerSeriesProfile is not None, "from_desc method requires Desc module")
+    def to_desc(self):
+        """Return an equivalent Desc PowerSeriesProfile. Note that Desc profiles are functions
+        of ``rho``.
+
+        Returns:
+            PowerSeriesProfile: A Desc PowerSeriesProfile.
+        """
+        return DescPowerSeriesProfile(params=self.local_full_x, sym=True)
 
 class ProfileScaled(Profile):
     """
@@ -208,6 +247,15 @@ class ProfileSpline(Profile):
 
     degree = PositiveInteger()
 
+    @property
+    def s(self):
+        """1d array of x coordinates (spline knot locations) for the spline."""
+        return self._s
+
+    @s.setter
+    def s(self, value):
+        self._s = value
+
     def __init__(self, s, f, degree=3):
         self.s = s
         self.degree = degree
@@ -241,6 +289,40 @@ class ProfileSpline(Profile):
         if degree is not None:
             new_degree = degree
         return ProfileSpline(new_s, self.f(new_s), degree=new_degree)
+
+    @classmethod
+    @SimsoptRequires(DescSplineProfile is not None, "from_desc method requires Desc module")
+    def from_desc(self, desc_profile, degree=3):
+        """Initialize an instance of the ProfileSpline from a Desc SplineProfile. Desc profiles
+        are functions of ``rho=sqrt(s)``, so the Simsopt profile may not interpolate them exactly
+        if the profile has components that depend on odd powers of ``rho``.
+
+        Args:
+            desc_profile (DescSplineProfile): A Desc SplineProfile.
+            degree: The polynomial degree of the simsopt spline. Must be in ``[1, 2, 3, 4, 5]``.
+
+        Returns:
+            ProfileSpline: A simsopt ProfileSpline.
+        """
+        rho_knots = np.array(desc_profile.knots)
+        return ProfileSpline(rho_knots**2, np.array(desc_profile.params), degree=degree)
+    
+    @SimsoptRequires(DescSplineProfile is not None, "from_desc method requires Desc module")
+    def to_desc(self):
+        """Return an equivalent Desc SplineProfile. Note that Desc profiles are functions
+        of ``rho``. If ``degree`` is anything other than ``1``, then the Desc profile will use
+        cubic splines.
+
+        Returns:
+            DescSplineProfile: A Desc SplineProfile.
+        """
+        if self.degree == 1:
+            method = "linear"
+        else:
+            method = "cubic2"
+        
+        rho = np.sqrt(self.s)
+        return DescSplineProfile(values=self.local_full_x, knots=rho, method=method)
 
 
 class ProfilePressure(Profile):

--- a/src/simsopt/mhd/profiles.py
+++ b/src/simsopt/mhd/profiles.py
@@ -186,6 +186,8 @@ class ProfilePolynomial(Profile):
         Returns:
             ProfilePolynomial: A simsopt ProfilePolynomial.
         """
+        if not isinstance(desc_profile, DescPowerSeriesProfile):
+            raise TypeError(f"Expected a Desc PowerSeriesProfile, got {type(desc_profile)}")
         params = desc_profile.params
         if desc_profile.sym:
             coeffs = np.copy(params)
@@ -304,6 +306,8 @@ class ProfileSpline(Profile):
         Returns:
             ProfileSpline: A simsopt ProfileSpline.
         """
+        if not isinstance(desc_profile, DescSplineProfile):
+            raise TypeError(f"Expected a Desc SplineProfile, got {type(desc_profile)}")
         rho_knots = np.array(desc_profile.knots)
         return ProfileSpline(rho_knots**2, np.array(desc_profile.params), degree=degree)
     

--- a/tests/mhd/test_profiles.py
+++ b/tests/mhd/test_profiles.py
@@ -8,6 +8,15 @@ try:
 except ImportError:
     matplotlib = None
 
+try:
+    from desc.profiles import (
+        PowerSeriesProfile as DescPowerSeriesProfile,
+        SplineProfile as DescSplineProfile,
+    )
+except ImportError:
+    DescPowerSeriesProfile = None
+    DescSplineProfile = None
+
 from simsopt.mhd import (ProfilePolynomial, ProfileScaled, ProfileSpline,
                          ProfilePressure, ProfileSpec)
 
@@ -208,3 +217,91 @@ class ProfilesTests(unittest.TestCase):
             ProfilePressure(ne, Te, nD)
         with self.assertRaises(ValueError):
             ProfilePressure(ne, Te, nD, TD, nT)
+
+
+@unittest.skipUnless(DescPowerSeriesProfile is not None, "DESC not installed")
+class TestProfilePolynomialDesc(unittest.TestCase):
+    """Tests for ProfilePolynomial <-> DESC PowerSeriesProfile conversion."""
+
+    def test_to_desc_sym(self):
+        """to_desc produces a DESC profile with matching values (sym=True)."""
+        # f(s) = 1 + 0.5*s - 0.3*s^2
+        coeffs = np.array([1.0, 0.5, -0.3])
+        prof = ProfilePolynomial(coeffs)
+        prof_desc = prof.to_desc()
+
+        # DESC uses rho; simsopt uses s = rho^2
+        rho = np.linspace(0, 1, 11)
+        np.testing.assert_allclose(prof(rho**2), prof_desc(rho), rtol=1e-12)
+
+    def test_from_desc_sym(self):
+        """from_desc with sym=True roundtrips coefficients exactly."""
+        params = np.array([1.0, 0.5, -0.3])
+        prof_desc = DescPowerSeriesProfile(params=params, sym=True)
+        prof = ProfilePolynomial.from_desc(prof_desc)
+
+        self.assertIsInstance(prof, ProfilePolynomial)
+        np.testing.assert_array_equal(prof.local_full_x, params)
+
+        rho = np.linspace(0, 1, 11)
+        np.testing.assert_allclose(prof(rho**2), prof_desc(rho), rtol=1e-12)
+
+    def test_from_desc_no_sym(self):
+        """from_desc with sym=False drops odd-power terms."""
+        # f(rho) = 1 + 0.5*rho - 0.3*rho^2 + 0.1*rho^3
+        # Even terms: a0=1, a2=-0.3 -> ProfilePolynomial([1, -0.3])
+        params = np.array([1.0, 0.5, -0.3, 0.1])
+        prof_desc = DescPowerSeriesProfile(params=params, sym=False)
+        prof = ProfilePolynomial.from_desc(prof_desc)
+
+        np.testing.assert_array_equal(prof.local_full_x, params[::2])
+
+    def test_roundtrip(self):
+        """simsopt -> DESC -> simsopt preserves values."""
+        coeffs = np.array([1.0, 0.5, -0.3, 0.0, 0.2])
+        prof_orig = ProfilePolynomial(coeffs)
+        prof_rt = ProfilePolynomial.from_desc(prof_orig.to_desc())
+
+        s = np.linspace(0, 1, 20)
+        np.testing.assert_allclose(prof_orig(s), prof_rt(s), rtol=1e-12)
+
+
+@unittest.skipUnless(DescSplineProfile is not None, "DESC not installed")
+class TestProfileSplineDesc(unittest.TestCase):
+    """Tests for ProfileSpline <-> DESC SplineProfile conversion."""
+
+    def test_to_desc(self):
+        """to_desc maps s-space knots to rho-space and preserves values."""
+        s_knots = np.linspace(0, 1, 6)
+        f_values = 1.0 - s_knots
+        prof = ProfileSpline(s_knots, f_values, degree=3)
+        prof_desc = prof.to_desc()
+
+        rho = np.linspace(0, 1, 11)
+        np.testing.assert_allclose(prof(rho**2), prof_desc(rho), rtol=1e-6)
+
+    def test_from_desc(self):
+        """from_desc maps rho-space knots to s-space and preserves values."""
+        # f(rho) = 1 - 1.5*rho^2 + 0.5*rho^4 uses even rho powers only,
+        # so f(s) = 1 - 1.5*s + 0.5*s^2 is polynomial — exactly representable
+        # by the s-spline. Error only comes from the DESC cubic spline
+        # approximating the degree-4 rho term.
+        rho_knots = np.linspace(0, 1, 20)
+        f_values = 1.0 - 1.5 * rho_knots**2 + 0.5 * rho_knots**4
+        prof_desc = DescSplineProfile(values=f_values, knots=rho_knots, method="cubic2")
+        prof = ProfileSpline.from_desc(prof_desc, degree=3)
+
+        rho = np.linspace(0, 1, 50)
+        np.testing.assert_allclose(prof(rho**2), prof_desc(rho), atol=1e-5)
+
+    def test_roundtrip(self):
+        """simsopt -> DESC -> simsopt preserves values."""
+        # f(s) = 1 - s maps to 1 - rho^2 in rho-space (degree 2),
+        # which a cubic spline represents exactly — making the roundtrip exact.
+        s_knots = np.linspace(0, 1, 6)
+        f_values = 1.3252 - s_knots
+        prof_orig = ProfileSpline(s_knots, f_values, degree=3)
+        prof_rt = ProfileSpline.from_desc(prof_orig.to_desc(), degree=3)
+
+        s = np.linspace(0, 1, 20)
+        np.testing.assert_allclose(prof_orig(s), prof_rt(s), atol=1e-12)

--- a/tests/mhd/test_profiles.py
+++ b/tests/mhd/test_profiles.py
@@ -284,7 +284,7 @@ class TestProfileSplineDesc(unittest.TestCase):
         prof_desc = prof.to_desc()
 
         rho = np.linspace(0, 1, 11)
-        np.testing.assert_allclose(prof(rho**2), prof_desc(rho), rtol=1e-6)
+        np.testing.assert_allclose(prof(rho**2), prof_desc(rho), atol=1e-12, rtol=1e-6)
 
     def test_from_desc(self):
         """from_desc maps rho-space knots to s-space and preserves values."""
@@ -305,7 +305,7 @@ class TestProfileSplineDesc(unittest.TestCase):
         # f(s) = 1 - s maps to 1 - rho^2 in rho-space (degree 2),
         # which a cubic spline represents exactly — making the roundtrip exact.
         s_knots = np.linspace(0, 1, 6)
-        f_values = 1.3252 - s_knots
+        f_values = 1.0 - s_knots
         prof_orig = ProfileSpline(s_knots, f_values, degree=3)
         prof_rt = ProfileSpline.from_desc(prof_orig.to_desc(), degree=3)
 
@@ -317,3 +317,12 @@ class TestProfileSplineDesc(unittest.TestCase):
         poly_prof = DescPowerSeriesProfile(params=np.array([1.0, -1.0]), sym=True)
         with self.assertRaises(TypeError):
             ProfileSpline.from_desc(poly_prof)
+
+    def test_to_desc_unsupported_degree(self):
+        """to_desc raises ValueError for degrees other than 1 and 3."""
+        s_knots = np.linspace(0, 1, 6)
+        f_values = 1.0 - s_knots
+        for degree in [2, 4, 5]:
+            prof = ProfileSpline(s_knots, f_values, degree=degree)
+            with self.assertRaises(ValueError):
+                prof.to_desc()

--- a/tests/mhd/test_profiles.py
+++ b/tests/mhd/test_profiles.py
@@ -265,6 +265,12 @@ class TestProfilePolynomialDesc(unittest.TestCase):
         s = np.linspace(0, 1, 20)
         np.testing.assert_allclose(prof_orig(s), prof_rt(s), rtol=1e-12)
 
+    def test_from_desc_wrong_type(self):
+        """from_desc raises TypeError when given a non-PowerSeriesProfile."""
+        spline_prof = DescSplineProfile(values=np.ones(5), knots=np.linspace(0, 1, 5))
+        with self.assertRaises(TypeError):
+            ProfilePolynomial.from_desc(spline_prof)
+
 
 @unittest.skipUnless(DescSplineProfile is not None, "DESC not installed")
 class TestProfileSplineDesc(unittest.TestCase):
@@ -305,3 +311,9 @@ class TestProfileSplineDesc(unittest.TestCase):
 
         s = np.linspace(0, 1, 20)
         np.testing.assert_allclose(prof_orig(s), prof_rt(s), atol=1e-12)
+
+    def test_from_desc_wrong_type(self):
+        """from_desc raises TypeError when given a non-SplineProfile."""
+        poly_prof = DescPowerSeriesProfile(params=np.array([1.0, -1.0]), sym=True)
+        with self.assertRaises(TypeError):
+            ProfileSpline.from_desc(poly_prof)

--- a/tests/mhd/test_profiles.py
+++ b/tests/mhd/test_profiles.py
@@ -286,6 +286,18 @@ class TestProfileSplineDesc(unittest.TestCase):
         rho = np.linspace(0, 1, 11)
         np.testing.assert_allclose(prof(rho**2), prof_desc(rho), atol=1e-12, rtol=1e-6)
 
+    def test_to_desc_degree1(self):
+        """to_desc with degree=1 uses linear interpolation and preserves values at knots."""
+        s_knots = np.linspace(0, 1, 6)
+        f_values = 1.0 - s_knots
+        prof = ProfileSpline(s_knots, f_values, degree=1)
+        prof_desc = prof.to_desc()
+
+        # f(s) = 1 - s is linear in s, so f(rho) = 1 - rho^2; a linear spline
+        # in rho matches only at knots, not between them.
+        rho_knots = np.sqrt(s_knots)
+        np.testing.assert_allclose(prof(rho_knots**2), prof_desc(rho_knots), atol=1e-12)
+
     def test_from_desc(self):
         """from_desc maps rho-space knots to s-space and preserves values."""
         # f(rho) = 1 - 1.5*rho^2 + 0.5*rho^4 uses even rho powers only,


### PR DESCRIPTION
**Summary**
This PR introduces new methods to convert `ProfilePolynomial` and `ProfileSpline` objects to and from the equivalent Desc formats, `PowerSeriesProfile` and `SplineProfile`. The methods are covered by unit tests.

**New Methods**
Two new methods have been added to the `ProfilePolynomial` and `ProfileSpline` classes:
- `to_desc`:  converts an instance to the Desc format,
- `from_desc`:  a _class method_ that builds an instance of the class from an existing Desc profile.

The `to_desc` and `from_desc` functions only allow conversion between the appropriate classes i.e. `ProfilePolynomial <--> PowerSeriesProfile` and `ProfileSpline <--> SplineProfile`
 