### PR TITLE
Added BoozXform Protocol and BoozerOutput

### DIFF
--- a/src/simsopt/field/boozermagneticfield.py
+++ b/src/simsopt/field/boozermagneticfield.py
@@ -351,20 +351,20 @@ class BoozerRadialInterpolant(BoozerMagneticField):
             # Determine if radial grid for Boozer needs to be updated
 
             # Grid not initialized
-            if len(self.booz.bx.s_in) == 0:
+            if self.booz._output is None or len(self.booz.output.s_in) == 0:
                 self.booz.register(self.booz.equil.s_half_grid)
             # Grid does not have correct size
-            elif (len(self.booz.bx.s_in) != len(self.booz.bx.s_b)):
+            elif (len(self.booz.output.s_in) != len(self.booz.output.s_b)):
                 self.booz.register(self.booz.equil.s_half_grid)
             # Grid does not match Vmec half grid
-            elif (np.any(self.booz.bx.s_in != self.booz.bx.s_b)):
+            elif (np.any(self.booz.output.s_in != self.booz.output.s_b)):
                 self.booz.register(self.booz.equil.s_half_grid)
 
             # Run booz_xform if needed
             if self.booz.need_to_run_code:
                 self.booz.run()
 
-        self.stellsym = not self.booz.bx.asym
+        self.stellsym = not self.booz.output.asym
         self.order = order
         self.enforce_qs = False
         self.enforce_vacuum = enforce_vacuum
@@ -450,48 +450,49 @@ class BoozerRadialInterpolant(BoozerMagneticField):
                 self.compute_K()
 
     def init_splines(self):
-        self.xm_b = self.booz.bx.xm_b
-        self.xn_b = self.booz.bx.xn_b
+        out = self.booz.output
+        self.xm_b = out.xm_b
+        self.xn_b = out.xn_b
 
         # Define quantities on extended half grid
-        iota = np.zeros((self.booz.bx.ns_b+2))
-        G = np.zeros((self.booz.bx.ns_b+2))
-        I = np.zeros((self.booz.bx.ns_b+2))
+        iota = np.zeros((out.ns_b+2))
+        G = np.zeros((out.ns_b+2))
+        I = np.zeros((out.ns_b+2))
 
-        self.s_half_ext = np.zeros((self.booz.bx.ns_b+2))
-        self.s_half_ext[1:-1] = self.booz.bx.s_in
+        self.s_half_ext = np.zeros((out.ns_b+2))
+        self.s_half_ext[1:-1] = out.s_in
         self.s_half_ext[-1] = 1
 
-        ds = self.booz.bx.s_in[1]-self.booz.bx.s_in[0]
+        ds = out.s_in[1]-out.s_in[0]
 
-        s_full = np.linspace(0, 1, self.booz.bx.ns_in+1)
+        s_full = np.linspace(0, 1, out.ns_in+1)
 
         psip = self.booz.equil.wout.chi/(2*np.pi)
-        iota[1:-1] = self.booz.bx.iota
-        G[1:-1] = self.booz.bx.Boozer_G
-        I[1:-1] = self.booz.bx.Boozer_I
+        iota[1:-1] = out.iota
+        G[1:-1] = out.Boozer_G
+        I[1:-1] = out.Boozer_I
         if self.rescale:
-            s_half_mn = self.booz.bx.s_in[self.ns_delete::]
-            bmnc = np.zeros((len(self.xm_b), self.booz.bx.ns_in-self.ns_delete))
-            rmnc = np.zeros((len(self.xm_b), self.booz.bx.ns_in-self.ns_delete))
-            zmns = np.zeros((len(self.xm_b), self.booz.bx.ns_in-self.ns_delete))
-            numns = np.zeros((len(self.xm_b), self.booz.bx.ns_in-self.ns_delete))
+            s_half_mn = out.s_in[self.ns_delete::]
+            bmnc = np.zeros((len(self.xm_b), out.ns_in-self.ns_delete))
+            rmnc = np.zeros((len(self.xm_b), out.ns_in-self.ns_delete))
+            zmns = np.zeros((len(self.xm_b), out.ns_in-self.ns_delete))
+            numns = np.zeros((len(self.xm_b), out.ns_in-self.ns_delete))
 
-            bmnc = self.booz.bx.bmnc_b[:, self.ns_delete::]
-            rmnc = self.booz.bx.rmnc_b[:, self.ns_delete::]
-            zmns = self.booz.bx.zmns_b[:, self.ns_delete::]
-            numns = self.booz.bx.numns_b[:, self.ns_delete::]
+            bmnc = out.bmnc_b[:, self.ns_delete::]
+            rmnc = out.rmnc_b[:, self.ns_delete::]
+            zmns = out.zmns_b[:, self.ns_delete::]
+            numns = out.numns_b[:, self.ns_delete::]
 
             if not self.stellsym:
-                bmns = np.zeros((len(self.xm_b), self.booz.bx.ns_in-self.ns_delete))
-                rmns = np.zeros((len(self.xm_b), self.booz.bx.ns_in-self.ns_delete))
-                zmnc = np.zeros((len(self.xm_b), self.booz.bx.ns_in-self.ns_delete))
-                numnc = np.zeros((len(self.xm_b), self.booz.bx.ns_in-self.ns_delete))
+                bmns = np.zeros((len(self.xm_b), out.ns_in-self.ns_delete))
+                rmns = np.zeros((len(self.xm_b), out.ns_in-self.ns_delete))
+                zmnc = np.zeros((len(self.xm_b), out.ns_in-self.ns_delete))
+                numnc = np.zeros((len(self.xm_b), out.ns_in-self.ns_delete))
 
-                bmns = self.booz.bx.bmns_b[:, self.ns_delete::]
-                rmns = self.booz.bx.rmns_b[:, self.ns_delete::]
-                zmnc = self.booz.bx.zmnc_b[:, self.ns_delete::]
-                numnc = self.booz.bx.numnc_b[:, self.ns_delete::]
+                bmns = out.bmns_b[:, self.ns_delete::]
+                rmns = out.rmns_b[:, self.ns_delete::]
+                zmnc = out.zmnc_b[:, self.ns_delete::]
+                numnc = out.numnc_b[:, self.ns_delete::]
 
             mn_factor = np.ones_like(bmnc)
             d_mn_factor = np.zeros_like(bmnc)
@@ -503,24 +504,24 @@ class BoozerRadialInterpolant(BoozerMagneticField):
             d_mn_factor[(self.xm_b % 2 == 0)*(self.xm_b > 1), :] = -s_half_mn[None, :]**(-2.)
         else:
             s_half_mn = self.s_half_ext
-            bmnc = np.zeros((len(self.xm_b), self.booz.bx.ns_in+2))
-            bmnc[:, 1:-1] = self.booz.bx.bmnc_b
+            bmnc = np.zeros((len(self.xm_b), out.ns_in+2))
+            bmnc[:, 1:-1] = out.bmnc_b
             bmnc[:, 0] = 1.5*bmnc[:, 1] - 0.5*bmnc[:, 2]
             bmnc[:, -1] = 1.5*bmnc[:, -2] - 0.5*bmnc[:, -3]
             dbmncds = (bmnc[:, 2:-1] - bmnc[:, 1:-2])/ds
             mn_factor = np.ones_like(bmnc)
             d_mn_factor = np.zeros_like(bmnc)
 
-            numns = np.zeros((len(self.xm_b), self.booz.bx.ns_in+2))
-            rmnc = np.zeros((len(self.xm_b), self.booz.bx.ns_in+2))
-            zmns = np.zeros((len(self.xm_b), self.booz.bx.ns_in+2))
-            numns[:, 1:-1] = self.booz.bx.numns_b
+            numns = np.zeros((len(self.xm_b), out.ns_in+2))
+            rmnc = np.zeros((len(self.xm_b), out.ns_in+2))
+            zmns = np.zeros((len(self.xm_b), out.ns_in+2))
+            numns[:, 1:-1] = out.numns_b
             numns[:, 0] = 1.5*numns[:, 1] - 0.5*numns[:, 2]
             numns[:, -1] = 1.5*numns[:, -2] - 0.5*numns[:, -3]
-            rmnc[:, 1:-1] = self.booz.bx.rmnc_b
+            rmnc[:, 1:-1] = out.rmnc_b
             rmnc[:, 0] = 1.5*rmnc[:, 1] - 0.5*rmnc[:, 2]
             rmnc[:, -1] = 1.5*rmnc[:, -2] - 0.5*rmnc[:, -3]
-            zmns[:, 1:-1] = self.booz.bx.zmns_b
+            zmns[:, 1:-1] = out.zmns_b
             zmns[:, 0] = 1.5*zmns[:, 1] - 0.5*zmns[:, 2]
             zmns[:, -1] = 1.5*zmns[:, -2] - 0.5*zmns[:, -3]
 
@@ -529,22 +530,22 @@ class BoozerRadialInterpolant(BoozerMagneticField):
             dnumnsds = (numns[:, 2:-1] - numns[:, 1:-2])/ds
 
             if not self.stellsym:
-                bmns = np.zeros((len(self.xm_b), self.booz.bx.ns_in+2))
-                bmns[:, 1:-1] = self.booz.bx.bmns_b
+                bmns = np.zeros((len(self.xm_b), out.ns_in+2))
+                bmns[:, 1:-1] = out.bmns_b
                 bmns[:, 0] = 1.5*bmns[:, 1] - 0.5*bmns[:, 2]
                 bmns[:, -1] = 1.5*bmns[:, -2] - 0.5*bmns[:, -3]
                 dbmnsds = (bmns[:, 2:-1] - bmns[:, 1:-2])/ds
 
-                numnc = np.zeros((len(self.xm_b), self.booz.bx.ns_in+2))
-                rmns = np.zeros((len(self.xm_b), self.booz.bx.ns_in+2))
-                zmnc = np.zeros((len(self.xm_b), self.booz.bx.ns_in+2))
-                numnc[:, 1:-1] = self.booz.bx.numnc_b
+                numnc = np.zeros((len(self.xm_b), out.ns_in+2))
+                rmns = np.zeros((len(self.xm_b), out.ns_in+2))
+                zmnc = np.zeros((len(self.xm_b), out.ns_in+2))
+                numnc[:, 1:-1] = out.numnc_b
                 numnc[:, 0] = 1.5*numnc[:, 1] - 0.5*numnc[:, 2]
                 numnc[:, -1] = 1.5*numnc[:, -2] - 0.5*numnc[:, -3]
-                rmns[:, 1:-1] = self.booz.bx.rmns_b
+                rmns[:, 1:-1] = out.rmns_b
                 rmns[:, 0] = 1.5*rmns[:, 1] - 0.5*rmns[:, 2]
                 rmns[:, -1] = 1.5*rmns[:, -2] - 0.5*rmns[:, -3]
-                zmnc[:, 1:-1] = self.booz.bx.zmnc_b
+                zmnc[:, 1:-1] = out.zmnc_b
                 zmnc[:, 0] = 1.5*zmnc[:, 1] - 0.5*zmnc[:, 2]
                 zmnc[:, -1] = 1.5*zmnc[:, -2] - 0.5*zmnc[:, -3]
 
@@ -646,11 +647,11 @@ class BoozerRadialInterpolant(BoozerMagneticField):
                     self.dzmncds_splines.append(InterpolatedUnivariateSpline(s_full[1:-1], dzmncds[im, :], k=self.order))
 
     def compute_K(self):
-        ntheta = 2 * (2 * self.booz.bx.mboz + 1)
-        nzeta = 2 * (2 * self.booz.bx.nboz + 1)
+        ntheta = 2 * (2 * self.booz.output.mboz + 1)
+        nzeta = 2 * (2 * self.booz.output.nboz + 1)
         thetas = np.linspace(0, 2*np.pi, ntheta, endpoint=False)
         dtheta = thetas[1]-thetas[0]
-        zetas = np.linspace(0, 2*np.pi/self.booz.bx.nfp, nzeta, endpoint=False)
+        zetas = np.linspace(0, 2*np.pi/self.booz.output.nfp, nzeta, endpoint=False)
         dzeta = zetas[1]-zetas[0]
         thetas, zetas = np.meshgrid(thetas, zetas)
         thetas = thetas.flatten()
@@ -702,12 +703,12 @@ class BoozerRadialInterpolant(BoozerMagneticField):
                                                iota_half, G_half, I_half, self.xm_b, self.xn_b, thetas, zetas)
             kmnc = kmnc_kmns[0, :, :]
             kmns = kmnc_kmns[1, :, :]
-            kmnc = kmnc*dtheta*dzeta*self.booz.bx.nfp/self.psi0
+            kmnc = kmnc*dtheta*dzeta*self.booz.output.nfp/self.psi0
         else:
             kmns = sopp.compute_kmns(rmnc_half, drmncds_half, zmns_half, dzmnsds_half,
                                      numns_half, dnumnsds_half, bmnc_half, iota_half, G_half, I_half,
                                      self.xm_b, self.xn_b, thetas, zetas)
-        kmns = kmns*dtheta*dzeta*self.booz.bx.nfp/self.psi0
+        kmns = kmns*dtheta*dzeta*self.booz.output.nfp/self.psi0
 
         self.kmns_splines = []
         if not self.stellsym:

--- a/src/simsopt/mhd/bootstrap.py
+++ b/src/simsopt/mhd/bootstrap.py
@@ -558,7 +558,7 @@ class RedlGeomBoozer(Optimizable):
         self.vmec = vmec
         nfp = vmec.wout.nfp
         psi_edge = -vmec.wout.phi[-1] / (2 * np.pi)
-        logger.info(f'Surfaces from booz_xform: {self.booz.bx.s_b}  '
+        logger.info(f'Surfaces from booz_xform: {self.booz.output.s_b}  '
                     f'Surfaces for RedlGeomBoozer: {surfaces}')
 
         # First, interpolate in s to get the quantities we need on the surfaces we need.
@@ -574,11 +574,11 @@ class RedlGeomBoozer(Optimizable):
         I = interp(surfaces)
 
         if self.vmec.mpi.proc0_groups:
-            interp = interp1d(self.booz.bx.s_b, self.booz.bx.bmnc_b, fill_value="extrapolate")
+            interp = interp1d(self.booz.output.s_b, self.booz.output.bmnc_b, fill_value="extrapolate")
             bmnc_b = interp(surfaces)
-            logger.info(f'Original bmnc_b.shape: {self.booz.bx.bmnc_b.shape}  Interpolated bmnc_b.shape: {bmnc_b.shape}')
+            logger.info(f'Original bmnc_b.shape: {self.booz.output.bmnc_b.shape}  Interpolated bmnc_b.shape: {bmnc_b.shape}')
 
-            interp = interp1d(self.booz.bx.s_b, self.booz.bx.gmnc_b, fill_value="extrapolate")
+            interp = interp1d(self.booz.output.s_b, self.booz.output.gmnc_b, fill_value="extrapolate")
             gmnc_b = interp(surfaces)
 
             # Evaluate modB and sqrtg on a uniform grid in theta,
@@ -586,12 +586,12 @@ class RedlGeomBoozer(Optimizable):
             modB = np.zeros((ntheta, ns))
             sqrtg = np.zeros((ntheta, ns))
             s, theta = np.meshgrid(surfaces, theta1d)
-            for jmn in range(booz.bx.mnboz):
-                if booz.bx.xm_b[jmn] * self.helicity_n * nfp == booz.bx.xn_b[jmn]:
+            for jmn in range(booz.output.mnboz):
+                if booz.output.xm_b[jmn] * self.helicity_n * nfp == booz.output.xn_b[jmn]:
                     # modB += cos(m * theta) * bmnc:
-                    modB += np.cos(booz.bx.xm_b[jmn] * theta) \
+                    modB += np.cos(booz.output.xm_b[jmn] * theta) \
                         * np.kron(np.ones((ntheta, 1)), bmnc_b[jmn, None, :])
-                    sqrtg += np.cos(booz.bx.xm_b[jmn] * theta) \
+                    sqrtg += np.cos(booz.output.xm_b[jmn] * theta) \
                         * np.kron(np.ones((ntheta, 1)), gmnc_b[jmn, None, :])
         else:
             modB = 0

--- a/src/simsopt/mhd/boozer.py
+++ b/src/simsopt/mhd/boozer.py
@@ -8,7 +8,8 @@ Boozer coordinates, and an optimization target for quasisymmetry.
 """
 
 import logging
-from typing import Union, Iterable
+from dataclasses import dataclass
+from typing import Union, Iterable, Protocol, runtime_checkable, Any, Optional
 
 import numpy as np
 
@@ -31,7 +32,116 @@ from .._core.optimizable import Optimizable
 from .._core.types import RealArray
 from .._core.descriptor import Integer
 
-__all__ = ['Boozer', 'Quasisymmetry']
+__all__ = ['Boozer', 'BoozerOutput', 'BoozXFormProtocol', 'Quasisymmetry']
+
+@runtime_checkable
+class BoozXFormProtocol(Protocol):
+    """Structural interface for ``Booz_xform``-like objects.
+
+    Covers only the *input* side: attributes that :meth:`Boozer.run` sets on the
+    object before calling ``run()``, plus the two methods it calls.  Output
+    quantities produced by ``run()`` are captured in :class:`BoozerOutput` and do
+    not belong here.
+
+    Running,
+        ```
+        from booz_xform import Booz_xform
+        bx = Booz_xform()
+        isinstance(bx, BoozXFormProtocol)
+        ```
+    will verify the object has the minimum structure required by ``Boozer``.
+    """
+
+    # --- Input attributes (set by Boozer.run() before calling bx.run()) ---
+    verbose: bool
+    asym: bool
+    nfp: int
+    mpol: int
+    ntor: int
+    mnmax: int
+    xm: Any  # 1-D integer array of poloidal mode numbers
+    xn: Any  # 1-D integer array of toroidal mode numbers
+    mpol_nyq: int
+    ntor_nyq: int
+    mnmax_nyq: int
+    xm_nyq: Any  # 1-D integer array of Nyquist poloidal mode numbers
+    xn_nyq: Any  # 1-D integer array of Nyquist toroidal mode numbers
+    compute_surfs: Any  # half-grid surface indices to transform
+    mboz: int  # number of poloidal Boozer modes requested
+    nboz: int  # number of toroidal Boozer modes requested
+
+    def init_from_vmec(self,
+                       ns: int,
+                       iotas: Any,
+                       rmnc: Any,
+                       rmns: Any,
+                       zmnc: Any,
+                       zmns: Any,
+                       lmnc: Any,
+                       lmns: Any,
+                       bmnc: Any,
+                       bmns: Any,
+                       bsubumnc: Any,
+                       bsubumns: Any,
+                       bsubvmnc: Any,
+                       bsubvmns: Any) -> None:
+        """Load VMEC equilibrium data into the Booz_xform object."""
+        ...
+
+    def run(self) -> None:
+        """Execute the Boozer coordinate transformation on ``compute_surfs``."""
+        ...
+
+
+@dataclass
+class BoozerOutput:
+    """All output quantities produced by a ``Booz_xform`` run.
+
+    Populated by :meth:`Boozer.run` and stored as ``Boozer.output``.
+    Other simsopt classes should read Boozer results from here rather than
+    accessing ``Boozer.bx`` directly.
+
+    Array fields are typed ``Any`` and accept ``np.ndarray``, ``jax.Array``, or
+    any other array-like type.
+    """
+
+    # --- Scalar metadata ---
+    nfp: int
+    asym: bool
+    mboz: int
+    nboz: int
+    ns_in: int
+    ns_b: int
+    mnboz: int
+
+    # --- Surface grids ---
+    s_in: Any
+    s_b: Any
+
+    # --- Physics profiles ---
+    iota: Any
+    Boozer_G: Any     # G on the ns_b output surfaces
+    Boozer_I: Any     # I on the ns_b output surfaces
+    Boozer_G_all: Any # G on all ns_in input surfaces
+    Boozer_I_all: Any # I on all ns_in input surfaces
+
+    # --- Boozer mode numbers ---
+    xm_b: Any
+    xn_b: Any
+
+    # --- Fourier coefficients (stellarator-symmetric) ---
+    bmnc_b: Any
+    rmnc_b: Any
+    zmns_b: Any
+    numns_b: Any
+    gmnc_b: Any
+
+    # --- Fourier coefficients (asymmetric; 0x0 arrays when asym=False) ---
+    bmns_b: Any
+    rmns_b: Any
+    zmnc_b: Any
+    numnc_b: Any
+    gmns_b: Any
 
 
 class Boozer(Optimizable):
@@ -57,6 +167,41 @@ class Boozer(Optimizable):
     mpol = Integer()
     ntor = Integer()
 
+    @property
+    def bx(self) -> BoozXFormProtocol:
+        """The underlying ``Booz_xform`` object used to perform the coordinate transformation.
+
+        This is the raw ``booz_xform.Booz_xform`` instance. For reading transformation
+        results, prefer :attr:`output`, which exposes all output quantities in a
+        structured :class:`BoozerOutput` object after :meth:`run` has been called.
+        """
+        return self._bx
+
+    @bx.setter
+    def bx(self, value: BoozXFormProtocol) -> None:
+        if not isinstance(value, BoozXFormProtocol):
+            raise TypeError(
+                f"bx must implement BoozXFormProtocol, got {type(value)}")
+        self._bx = value
+
+    @property
+    def output(self) -> 'BoozerOutput':
+        """The results of the most recent Boozer coordinate transformation.
+
+        Returns a :class:`BoozerOutput` containing all output quantities (Fourier
+        coefficients, rotational transform, surface grids, etc.) produced by the
+        last call to :meth:`run`. Raises ``RuntimeError`` if :meth:`run` has not
+        yet been called.
+        """
+        if self._output is None:
+            raise RuntimeError(
+                "Boozer.run() has not been called yet. Call run() before accessing output.")
+        return self._output
+
+    @output.setter
+    def output(self, value: Optional['BoozerOutput']) -> None:
+        self._output = value
+
     def __init__(self,
                  equil: Vmec,
                  mpol: int = 32,
@@ -74,6 +219,7 @@ class Boozer(Optimizable):
         self.bx = booz_xform.Booz_xform()
         self.bx.verbose = verbose
         self.s = set()
+        self._output: Optional[BoozerOutput] = None
         self.need_to_run_code = True
         self._calls = 0  # For testing, keep track of how many times we call bx.run()
 
@@ -112,8 +258,7 @@ class Boozer(Optimizable):
 
         for new_s in ss:
             if new_s < 0 or new_s > 1:
-                raise ValueError("Normalized toroidal flux values s must lie"
-                                 "in the interval [0, 1]")
+                raise ValueError("Normalized toroidal flux values s must lie in the interval [0, 1]")
         logger.info("Adding entries to Boozer registry: {}".format(ss))
         self.s = self.s.union(ss)
         self.need_to_run_code = True
@@ -247,6 +392,34 @@ class Boozer(Optimizable):
         self.bx.run()
         self._calls += 1
         logger.info("Returned from calling booz_xform.Booz_xform.run().")
+        self.output = BoozerOutput(
+            nfp=self.bx.nfp,
+            asym=self.bx.asym,
+            mboz=self.bx.mboz,
+            nboz=self.bx.nboz,
+            ns_in=self.bx.ns_in,
+            ns_b=self.bx.ns_b,
+            mnboz=self.bx.mnboz,
+            s_in=self.bx.s_in,
+            s_b=self.bx.s_b,
+            iota=self.bx.iota,
+            Boozer_G=self.bx.Boozer_G,
+            Boozer_I=self.bx.Boozer_I,
+            Boozer_G_all=self.bx.Boozer_G_all,
+            Boozer_I_all=self.bx.Boozer_I_all,
+            xm_b=self.bx.xm_b,
+            xn_b=self.bx.xn_b,
+            bmnc_b=self.bx.bmnc_b,
+            rmnc_b=self.bx.rmnc_b,
+            zmns_b=self.bx.zmns_b,
+            numns_b=self.bx.numns_b,
+            gmnc_b=self.bx.gmnc_b,
+            bmns_b=self.bx.bmns_b,
+            rmns_b=self.bx.rmns_b,
+            zmnc_b=self.bx.zmnc_b,
+            numnc_b=self.bx.numnc_b,
+            gmns_b=self.bx.gmns_b,
+        )
         self.need_to_run_code = False
 
 
@@ -346,9 +519,9 @@ class Quasisymmetry(Optimizable):
         symmetry_error = []
         for s in self.s:
             index = self.boozer.s_to_index[s]
-            bmnc = self.boozer.bx.bmnc_b[:, index]
-            xm = self.boozer.bx.xm_b
-            xn = self.boozer.bx.xn_b / self.boozer.bx.nfp
+            bmnc = self.boozer.output.bmnc_b[:, index]
+            xm = self.boozer.output.xm_b
+            xn = self.boozer.output.xn_b / self.boozer.output.nfp
 
             if self.helicity_m != 0 and self.helicity_m != 1:
                 raise ValueError("m for quasisymmetry should be 0 or 1.")

--- a/tests/mhd/test_boozer.py
+++ b/tests/mhd/test_boozer.py
@@ -301,6 +301,11 @@ class QuasisymmetryTests(unittest.TestCase):
         # Register two surfaces, with a copy:
         Quasisymmetry(b1, {0.2, 0.3}, 1, 0)
         self.assertEqual(b1.s, {0.1, 0.2, 0.3, 0.5, 0.75})
+        # Registering s outside [0, 1] should raise ValueError:
+        with self.assertRaises(ValueError):
+            b1.register(-0.1)
+        with self.assertRaises(ValueError):
+            b1.register(1.1)
 
     @unittest.skipIf((booz_xform is None) or (vmec is None),
                      "vmec or booz_xform python package not found")

--- a/tests/mhd/test_boozer.py
+++ b/tests/mhd/test_boozer.py
@@ -21,9 +21,10 @@ except ImportError:
     MPI = None
 
 from simsopt._core.optimizable import Optimizable
+from simsopt.mhd.boozer import BoozerOutput, BoozXFormProtocol
 if MPI is not None:
-    from simsopt.mhd.boozer import Boozer, Quasisymmetry  # , booz_xform_found
-    from simsopt.mhd.vmec import Vmec  # , vmec_found
+    from simsopt.mhd.boozer import Boozer, Quasisymmetry
+    from simsopt.mhd.vmec import Vmec
 from . import TEST_DIR
 
 logger = logging.getLogger(__name__)
@@ -54,8 +55,6 @@ class MockBoozXform():
         arr2 = arr1 + 1
         arr2[0] = 100
         self.bmnc_b = np.stack((arr1, arr2)).transpose()
-        print('bmnc_b:')
-        print(self.bmnc_b)
         # print('booz_xform_found:', booz_xform_found)
 
 
@@ -67,7 +66,37 @@ class MockBoozer(Optimizable):
     """
 
     def __init__(self, mpol, ntor, nfp):
-        self.bx = MockBoozXform(mpol, ntor, nfp)
+        mock = MockBoozXform(mpol, ntor, nfp)
+        zeros = np.zeros_like(mock.bmnc_b)
+        empty = np.array([[]])
+        self.output = BoozerOutput(
+            nfp=nfp,
+            asym=False,
+            mboz=mpol,
+            nboz=ntor,
+            ns_in=2,
+            ns_b=2,
+            mnboz=len(mock.xm_b),
+            s_in=np.array([0.0, 1.0]),
+            s_b=np.array([0.0, 1.0]),
+            iota=np.zeros(2),
+            Boozer_G=np.zeros(2),
+            Boozer_I=np.zeros(2),
+            Boozer_G_all=np.zeros(2),
+            Boozer_I_all=np.zeros(2),
+            xm_b=mock.xm_b,
+            xn_b=mock.xn_b,
+            bmnc_b=mock.bmnc_b,
+            rmnc_b=zeros,
+            zmns_b=zeros,
+            numns_b=zeros,
+            gmnc_b=zeros,
+            bmns_b=empty,
+            rmns_b=empty,
+            zmnc_b=empty,
+            numnc_b=empty,
+            gmns_b=empty,
+        )
         self.s_to_index = {0: 0, 1: 1}
         self.mpi = None
         super().__init__()
@@ -77,6 +106,143 @@ class MockBoozer(Optimizable):
 
     def run(self):
         pass
+
+
+class MinimalBoozXform:
+    """Minimal object that satisfies BoozXFormProtocol for testing purposes."""
+    verbose = False
+    asym = False
+    nfp = 1
+    mpol = 1
+    ntor = 1
+    mnmax = 1
+    xm = np.array([0])
+    xn = np.array([0])
+    mpol_nyq = 1
+    ntor_nyq = 1
+    mnmax_nyq = 1
+    xm_nyq = np.array([0])
+    xn_nyq = np.array([0])
+    compute_surfs = []
+    mboz = 1
+    nboz = 1
+
+    def init_from_vmec(self, *_): pass
+    def run(self): pass
+
+
+class BoozXFormProtocolTests(unittest.TestCase):
+    def test_minimal_object_satisfies_protocol(self):
+        """An object with all required attributes and methods satisfies the protocol."""
+        self.assertIsInstance(MinimalBoozXform(), BoozXFormProtocol)
+
+    def test_missing_attribute_fails_protocol(self):
+        """An object missing a required attribute does not satisfy the protocol."""
+        attrs = {k: v for k, v in vars(MinimalBoozXform).items() if k != 'nfp'}
+        MissingNfp = type('MissingNfp', (), attrs)
+        self.assertNotIsInstance(MissingNfp(), BoozXFormProtocol)
+
+    def test_missing_method_fails_protocol(self):
+        """An object missing a required method does not satisfy the protocol."""
+        attrs = {k: v for k, v in vars(MinimalBoozXform).items() if k != 'run'}
+        MissingRun = type('MissingRun', (), attrs)
+        self.assertNotIsInstance(MissingRun(), BoozXFormProtocol)
+
+    def test_plain_object_fails_protocol(self):
+        """A plain object() does not satisfy the protocol."""
+        self.assertNotIsInstance(object(), BoozXFormProtocol)
+
+    @unittest.skipIf(booz_xform is None, "booz_xform python package not found")
+    def test_real_booz_xform_satisfies_protocol(self):
+        """A real Booz_xform instance satisfies the protocol."""
+        self.assertIsInstance(booz_xform.Booz_xform(), BoozXFormProtocol)
+
+
+class BoozerOutputTests(unittest.TestCase):
+    def _make_output(self, asym=False):
+        mnboz = 3
+        ns_b = 2
+        shape = (mnboz, ns_b)
+        empty = np.array([[]])
+        return BoozerOutput(
+            nfp=4,
+            asym=asym,
+            mboz=8,
+            nboz=8,
+            ns_in=ns_b,
+            ns_b=ns_b,
+            mnboz=mnboz,
+            s_in=np.array([0.25, 0.75]),
+            s_b=np.array([0.25, 0.75]),
+            iota=np.array([0.4, 0.5]),
+            Boozer_G=np.ones(ns_b),
+            Boozer_I=np.zeros(ns_b),
+            Boozer_G_all=np.ones(ns_b),
+            Boozer_I_all=np.zeros(ns_b),
+            xm_b=np.array([0, 1, 1]),
+            xn_b=np.array([0, 0, 4]),
+            bmnc_b=np.ones(shape),
+            rmnc_b=np.ones(shape),
+            zmns_b=np.ones(shape),
+            numns_b=np.zeros(shape),
+            gmnc_b=np.ones(shape),
+            bmns_b=np.ones(shape) if asym else empty,
+            rmns_b=np.ones(shape) if asym else empty,
+            zmnc_b=np.ones(shape) if asym else empty,
+            numnc_b=np.zeros(shape) if asym else empty,
+            gmns_b=np.ones(shape) if asym else empty,
+        )
+
+    def test_construction_stellsym(self):
+        """BoozerOutput stores all scalar and array fields correctly for a symmetric config."""
+        out = self._make_output(asym=False)
+        self.assertEqual(out.nfp, 4)
+        self.assertFalse(out.asym)
+        self.assertEqual(out.ns_b, 2)
+        self.assertEqual(out.mnboz, 3)
+        np.testing.assert_array_equal(out.xm_b, [0, 1, 1])
+        np.testing.assert_array_equal(out.xn_b, [0, 0, 4])
+        self.assertEqual(out.bmnc_b.shape, (3, 2))
+
+    def test_construction_non_stellsym(self):
+        """BoozerOutput stores asymmetric Fourier coefficient arrays for a non-symmetric config."""
+        out = self._make_output(asym=True)
+        self.assertTrue(out.asym)
+        self.assertEqual(out.bmns_b.shape, (3, 2))
+        self.assertEqual(out.gmns_b.shape, (3, 2))
+
+    def test_asymmetric_fields_empty_when_stellsym(self):
+        """Asymmetric Fourier fields are empty arrays for a stellarator-symmetric config."""
+        out = self._make_output(asym=False)
+        self.assertEqual(out.bmns_b.size, 0)
+        self.assertEqual(out.gmns_b.size, 0)
+
+
+@unittest.skipIf(booz_xform is None, "booz_xform python package not found")
+class BoozerBxPropertyTests(unittest.TestCase):
+    def test_bx_setter_accepts_protocol_compatible_object(self):
+        """Setting bx to an object satisfying BoozXFormProtocol does not raise."""
+        b = Boozer(None)
+        b.bx = MinimalBoozXform()
+
+    def test_bx_setter_rejects_incompatible_object(self):
+        """Setting bx to an object that does not satisfy BoozXFormProtocol raises TypeError."""
+        b = Boozer(None)
+        with self.assertRaises(TypeError):
+            b.bx = object()
+
+    def test_bx_getter_returns_assigned_value(self):
+        """The bx getter returns the exact object that was assigned."""
+        b = Boozer(None)
+        m = MinimalBoozXform()
+        b.bx = m
+        self.assertIs(b.bx, m)
+
+    def test_output_raises_before_run(self):
+        """Accessing output before run() raises RuntimeError."""
+        b = Boozer(None)
+        with self.assertRaises(RuntimeError):
+            _ = b.output
 
 
 @unittest.skipIf(MPI is None, "mpi4py python package is not found")
@@ -169,7 +335,7 @@ class QuasisymmetryTests(unittest.TestCase):
             self.assertEqual(b._calls, 2)
             self.assertEqual(len(residuals1), 0)
             # All the modes except m=0 should contribute to the qs2 residuals:
-            bmnc = b.bx.bmnc_b
+            bmnc = b.output.bmnc_b
             np.testing.assert_allclose(bmnc[1:, 1] / bmnc[0, 1], residuals2)
 
             # Register a QH target on the same pair of surfaces:
@@ -211,7 +377,7 @@ class QuasisymmetryTests(unittest.TestCase):
         Quasisymmetry(b, [0.0, 1.0], 1, 0).J()
         np.testing.assert_allclose(b.bx.compute_surfs, [0, 14])
         self.assertEqual(b.s_to_index, {0.0: 0, 1.0: 1})
-        bmnc = b.bx.bmnc_b
+        bmnc = b.output.bmnc_b
 
         # Compare to a reference boozmn*.nc file created by standalone
         # booz_xform:


### PR DESCRIPTION
**Summary**
This PR introduces a BoozXform Protocol to simplify connecting Simsopt to multiple booz_xform modules (booz_xform, booz_xform-jax). This PR also introduces the `BoozerOutput` object which captures the output of the booz_xform. Simsopt classes should access the `BoozerOutput` class rather than the `Boozer.bx` object.

**New Classes**
Two new public classes are introduced in `simsopt.mhd.boozer`:

- `BoozXFormProtocol`: a `@runtime_checkable` Protocol describing the structural interface required of any Booz_xform-like object. Enables duck-typed alternatives to be validated with `isinstance`.
- `BoozerOutput`: a `@dataclass` collecting all output quantities produced by a booz_xform run (Fourier coefficients, rotational transform, surface grids, etc.). 

**Changes to Boozer**
- `bx` is now a validated property: the setter checks `isinstance(value, BoozXFormProtocol)` and raises `TypeError` on incompatible objects.
- `output` is a new property. It raises `RuntimeError` if accessed before `run()` has been called. `run()` populates it with a `BoozerOutput` at the end of each transformation.

**Downstream updates**
`Quasisymmetry.J()`, `boozermagneticfield.py`, and `bootstrap.py` are updated to read results from `boozer.output` instead of `boozer.bx` directly.

**Tests**
Unit tests are added for `BoozXFormProtocol` (protocol satisfaction and rejection), `BoozerOutput` (construction for symmetric and asymmetric configs), and the bx / output properties.