### PR TITLE
pyproject edits, fixing example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ pip-wheel-metadata/
 .coverage
 .tox
 *fort.9
+
+# uv related
+.venv/
+uv.lock
 	
 # f90wrap related
 src.*/

--- a/examples/1_Simple/logger_example.py
+++ b/examples/1_Simple/logger_example.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 
 import logging
-from simsopt.util.log import initialize_logging
+from simsopt.util.logger import initialize_logging
 
 """
 Example file for transparently logging both MPI and serial jobs
 """
 
 # Serial logging
-initialize_logging(filename='serial.log')
+initialize_logging(filename='examples/serial.log')
 print("Running 1_Simple/logger_example.py")
 print("==================================")
 for i in range(2):

--- a/examples/1_Simple/tracing_fieldlines_NCSX.py
+++ b/examples/1_Simple/tracing_fieldlines_NCSX.py
@@ -4,7 +4,7 @@
 This example demonstrates how to use SIMSOPT to compute Poincare plots.
 
 This script uses the NCSX coil shapes available in
-``simsopt.util.zoo.get_data("ncsx")``. For an example in which coils
+``simsopt.configs.zoo.get_data("ncsx")``. For an example in which coils
 optimized from a simsopt stage-2 optimization are used, see the
 example tracing_fieldlines_QA.py.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description="Framework for optimizing stellarators"
 readme = "README.md"
 # long_description = file: README.md
 # long_description_content_type = text/markdown
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
   {name = "Matt Landreman", email = "mattland@umd.edu"},
   {name = "Bharat Medasani", email = "mbkumar@gmail.com"},
@@ -67,7 +67,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-SPEC = ["py_spec>=3.0.1", "pyoculus>=0.1.1", "h5py>=3.1.0"]
+SPEC = ["py_spec>=3.0.1", "pyoculus==0.3.3", "h5py>=3.1.0"]
 MPI = ["mpi4py>=3.0.3"]
 VIS = ["vtk >= 8.1.2", "PyQt5", "plotly", "networkx"]
 DOCS = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-napoleon", "sphinx-autodoc-napoleon-typehints", "breathe"]


### PR DESCRIPTION
- Edited pyproject.toml to have fixed pyoculus source where distutils is deprecated, updated required python version to allow project to build with this pyoculus version
- Added uv fields to be git-ignored
- Fixed example docstring and imports

I fixed the pyoculus version to commit [d71914e](https://github.com/pyoculus/pyoculus/commit/d71914eb20a5e9b3ab5059fefeaa3199c69001f6) for now, I wanted to pin it to a release tag on that repo but the latest one still depended on distutils. If another release is made on pyoculus then it would be wise to pin it to that version. Python 3.9 was also the oldest version I could find which allowed building with this new pyoculus requirement, hopefully this is not too big of an issue to upgrade the python requirement.