### PR TITLE
Fix wheel builds: use manylinux_2_28 image

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -35,6 +35,10 @@ jobs:
           #   # Skip python 3.8 and PyPy builds since there is are errors when building the
           #   # wheel in those cases:
           CIBW_SKIP: cp38-* cp39-* pp* *-manylinux_i686 *-musllinux*
+          # numpy >= 2.3 ships only manylinux_2_28 wheels and its sdist needs
+          # GCC >= 10.3, which the default manylinux2014 image lacks.
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           #   CIBW_DEPENDENCY_VERSIONS: latest
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
The `Build wheels` job fails on `ubuntu-latest` and `ubuntu-24.04-arm` (on `master` and every open PR) while installing the build dependency `numpy`:

```
Downloading numpy-2.5.1.tar.gz (20.8 MB)
../meson.build:25:4: ERROR: Problem encountered: NumPy requires GCC >= 10.3
error: metadata-generation-failed
```

cibuildwheel 2.22.0's default manylinux image is `manylinux2014` (GCC 10.2.1). `numpy>=2.0.0` now resolves to numpy 2.5.1, which no longer ships `manylinux2014` wheels, so pip builds it from source in the container and hits the GCC requirement.

## Fix
Pin the x86_64 and aarch64 build images to `manylinux_2_28` (GCC 12). This provides a new enough toolchain and matches numpy 2.x's wheel platform, so a prebuilt numpy wheel is installed instead of compiled from source. `wheel.yml` only.

## Scope
Independent build-infra regression, split out from the other open PRs (#619 3.14, #636 conda, #637 codecov, #638 tests). This is the blocker for their `Build wheels` checks and should merge first — the others go green once they pick it up.

## Verification
Confirmed via this PR's own `Build wheels` run (the failure reproduces on every PR without this change).