### PR TITLE
Refactored coil optimization helper

### DIFF
--- a/src/simsopt/field/force.py
+++ b/src/simsopt/field/force.py
@@ -922,7 +922,11 @@ class SquaredMeanForce(Optimizable):
     To minimize function calls, pass ``target_coils`` as a single list and instantiate this class **once**.
     Creating one instance per coil (``sum(SquaredMeanForce([c], sources, ...) for c in coils)``)
     builds an :math:`O(N^2)` :class:`Optimizable` dependency graph, making
-    ``JF.x = dofs`` extremely slow as ``N`` grows
+    ``JF.x = dofs`` extremely slow as ``N`` grows.
+    This single-instance form is also only numerically equivalent to the
+    one-instance-per-coil form when every target coil also appears in the source
+    coils, since physically the force on each target includes the field from the
+    other target coils.
 
     Args:
         target_coils (list of Coil or RegularizedCoil, shape (m,)): 
@@ -1240,7 +1244,11 @@ class LpCurveForce(Optimizable):
     To minimize function calls, pass ``target_coils`` as a single list and instantiate this class **once**.
     Creating one instance per coil (``sum(LpCurveForce([c], sources, ...) for c in coils)``)
     builds an :math:`O(N^2)` :class:`Optimizable` dependency graph, making
-    ``JF.x = dofs`` extremely slow as ``N`` grows
+    ``JF.x = dofs`` extremely slow as ``N`` grows.
+    This single-instance form is also only numerically equivalent to the
+    one-instance-per-coil form when every target coil also appears in the source
+    coils, since physically the force on each target includes the field from the
+    other target coils.
 
     Args:
         target_coils (list of RegularizedCoil, shape (m,)): 
@@ -1562,7 +1570,11 @@ class LpCurveTorque(Optimizable):
     To minimize function calls, pass ``target_coils`` as a single list and instantiate this class **once**.
     Creating one instance per coil (``sum(LpCurveTorque([c], sources, ...) for c in coils)``)
     builds an :math:`O(N^2)` :class:`Optimizable` dependency graph, making
-    ``JF.x = dofs`` extremely slow as ``N`` grows
+    ``JF.x = dofs`` extremely slow as ``N`` grows.
+    This single-instance form is also only numerically equivalent to the
+    one-instance-per-coil form when every target coil also appears in the source
+    coils, since physically the torque on each target includes the field from the
+    other target coils.
 
     Args:
         target_coils (list of RegularizedCoil, shape (m,)): List of coils to use for computing LpCurveTorque. 
@@ -1859,7 +1871,11 @@ class SquaredMeanTorque(Optimizable):
     To minimize function calls, pass ``target_coils`` as a single list and instantiate this class **once**.
     Creating one instance per coil (``sum(SquaredMeanTorque([c], sources, ...) for c in coils)``)
     builds an :math:`O(N^2)` :class:`Optimizable` dependency graph, making
-    ``JF.x = dofs`` extremely slow as ``N`` grows
+    ``JF.x = dofs`` extremely slow as ``N`` grows.
+    This single-instance form is also only numerically equivalent to the
+    one-instance-per-coil form when every target coil also appears in the source
+    coils, since physically the torque on each target includes the field from the
+    other target coils.
     
     Args:
         target_coils (list of Coil or RegularizedCoil, shape (m,)): List of coils to use for computing SquaredMeanTorque. 

--- a/src/simsopt/field/force.py
+++ b/src/simsopt/field/force.py
@@ -919,6 +919,11 @@ class SquaredMeanForce(Optimizable):
     allows one to optimize e.g. the force on target_coils from a set of dipole coils 
     (with barely any quadrature points) and a set of TF coils (with many quadrature points).
 
+    To minimize function calls, pass ``target_coils`` as a single list and instantiate this class **once**.
+    Creating one instance per coil (``sum(SquaredMeanForce([c], sources, ...) for c in coils)``)
+    builds an :math:`O(N^2)` :class:`Optimizable` dependency graph, making
+    ``JF.x = dofs`` extremely slow as ``N`` grows
+
     Args:
         target_coils (list of Coil or RegularizedCoil, shape (m,)): 
             List of coils to use for computing SquaredMeanForce. 
@@ -1231,6 +1236,11 @@ class LpCurveForce(Optimizable):
     all coils must have the same number of quadrature points. The source_coils_coarse and source_coils_fine lists
     allows one to optimize e.g. the torque on target_coils from a set of dipole coils 
     (with barely any quadrature points) and a set of TF coils (with many quadrature points).
+    
+    To minimize function calls, pass ``target_coils`` as a single list and instantiate this class **once**.
+    Creating one instance per coil (``sum(LpCurveForce([c], sources, ...) for c in coils)``)
+    builds an :math:`O(N^2)` :class:`Optimizable` dependency graph, making
+    ``JF.x = dofs`` extremely slow as ``N`` grows
 
     Args:
         target_coils (list of RegularizedCoil, shape (m,)): 
@@ -1548,6 +1558,11 @@ class LpCurveTorque(Optimizable):
     all coils must have the same number of quadrature points. The source_coils_coarse and source_coils_fine lists
     allows one to optimize e.g. the torque on target_coils from a set of dipole coils 
     (with barely any quadrature points) and a set of TF coils (with many quadrature points).
+    
+    To minimize function calls, pass ``target_coils`` as a single list and instantiate this class **once**.
+    Creating one instance per coil (``sum(LpCurveTorque([c], sources, ...) for c in coils)``)
+    builds an :math:`O(N^2)` :class:`Optimizable` dependency graph, making
+    ``JF.x = dofs`` extremely slow as ``N`` grows
 
     Args:
         target_coils (list of RegularizedCoil, shape (m,)): List of coils to use for computing LpCurveTorque. 
@@ -1841,6 +1856,11 @@ class SquaredMeanTorque(Optimizable):
     allows one to optimize e.g. the torque on target_coils from a set of dipole coils 
     (with barely any quadrature points) and a set of TF coils (with many quadrature points).
 
+    To minimize function calls, pass ``target_coils`` as a single list and instantiate this class **once**.
+    Creating one instance per coil (``sum(SquaredMeanTorque([c], sources, ...) for c in coils)``)
+    builds an :math:`O(N^2)` :class:`Optimizable` dependency graph, making
+    ``JF.x = dofs`` extremely slow as ``N`` grows
+    
     Args:
         target_coils (list of Coil or RegularizedCoil, shape (m,)): List of coils to use for computing SquaredMeanTorque. 
         source_coils_coarse (list of Coil or RegularizedCoil, shape (m',)): 

--- a/src/simsopt/util/coil_optimization_helper_functions.py
+++ b/src/simsopt/util/coil_optimization_helper_functions.py
@@ -182,7 +182,7 @@ def coil_optimization(s, bs, base_curves, curves, **kwargs):
     if FORCE_WEIGHT > 0:
         reg_base_coils = [RegularizedCoil(c.curve, c.current, regularization_circ(0.03 * R0)) if not isinstance(c, RegularizedCoil) else c for c in base_coils]
         reg_coils = [RegularizedCoil(c.curve, c.current, regularization_circ(0.03 * R0)) if not isinstance(c, RegularizedCoil) else c for c in coils]
-        Jforce = sum([LpCurveForce([reg_base_coils[i]], reg_coils, p=2, threshold=FORCE_THRESHOLD) for i in range(len(reg_base_coils))])
+        Jforce = LpCurveForce(reg_base_coils, reg_coils, p=2, threshold=FORCE_THRESHOLD)
     else:
         Jforce = None
 
@@ -864,10 +864,7 @@ def vacuum_stage_II_optimization(
     reg_param = regularization_circ(0.05)
     base_coils_reg = [RegularizedCoil(c.curve, c.current, reg_param) for c in base_coils]
     
-    lpcurveforce = sum([LpCurveForce(c, coils, p=2, 
-        threshold=FORCE_THRESHOLD, 
-        ) for c in base_coils_reg]
-    ).J()
+    lpcurveforce = LpCurveForce(base_coils_reg, coils, p=2, threshold=FORCE_THRESHOLD).J()
     max_forces = [np.max(np.linalg.norm(c_reg.force(coils), axis=1)) for c_reg in base_coils_reg]
     min_forces = [np.min(np.linalg.norm(c_reg.force(coils), axis=1)) for c_reg in base_coils_reg]
     RMS_forces = [np.sqrt(np.mean(np.square(np.linalg.norm(c_reg.force(coils), axis=1)))) for c_reg in base_coils_reg]


### PR DESCRIPTION
The `coil_optimization()` and `vacuum_stage_II_optimization()` from `coil_optimization_helper_functions.py` used an anti-pattern which gives rise to the edge-explosion kind of behaviour seen in [issue 487](https://github.com/hiddenSymmetries/simsopt/issues/487).

To construct the `LpCurveForce` optimizable, the old helper functions passed a single coil as the target coil and the complete list of source coils as the source coils. It then continues to construct additional `LpCurveForce` optimizables this way, passing target coils one at a time, resulting (roughly) in number of edges scaling quadratically to number of coils. Simply passing the entire target coil list in construction of one `LpCurveForce` lowers the scaling to $2N$. 

**Note** while it's faster to create one instance with all target coils passed at once rather than summing instances of each target coil, the two forms are only numerically equivalent when every target coil also appears among the source coils. Because force on one target coil counts contribution from other target coils + source coils. I.e. it doesn't make sense in all problems to pass all target coils at once.  

I ran the `util.test_coil_optimization_helper_functions.TestCoilOptimization` test as a quick sanity check that nothing broke.

In summary, the changes are:
1. Rewriting list comprehensions in `coil_optimization()` and `vacuum_stage_II_optimization()` to pass the complete list of target coils instead of looping over each target.
2. Edited docstrings in `force.py` to suggest more efficient construction of `Optimizable` objects

Would be great if @akaptano, @smiet, or other maintainers could take a look at this.