### PR TITLE
Use conda-build command in workflow

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -51,20 +51,20 @@ jobs:
         if: github.event_name == 'release' && github.event.action == 'published'
         run: |
           conda config --set anaconda_upload yes
-          conda build --token ${{ secrets.ANACONDA_TOKEN }} conda.recipe
+          conda-build --token ${{ secrets.ANACONDA_TOKEN }} conda.recipe
 
       - name: Build and upload to test
         if: github.event_name == 'push' && github.ref == 'refs/heads/mbk/conda_package'
         run: |
           conda config --set anaconda_upload yes
-          conda build --token ${{ secrets.MBK_ANACONDA_TOKEN }} conda.recipe
+          conda-build --token ${{ secrets.MBK_ANACONDA_TOKEN }} conda.recipe
 
       - name: Build 
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
-          conda build --no-test conda.recipe
+          conda-build --no-test conda.recipe
 
       - name: Build on PR
         if: github.event_name == 'pull_request'
         run: |
-          conda build --no-test conda.recipe
+          conda-build --no-test conda.recipe


### PR DESCRIPTION
## Summary

This PR fixes the Conda workflow after the current runner stopped exposing `conda build` as a subcommand.

Changes:
- call the `conda-build` executable installed by the prepare step
- keep the existing upload tokens and `--no-test` build mode

## Verification

### Test fails on main
```bash
$ gh run view 26345424899 --log-failed
...
conda: error: argument COMMAND: invalid choice: 'build'
```

### Test passes after fix
```bash
$ micromamba create -y -p /tmp/simsopt-conda-build-check -c conda-forge python=3.12 conda-build
$ micromamba run -p /tmp/simsopt-conda-build-check conda-build --help
usage: conda build [-h] ... [--token TOKEN] ... [--no-test] ... RECIPE_PATH
$ git diff --check upstream/master..HEAD
```
