### PR TITLE
Document VMEC current harmonic convention

### DIFF
--- a/docs/source/example_vmec.rst
+++ b/docs/source/example_vmec.rst
@@ -260,6 +260,17 @@ VMEC outputs are saved on the so-called half and full grids. The full grid is li
   double currvmnc(radius, mn_mode_nyq) ;
     currvmnc:long_name = "cosmn covariant v-component of J, full mesh" ;
 
+Some VMEC-family ``wout`` files label ``currumnc`` and ``currvmnc`` as
+covariant components in their NetCDF ``long_name`` attributes. These arrays
+should instead be interpreted as full-grid Fourier coefficients of
+:math:`\sqrt{g} J^u` and :math:`\sqrt{g} J^v` on the Nyquist basis. When
+``Vmec.load_wout()`` reads a ``wout`` file, two-dimensional arrays are
+transposed from NetCDF ``(radius, mode)`` order to SIMSOPT ``(mode, radius)``
+order, so these coefficients are accessed as ``vmec.wout.currumnc[:, js]`` and
+``vmec.wout.currvmnc[:, js]``. Reconstruct them with the usual VMEC phase
+``xm_nyq * theta - xn_nyq * phi``; ``xn_nyq`` already includes the field-period
+factor.
+
 .. _interp:
 
 Interpreting VMEC errors 
@@ -370,4 +381,4 @@ Since the force residual did not get very small in the ``ns=25`` stage, in this 
 
 Sometimes adjusting ``delt`` (in either direction) can also help convergence. 
 
-Often if ``mpol`` and ``ntor`` get too large and in very strongly shaped geometries, it becomes challenging to converge. 
+Often if ``mpol`` and ``ntor`` get too large and in very strongly shaped geometries, it becomes challenging to converge.

--- a/docs/source/example_vmec.rst
+++ b/docs/source/example_vmec.rst
@@ -266,8 +266,9 @@ should instead be interpreted as full-grid Fourier coefficients of
 :math:`\sqrt{g} J^u` and :math:`\sqrt{g} J^v` on the Nyquist basis. When
 ``Vmec.load_wout()`` reads a ``wout`` file, two-dimensional arrays are
 transposed from NetCDF ``(radius, mode)`` order to SIMSOPT ``(mode, radius)``
-order, so these coefficients are accessed as ``vmec.wout.currumnc[:, js]`` and
-``vmec.wout.currvmnc[:, js]``. Reconstruct them with the usual VMEC phase
+order, so at a 0-based radial index ``js`` these coefficients are accessed as
+``vmec.wout.currumnc[:, js]`` and ``vmec.wout.currvmnc[:, js]``. Reconstruct
+them with the usual VMEC phase
 ``xm_nyq * theta - xn_nyq * phi``; ``xn_nyq`` already includes the field-period
 factor.
 


### PR DESCRIPTION
## Summary

This is a documentation-only PR for the VMEC example docs.

It adds an explicit note about the VMEC current-harmonic convention:

- some wout NetCDF `long_name` metadata labels `currumnc/currvmnc` as covariant components, but that label is misleading
- the arrays are Fourier coefficients of `sqrt(g)J^u` and `sqrt(g)J^v`
- they live on the full-grid Nyquist basis, so they should be interpreted with `xm_nyq/xn_nyq`
- `Vmec.load_wout()` transposes 2-D arrays from raw NetCDF `(radius, mode)` order to SIMSOPT's internal `(mode, radius)` order
- VMEC's phase is `m*theta - xn*phi`, and `xn_nyq` already includes the field-period factor

No runtime behavior is changed.

## Why this matters

The existing docs show how to inspect VMEC output through SIMSOPT. For most geometry arrays the mode basis is `xm/xn`, but current harmonics are different: they use the Nyquist basis and store `sqrt(g)J`, not a physical covariant current component.

This has been a source of downstream mistakes in visualization and field-line/current-line tooling. A user who trusts the legacy NetCDF `long_name` text can easily:

- use `xm/xn` instead of `xm_nyq/xn_nyq`
- miss the `(radius, mode)` to `(mode, radius)` transposition done by `load_wout()`
- interpret `sqrt(g)J^u/sqrt(g)J^v` as physical current components

The added note is meant to make this convention explicit at the point where users are learning to consume VMEC data through SIMSOPT.

## Public-data diagnostic

The figure below uses the public finite-beta W7-X test file already in this repository:

```text
tests/test_files/wout_W7-X_without_coil_ripple_beta0p05_d23p4_tm_reference.nc
```

It shows the raw dimensions and mode bases relevant to the documentation note.

![SIMSOPT VMEC current harmonic convention](https://raw.githubusercontent.com/WenyinWei/simsopt/pr-assets/current-harmonics/simsopt-635/current_harmonics_convention.png)

For that file:

- `beta_total = 0.04484`
- `nfp = 5`
- `ns = 201`
- `rmnc/zmns` shape is `(201, 200)`, using `mnmax`
- `gmnc` shape is `(201, 841)`, using `mnmax_nyq`
- `currumnc/currvmnc` shape is `(201, 841)`, also using `mnmax_nyq`
- the observed legacy `long_name` text says `covariant ... component of J`, which is the misleading wording this docs note warns about

## Reproducer

From a SIMSOPT checkout:

```bash
python3 - <<'PY'
from scipy.io import netcdf_file

path = "tests/test_files/wout_W7-X_without_coil_ripple_beta0p05_d23p4_tm_reference.nc"
with netcdf_file(path, "r", mmap=False) as nc:
    print("beta_total:", float(nc.variables["betatotal"].data.copy()))
    print("nfp:", int(nc.variables["nfp"].data.copy()))
    print("ns:", int(nc.variables["ns"].data.copy()))
    print("mnmax:", int(nc.variables["mnmax"].data.copy()))
    print("mnmax_nyq:", int(nc.variables["mnmax_nyq"].data.copy()))
    print("rmnc shape:", nc.variables["rmnc"].data.shape)
    print("gmnc shape:", nc.variables["gmnc"].data.shape)
    print("currumnc shape:", nc.variables["currumnc"].data.shape)
    print("currumnc long_name:", nc.variables["currumnc"].long_name)
    print("currvmnc long_name:", nc.variables["currvmnc"].long_name)
PY
```

Expected metadata:

```text
beta_total: 0.04484065...
nfp: 5
ns: 201
mnmax: 200
mnmax_nyq: 841
rmnc shape: (201, 200)
gmnc shape: (201, 841)
currumnc shape: (201, 841)
currumnc long_name: cosmn covariant u-component of J, full mesh
currvmnc long_name: cosmn covariant v-component of J, full mesh
```

## Verification

```bash
git diff --check
```

This is a docs-only change.