### PR TITLE
Fix conda workflow: call conda-build binary from active env

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -52,20 +52,20 @@ jobs:
         if: github.event_name == 'release' && github.event.action == 'published'
         run: |
           conda config --set anaconda_upload yes
-          conda build --token ${{ secrets.ANACONDA_TOKEN }} conda.recipe
+          "$CONDA/bin/conda-build" --token ${{ secrets.ANACONDA_TOKEN }} conda.recipe
 
       - name: Build and upload to test
         if: github.event_name == 'push' && github.ref == 'refs/heads/mbk/conda_package'
         run: |
           conda config --set anaconda_upload yes
-          conda build --token ${{ secrets.MBK_ANACONDA_TOKEN }} conda.recipe
+          "$CONDA/bin/conda-build" --token ${{ secrets.MBK_ANACONDA_TOKEN }} conda.recipe
 
       - name: Build 
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
-          conda build --no-test conda.recipe
+          "$CONDA/bin/conda-build" --no-test conda.recipe
 
       - name: Build on PR
         if: github.event_name == 'pull_request'
         run: |
-          conda build --no-test conda.recipe
+          "$CONDA/bin/conda-build" --no-test conda.recipe


### PR DESCRIPTION
Conda `build`/`build-on-PR` jobs fail on current runners because `conda build` is no longer exposed as a conda subcommand (`conda: error: argument COMMAND: invalid choice: 'build'`), and the `conda-build` executable was installed into base only (via `setup-miniconda` `conda-build-version` and `conda install --name base`), so the build steps (running in the activated env) could not find it.

## Changes
- Call the `conda-build` executable instead of the `conda build` subcommand in all build/upload steps.
- Install `conda-build` into the active environment during Prepare; drop the base-only `conda-build-version` pin.

## Background
This is the fix from #633, which was closed as "folded into #632" but never actually landed in the conda workflow — `master` still carries the broken `conda build` subcommand form.

## Verification
- `master` conda `build`/`build-on-PR` currently fail (`invalid choice: 'build'` on current runners).
- After this change the workflow calls the installed `conda-build` binary from the active env. Full confirmation comes from this PR's own conda CI run.