### PR TITLE
B field rect section v2

### DIFF
--- a/src/simsopt/field/coil.py
+++ b/src/simsopt/field/coil.py
@@ -7,20 +7,29 @@ from simsopt.geo.curvexyzfourier import CurveXYZFourier
 from simsopt.geo.curve import RotatedCurve
 import simsoptpp as sopp
 
-__all__ = ['Coil', 'RegularizedCoil', 'CircularRegularizedCoil', 'RectangularRegularizedCoil',
-           'Current', 'coils_via_symmetries',
-           'load_coils_from_makegrid_file',
-           'apply_symmetries_to_currents', 'apply_symmetries_to_curves',
-           'coils_to_makegrid', 'coils_to_focus', 'coils_to_vtk'
-           ]
+
+__all__ = [
+    "Coil",
+    "RegularizedCoil",
+    "CircularRegularizedCoil",
+    "RectangularRegularizedCoil",
+    "Current",
+    "coils_via_symmetries",
+    "load_coils_from_makegrid_file",
+    "apply_symmetries_to_currents",
+    "apply_symmetries_to_curves",
+    "coils_to_makegrid",
+    "coils_to_focus",
+    "coils_to_vtk",
+]
 
 
 class Coil(sopp.Coil, Optimizable):
     """
     Represents a magnetic coil as a combination of a geometric curve and an electric current.
 
-    This class combines a :class:`~simsopt.geo.curve.Curve` and a :class:`Current` object, and 
-    is used as input for :class:`~simsopt.field.biotsavart.BiotSavart` field calculations. 
+    This class combines a :class:`~simsopt.geo.curve.Curve` and a :class:`Current` object, and
+    is used as input for :class:`~simsopt.field.biotsavart.BiotSavart` field calculations.
 
     Args:
         curve (simsopt.geo.curve.Curve) : The geometric curve describing the coil shape.
@@ -50,9 +59,11 @@ class Coil(sopp.Coil, Optimizable):
         Returns:
             The vector-Jacobian product of the coil.
         """
-        return self.curve.dgamma_by_dcoeff_vjp(v_gamma) \
-            + self.curve.dgammadash_by_dcoeff_vjp(v_gammadash) \
+        return (
+            self.curve.dgamma_by_dcoeff_vjp(v_gamma)
+            + self.curve.dgammadash_by_dcoeff_vjp(v_gammadash)
             + self.current.vjp(v_current)
+        )
 
     def plot(self, **kwargs):
         """
@@ -65,25 +76,27 @@ class Coil(sopp.Coil, Optimizable):
             kwargs (dictionary): Additional keyword arguments.
         """
         return self.curve.plot(**kwargs)
-    
+
+
 class RegularizedCoil(Coil):
     """
     A coil with a model for its cross section. This cross section is used to compute the
     forces and torques on the coil.
-    
+
     Args:
         curve (simsopt.geo.curve.Curve) : The geometric curve describing the coil shape.
         current (Current) : The current object describing the electric current in the coil.
         regularization (float) : The regularization parameter for the coil cross section.
     """
+
     def __init__(self, curve, current, regularization):
         self.regularization = regularization
         Coil.__init__(self, curve, current)
-    
+
     @staticmethod
     def _coil_force_pure(B, I, t):
         r"""
-        Compute the pointwise Lorentz force per unit length on a coil with n quadrature points, in Newtons/meter. 
+        Compute the pointwise Lorentz force per unit length on a coil with n quadrature points, in Newtons/meter.
 
         .. math::
             dF/d\ell = I \vec{t} \times \vec{B}
@@ -100,15 +113,17 @@ class RegularizedCoil(Coil):
             array (shape (n,3)): Array of force per unit length.
         """
         import jax.numpy as jnp
+
         return jnp.cross(I * t, B)
-    
+
     def B_regularized(self):
         """Calculate the regularized field on this coil following the Landreman and Hurwitz method.
-        
+
         Returns:
             array (shape (n,3)): The regularized field on the coil.
         """
         from .selffield import B_regularized_pure
+
         return B_regularized_pure(
             self.curve.gamma(),
             self.curve.gammadash(),
@@ -117,11 +132,11 @@ class RegularizedCoil(Coil):
             self._current.get_value(),
             self.regularization,
         )
-    
+
     def self_force(self):
         """
         Compute the self-force per unit length of this coil, in Newtons/meter.
-        
+
         Returns:
             array (shape (n,3)): Array of self-force per unit length.
         """
@@ -131,11 +146,11 @@ class RegularizedCoil(Coil):
         tangent = gammadash / gammadash_norm
         B = self.B_regularized()
         return self._coil_force_pure(B, I, tangent)
-    
+
     def force(self, source_coils):
         r"""
         Compute the force per unit length on this coil from other coils, in Newtons/meter.
-        
+
         .. math::
             dF_i/d\ell = I_i \vec{t_i} \times (\vec{B_{self}} + \vec{B_{mutual}})
 
@@ -144,13 +159,14 @@ class RegularizedCoil(Coil):
         :math:`\vec{B_{mutual}}` is the mutual field from the other coils.
 
         Args:
-            source_coils (list of Coil or RegularizedCoil, shape (m,)): 
-                List of coils contributing forces on this coil. 
+            source_coils (list of Coil or RegularizedCoil, shape (m,)):
+                List of coils contributing forces on this coil.
                 Can be a mix of Coil and RegularizedCoil objects.
         Returns:
             array (shape (n,3)): Array of forces per unit length along the coil curve.
         """
         from .biotsavart import BiotSavart
+
         gammadash = self.curve.gammadash()
         gammadash_norm = np.linalg.norm(gammadash, axis=1)[:, None]
         tangent = gammadash / gammadash_norm
@@ -159,8 +175,8 @@ class RegularizedCoil(Coil):
         B_mutual = mutual_field.B()
         mutualforce = np.cross(self.current.get_value() * tangent, B_mutual)
         selfforce = self.self_force()
-        return (selfforce + mutualforce)
-    
+        return selfforce + mutualforce
+
     def net_force(self, source_coils):
         r"""
         Compute the net forces on this coil from other coils, in Newtons. This is
@@ -170,8 +186,8 @@ class RegularizedCoil(Coil):
             F_net = \int (dF_i/d\ell) d\ell
 
         Args:
-            source_coils (list of Coil or RegularizedCoil, shape (m,)): 
-                List of coils contributing forces on this coil. 
+            source_coils (list of Coil or RegularizedCoil, shape (m,)):
+                List of coils contributing forces on this coil.
                 Can be a mix of Coil and RegularizedCoil objects.
         Returns:
             np.array (shape (3,)): Array of net forces.
@@ -181,23 +197,23 @@ class RegularizedCoil(Coil):
         gammadash_norm = np.linalg.norm(gammadash, axis=1)[:, None]
         net_force = np.sum(gammadash_norm * Fi, axis=0) / gammadash.shape[0]
         return net_force
-    
+
     def torque(self, source_coils):
         r"""
-        Compute the torques per unit length on this coil from other coils in Newtons 
-        (note that the force is per unit length, so the force has units of Newtons/meter 
+        Compute the torques per unit length on this coil from other coils in Newtons
+        (note that the force is per unit length, so the force has units of Newtons/meter
         and the torques per unit length have units of Newtons).
 
         .. math::
             dT_i/d\ell = (\gamma_i - c_i) \times (dF_i/d\ell)
 
-        where :math:`\gamma_i` is the position vector of the ith coil curve, 
+        where :math:`\gamma_i` is the position vector of the ith coil curve,
         :math:`c_i` is the centroid of the ith coil curve,
         :math:`dF_i/d\ell` is the pointwise force per unit length on the ith coil curve.
 
         Args:
-            source_coils (list of Coil or RegularizedCoil, shape (m,)): 
-                List of coils contributing torques on this coil. 
+            source_coils (list of Coil or RegularizedCoil, shape (m,)):
+                List of coils contributing torques on this coil.
                 Can be a mix of Coil and RegularizedCoil objects.
         Returns:
             np.array (shape (n,3)): Array of torques per unit length along the coil curve.
@@ -205,7 +221,7 @@ class RegularizedCoil(Coil):
         gamma = self.curve.gamma()
         center = self.curve.centroid()
         return np.cross(gamma - center, self.force(source_coils))
-    
+
     def net_torque(self, source_coils):
         r"""
         Compute the net torques on this coil from other coils, in Newton-meters. This is
@@ -215,8 +231,8 @@ class RegularizedCoil(Coil):
             T_net = \int dT_i/d\ell d\ell
 
         Args:
-            source_coils (list of Coil or RegularizedCoil, shape (m,)): 
-                List of coils contributing torques on this coil. 
+            source_coils (list of Coil or RegularizedCoil, shape (m,)):
+                List of coils contributing torques on this coil.
                 Can be a mix of Coil and RegularizedCoil objects.
         Returns:
             np.array (shape (3,)): Array of net torques.
@@ -232,14 +248,16 @@ class CircularRegularizedCoil(RegularizedCoil):
     """
     A coil with a circular cross section. The regularization parameter is computed
     from the radius during initialization.
-    
+
     Args:
         curve (simsopt.geo.curve.Curve) : The geometric curve describing the coil shape.
         current (Current) : The current object describing the electric current in the coil.
         a (float) : The radius of the circular cross-section.
     """
+
     def __init__(self, curve, current, a):
         from .selffield import regularization_circ
+
         regularization = regularization_circ(a)
         self.a = a
         RegularizedCoil.__init__(self, curve, current, regularization)
@@ -249,19 +267,92 @@ class RectangularRegularizedCoil(RegularizedCoil):
     """
     A coil with a rectangular cross section. The regularization parameter is computed
     from the width and height during initialization.
-    
+
     Args:
         curve (simsopt.geo.curve.Curve) : The geometric curve describing the coil shape.
         current (Current) : The current object describing the electric current in the coil.
         a (float) : The width of the rectangular cross-section.
         b (float) : The height of the rectangular cross-section.
     """
+
     def __init__(self, curve, current, a, b):
         from .selffield import regularization_rect
+
         regularization = regularization_rect(a, b)
         self.a = a
         self.b = b
-        RegularizedCoil.__init__(self, curve, current, regularization)    
+        RegularizedCoil.__init__(self, curve, current, regularization)
+
+    def B_total(self, u, v, a, b):
+        from simsopt.field.selffield import B_total_impl, compute_frame
+
+        gamma = self.curve.gamma()
+        gammadash = self.curve.gammadash()
+        gammadashdash = self.curve.gammadashdash()
+
+        t, p, q = compute_frame(gamma, gammadash)
+
+        return B_total_impl(
+            gamma,
+            gammadash,
+            gammadashdash,
+            self.curve.quadpoints,
+            u,
+            v,
+            a,
+            b,
+            t,
+            p,
+            q,
+            self._current.get_value(),
+            self.regularization,
+        )
+
+    def Bkappa(self, u, v, a, b):
+        from simsopt.field.selffield import Bkappa_impl, compute_frame
+
+        gamma = self.curve.gamma()
+        gammadash = self.curve.gammadash()
+        gammadashdash = self.curve.gammadashdash()
+
+        t, p, q = compute_frame(gamma, gammadash)
+
+        return Bkappa_impl(
+            u, v, a, b, self._current.get_value(), gammadash, gammadashdash, t, p, q
+        )
+
+    def B_b(self, a, b):
+        from simsopt.field.selffield import B_bimpl
+
+        gammadash = self.curve.gammadash()
+        gammadashdash = self.curve.gammadashdash()
+        return B_bimpl(a, b, self._current.get_value(), gammadash, gammadashdash)
+
+    def B0(self, u, v, a, b):
+        from simsopt.field.selffield import B0_impl, compute_frame
+
+        gamma = self.curve.gamma()
+        gammadash = self.curve.gammadash()
+        t, p, q = compute_frame(gamma, gammadash)
+        return B0_impl(u, v, a, b, self._current.get_value(), p, q)
+
+    def B_regularized(self):
+        """Calculate the regularized field on this coil following the Landreman and Hurwitz method.
+
+        Returns:
+            array (shape (n,3)): The regularized field on the coil.
+        """
+        from .selffield import B_regularized_pure
+
+        return B_regularized_pure(
+            self.curve.gamma(),
+            self.curve.gammadash(),
+            self.curve.gammadashdash(),
+            self.curve.quadpoints,
+            self._current.get_value(),
+            self.regularization,
+        )
+
 
 class CurrentBase(Optimizable):
     """
@@ -311,7 +402,7 @@ class CurrentBase(Optimizable):
             A new current object that is the quotient of the current object and the scalar.
         """
         assert isinstance(other, float) or isinstance(other, int)
-        return ScaledCurrent(self, 1.0/other)
+        return ScaledCurrent(self, 1.0 / other)
 
     def __neg__(self):
         """
@@ -320,7 +411,7 @@ class CurrentBase(Optimizable):
         Returns:
             A new current object that has the opposite sign of current.
         """
-        return ScaledCurrent(self, -1.)
+        return ScaledCurrent(self, -1.0)
 
     def __add__(self, other):
         """
@@ -355,10 +446,10 @@ class CurrentBase(Optimizable):
 
 class Current(sopp.Current, CurrentBase):
     """
-    An optimizable object that wraps around a single scalar degree of freedom representing 
+    An optimizable object that wraps around a single scalar degree of freedom representing
     an electric current.
 
-    This class is used for the current in a coil, or in a set of coils constrained 
+    This class is used for the current in a coil, or in a set of coils constrained
     to use the same current.
 
     Args:
@@ -370,11 +461,16 @@ class Current(sopp.Current, CurrentBase):
     def __init__(self, current, dofs=None, **kwargs):
         sopp.Current.__init__(self, current)
         if dofs is None:
-            CurrentBase.__init__(self, external_dof_setter=sopp.Current.set_dofs,
-                                 x0=self.get_dofs(), **kwargs)
+            CurrentBase.__init__(
+                self,
+                external_dof_setter=sopp.Current.set_dofs,
+                x0=self.get_dofs(),
+                **kwargs,
+            )
         else:
-            CurrentBase.__init__(self, external_dof_setter=sopp.Current.set_dofs,
-                                 dofs=dofs, **kwargs)
+            CurrentBase.__init__(
+                self, external_dof_setter=sopp.Current.set_dofs, dofs=dofs, **kwargs
+            )
 
     def vjp(self, v_current):
         """
@@ -401,7 +497,7 @@ class Current(sopp.Current, CurrentBase):
 
 class ScaledCurrent(sopp.CurrentBase, CurrentBase):
     """
-    Represents a current that is a scaled version of another current object 
+    Represents a current that is a scaled version of another current object
     (Scales :mod:`Current` by a factor.). The 'scale' is not treated as a dof, so it is not optimized.
     The scaled current has value I = scale * I_0 where `I_0` is the 'current_to_scale'.
 
@@ -439,6 +535,7 @@ class ScaledCurrent(sopp.CurrentBase, CurrentBase):
             The current value of the current object.
         """
         return self.scale * self.current_to_scale.get_value()
+
 
 class CurrentSum(sopp.CurrentBase, CurrentBase):
     """
@@ -504,7 +601,7 @@ def apply_symmetries_to_curves(base_curves, nfp, stellsym):
                 if k == 0 and not flip:
                     curves.append(base_curves[i])
                 else:
-                    rotcurve = RotatedCurve(base_curves[i], 2*pi*k/nfp, flip)
+                    rotcurve = RotatedCurve(base_curves[i], 2 * pi * k / nfp, flip)
                     curves.append(rotcurve)
     return curves
 
@@ -512,7 +609,7 @@ def apply_symmetries_to_curves(base_curves, nfp, stellsym):
 def apply_symmetries_to_currents(base_currents, nfp, stellsym):
     """
     Generate a list of currents by applying rotational and (optionally) stellarator symmetries.
-        
+
     Take a list of ``n`` :mod:`Current`s and return ``n * nfp * (1+int(stellsym))``
     :mod:`Current` objects obtained by copying (for ``nfp`` rotations) and
     sign-flipping (optionally for stellarator symmetry).
@@ -530,9 +627,12 @@ def apply_symmetries_to_currents(base_currents, nfp, stellsym):
     for k in range(0, nfp):
         for flip in flip_list:
             for i in range(len(base_currents)):
-                current = ScaledCurrent(base_currents[i], -1.) if flip else base_currents[i]
+                current = (
+                    ScaledCurrent(base_currents[i], -1.0) if flip else base_currents[i]
+                )
                 currents.append(current)
     return currents
+
 
 def coils_to_vtk(coils, filename, close=False, extra_data=None):
     """
@@ -556,26 +656,27 @@ def coils_to_vtk(coils, filename, close=False, extra_data=None):
 
     # get the number of points per curve
     if close:
-        ppl = np.asarray([c.gamma().shape[0]+1 for c in curves])
+        ppl = np.asarray([c.gamma().shape[0] + 1 for c in curves])
     else:
         ppl = np.asarray([c.gamma().shape[0] for c in curves])
-    ppl_cumsum = np.concatenate([[0], np.cumsum(ppl)])
 
     # get the current data, which is the same at every point on a given coil
     contig = np.ascontiguousarray
     pointData = {}
-    data = np.concatenate([i*np.ones((ppl[i], )) for i in range(len(curves))])
+    data = np.concatenate([i * np.ones((ppl[i],)) for i in range(len(curves))])
     coil_data = np.zeros(data.shape)
     for i in range(len(currents)):
-        coil_data[ppl_cumsum[i]:ppl_cumsum[i+1]] = currents[i]
+        coil_data[i * ppl[i]: (i + 1) * ppl[i]] = currents[i]
     coil_data = np.ascontiguousarray(coil_data)
-    pointData['I'] = coil_data
-    pointData['I_mag'] = contig(np.abs(coil_data))
+    pointData["I"] = coil_data
+    pointData["I_mag"] = contig(np.abs(coil_data))
 
     if not isinstance(coils[0], RegularizedCoil):
-        print("Warning: coils_to_vtk will not save forces and torques for coils that "
-              "do not have a model for their cross section. Please use the RegularizedCoil class.")
-    else:    
+        print(
+            "Warning: coils_to_vtk will not save forces and torques for coils that "
+            "do not have a model for their cross section. Please use the RegularizedCoil class."
+        )
+    else:
         net_forces = np.zeros((len(coils), 3))
         net_torques = np.zeros((len(coils), 3))
         coil_forces = np.zeros((data.shape[0], 3))
@@ -585,7 +686,7 @@ def coils_to_vtk(coils, filename, close=False, extra_data=None):
             coil_force_temp = c.force(coils)
             coil_torque_temp = c.torque(coils)
 
-            # get the net forces and torques for the current coil, 
+            # get the net forces and torques for the current coil,
             # which is the same at every point on the coil
             net_forces[i, :] = c.net_force(coils)
             net_torques[i, :] = c.net_torque(coils)
@@ -594,35 +695,48 @@ def coils_to_vtk(coils, filename, close=False, extra_data=None):
             if close:
                 coil_force_temp = np.vstack((coil_force_temp, coil_force_temp[0, :]))
                 coil_torque_temp = np.vstack((coil_torque_temp, coil_torque_temp[0, :]))
-            coil_forces[ppl_cumsum[i]:ppl_cumsum[i+1], :] = coil_force_temp
-            coil_torques[ppl_cumsum[i]:ppl_cumsum[i+1], :] = coil_torque_temp
+            coil_forces[i * ppl[i]: (i + 1) * ppl[i], :] = coil_force_temp
+            coil_torques[i * ppl[i]: (i + 1) * ppl[i], :] = coil_torque_temp
 
         # copy force and torque data over to pointwise data on a coil curve
         coil_data = np.zeros((data.shape[0], 3))
         for i in range(len(coils)):
-            coil_data[ppl_cumsum[i]:ppl_cumsum[i+1], :] = net_forces[i, :]
+            coil_data[i * ppl[i]: (i + 1) * ppl[i], :] = net_forces[i, :]
         coil_data = np.ascontiguousarray(coil_data)
-        pointData['NetForces'] = (contig(coil_data[:, 0]),
-                                    contig(coil_data[:, 1]),
-                                    contig(coil_data[:, 2]))
+        pointData["NetForces"] = (
+            contig(coil_data[:, 0]),
+            contig(coil_data[:, 1]),
+            contig(coil_data[:, 2]),
+        )
         coil_data = np.zeros((data.shape[0], 3))
         for i in range(len(coils)):
-            coil_data[ppl_cumsum[i]:ppl_cumsum[i+1], :] = net_torques[i, :]
+            coil_data[i * ppl[i]: (i + 1) * ppl[i], :] = net_torques[i, :]
         coil_data = np.ascontiguousarray(coil_data)
 
         # Add pointwise force and torque data to the dictionary
-        pointData['NetTorques'] = (contig(coil_data[:, 0]),
-                                    contig(coil_data[:, 1]),
-                                    contig(coil_data[:, 2]))
-        pointData["Pointwise_Forces"] = (contig(coil_forces[:, 0]), contig(coil_forces[:, 1]), contig(coil_forces[:, 2]))
-        pointData["Pointwise_Torques"] = (contig(coil_torques[:, 0]), contig(coil_torques[:, 1]), contig(coil_torques[:, 2]))
-    
+        pointData["NetTorques"] = (
+            contig(coil_data[:, 0]),
+            contig(coil_data[:, 1]),
+            contig(coil_data[:, 2]),
+        )
+        pointData["Pointwise_Forces"] = (
+            contig(coil_forces[:, 0]),
+            contig(coil_forces[:, 1]),
+            contig(coil_forces[:, 2]),
+        )
+        pointData["Pointwise_Torques"] = (
+            contig(coil_torques[:, 0]),
+            contig(coil_torques[:, 1]),
+            contig(coil_torques[:, 2]),
+        )
+
     # If extra data is provided, add it to the dictionary
     if extra_data is not None:
         pointData = {**pointData, **extra_data}
 
-    # Call curves_to_vtk to save the curves and extra dictionary data 
+    # Call curves_to_vtk to save the curves and extra dictionary data
     curves_to_vtk(curves, filename, close=close, extra_data=pointData)
+
 
 def coils_via_symmetries(curves, currents, nfp, stellsym, regularizations=None):
     """
@@ -633,7 +747,7 @@ def coils_via_symmetries(curves, currents, nfp, stellsym, regularizations=None):
     to ``nfp`` fold rotational symmetry and optionally stellarator symmetry.
 
     If regularizations are provided for the base curves, then RegularizedCoil objects are returned. This
-    is a coil class that carries around a regularization for a finite cross section, which is used 
+    is a coil class that carries around a regularization for a finite cross section, which is used
     for computing e.g. forces and torques on the coil. Format is e.g.
     regularizations = [regularization_circ(0.05) for _ in range(ncoils)]
 
@@ -655,7 +769,10 @@ def coils_via_symmetries(curves, currents, nfp, stellsym, regularizations=None):
         coils = [Coil(curv, curr) for (curv, curr) in zip(curves, currents)]
     else:
         regularizations = regularizations * (nfp * (1 + stellsym))
-        coils = [RegularizedCoil(curv, curr, regularization) for (curv, curr, regularization) in zip(curves, currents, regularizations)]
+        coils = [
+            RegularizedCoil(curv, curr, regularization)
+            for (curv, curr, regularization) in zip(curves, currents, regularizations)
+        ]
     return coils
 
 
@@ -663,8 +780,8 @@ def load_coils_from_makegrid_file(filename, order, ppp=20, group_names=None):
     """
     Load coils from a mgrid input file, returning a list of Coil objects.
 
-    This function loads a file in MAKEGRID input format containing the Cartesian coordinates 
-    and the currents for several coils and returns an array with the corresponding coils. 
+    This function loads a file in MAKEGRID input format containing the Cartesian coordinates
+    and the currents for several coils and returns an array with the corresponding coils.
     The format is described at
     https://princetonuniversity.github.io/STELLOPT/MAKEGRID
 
@@ -682,12 +799,12 @@ def load_coils_from_makegrid_file(filename, order, ppp=20, group_names=None):
         # Handle case of a single string
         group_names = [group_names]
 
-    with open(filename, 'r') as f:
+    with open(filename) as f:
         all_coils_values = f.read().splitlines()[3:]
 
     currents = []
     flag = True
-    for j in range(len(all_coils_values)-1):
+    for j in range(len(all_coils_values) - 1):
         vals = all_coils_values[j].split()
         if flag:
             curr = float(vals[3])
@@ -701,7 +818,9 @@ def load_coils_from_makegrid_file(filename, order, ppp=20, group_names=None):
                 if this_group_name in group_names:
                     currents.append(curr)
 
-    curves = CurveXYZFourier.load_curves_from_makegrid_file(filename, order=order, ppp=ppp, group_names=group_names)
+    curves = CurveXYZFourier.load_curves_from_makegrid_file(
+        filename, order=order, ppp=ppp, group_names=group_names
+    )
     coils = [Coil(curves[i], Current(currents[i])) for i in range(len(curves))]
 
     return coils
@@ -732,7 +851,7 @@ def coils_to_makegrid(filename, curves, currents, groups=None, nfp=1, stellsym=F
         assert len(groups) == ncoils
         # should be careful. SIMSOPT flips the current, but actually should change coil order
     with open(filename, "w") as wfile:
-        wfile.write("periods {:3d} \n".format(nfp))
+        wfile.write(f"periods {nfp:3d} \n")
         wfile.write("begin filament \n")
         wfile.write("mirror NIL \n")
         for icoil in range(ncoils):
@@ -741,20 +860,18 @@ def coils_to_makegrid(filename, curves, currents, groups=None, nfp=1, stellsym=F
             z = coils[icoil].curve.gamma()[:, 2]
             for iseg in range(len(x)):  # the last point matches the first one;
                 wfile.write(
-                    "{:23.15E} {:23.15E} {:23.15E} {:23.15E}\n".format(
-                        x[iseg], y[iseg], z[iseg], coils[icoil].current.get_value()
-                    )
+                    f"{x[iseg]:23.15E} {y[iseg]:23.15E} {z[iseg]:23.15E} {coils[icoil].current.get_value():23.15E}\n"
                 )
             wfile.write(
-                "{:23.15E} {:23.15E} {:23.15E} {:23.15E} {:} {:10} \n".format(
-                    x[0], y[0], z[0], 0.0, groups[icoil], coils[icoil].curve.name
-                )
+                f"{x[0]:23.15E} {y[0]:23.15E} {z[0]:23.15E} {0.0:23.15E} {groups[icoil]} {coils[icoil].curve.name:10} \n"
             )
         wfile.write("end \n")
     return
 
 
-def coils_to_focus(filename, curves, currents, nfp=1, stellsym=False, Ifree=False, Lfree=False):
+def coils_to_focus(
+    filename, curves, currents, nfp=1, stellsym=False, Ifree=False, Lfree=False
+):
     """
     Export a list of CurveXYZFourier objects and currents to a FOCUS input file.
 
@@ -781,33 +898,35 @@ def coils_to_focus(filename, curves, currents, nfp=1, stellsym=False, Ifree=Fals
     else:
         symm = 0  # no periodicity or symmetry
     if nfp > 1:
-        print('Please note: FOCUS sets Nfp in the plasma file.')
-    with open(filename, 'w') as f:
-        f.write('# Total number of coils \n')
-        f.write('  {:d} \n'.format(ncoils))
+        print("Please note: FOCUS sets Nfp in the plasma file.")
+    with open(filename, "w") as f:
+        f.write("# Total number of coils \n")
+        f.write(f"  {ncoils:d} \n")
         for i in range(ncoils):
             assert isinstance(curves[i], CurveXYZFourier)
             nf = curves[i].order
             xyz = curves[i].full_x.reshape((3, -1))
             xc = xyz[0, ::2]
-            xs = np.concatenate(([0.], xyz[0, 1::2]))
+            xs = np.concatenate(([0.0], xyz[0, 1::2]))
             yc = xyz[1, ::2]
-            ys = np.concatenate(([0.], xyz[1, 1::2]))
+            ys = np.concatenate(([0.0], xyz[1, 1::2]))
             zc = xyz[2, ::2]
-            zs = np.concatenate(([0.], xyz[2, 1::2]))
+            zs = np.concatenate(([0.0], xyz[2, 1::2]))
             length = CurveLength(curves[i]).J()
             nseg = len(curves[i].quadpoints)
-            f.write('#------------{:d}----------- \n'.format(i+1))
-            f.write('# coil_type  symm  coil_name \n')
-            f.write('  {:d}   {:d}  {:} \n'.format(1, symm, curves[i].name))
-            f.write('# Nseg current Ifree Length Lfree target_length \n')
-            f.write('  {:d} {:23.15E} {:d} {:23.15E} {:d} {:23.15E} \n'.format(nseg, currents[i].get_value(), Ifree, length, Lfree, length))
-            f.write('# NFcoil \n')
-            f.write('  {:d} \n'.format(nf))
-            f.write('# Fourier harmonics for coils ( xc; xs; yc; ys; zc; zs) \n')
+            f.write(f"#------------{i + 1:d}----------- \n")
+            f.write("# coil_type  symm  coil_name \n")
+            f.write(f"  {1:d}   {symm:d}  {curves[i].name} \n")
+            f.write("# Nseg current Ifree Length Lfree target_length \n")
+            f.write(
+                f"  {nseg:d} {currents[i].get_value():23.15E} {Ifree:d} {length:23.15E} {Lfree:d} {length:23.15E} \n"
+            )
+            f.write("# NFcoil \n")
+            f.write(f"  {nf:d} \n")
+            f.write("# Fourier harmonics for coils ( xc; xs; yc; ys; zc; zs) \n")
             for r in [xc, xs, yc, ys, zc, zs]:  # 6 lines
-                for k in range(nf+1):
-                    f.write('{:23.15E} '.format(r[k]))
-                f.write('\n')
-        f.write('\n')
+                for k in range(nf + 1):
+                    f.write(f"{r[k]:23.15E} ")
+                f.write("\n")
+        f.write("\n")
     return

--- a/src/simsopt/field/coil.py
+++ b/src/simsopt/field/coil.py
@@ -659,6 +659,7 @@ def coils_to_vtk(coils, filename, close=False, extra_data=None):
         ppl = np.asarray([c.gamma().shape[0] + 1 for c in curves])
     else:
         ppl = np.asarray([c.gamma().shape[0] for c in curves])
+    ppl_cumsum = np.concatenate([[0], np.cumsum(ppl)])
 
     # get the current data, which is the same at every point on a given coil
     contig = np.ascontiguousarray
@@ -666,7 +667,7 @@ def coils_to_vtk(coils, filename, close=False, extra_data=None):
     data = np.concatenate([i * np.ones((ppl[i],)) for i in range(len(curves))])
     coil_data = np.zeros(data.shape)
     for i in range(len(currents)):
-        coil_data[i * ppl[i]: (i + 1) * ppl[i]] = currents[i]
+        coil_data[ppl_cumsum[i]:ppl_cumsum[i + 1]] = currents[i]
     coil_data = np.ascontiguousarray(coil_data)
     pointData["I"] = coil_data
     pointData["I_mag"] = contig(np.abs(coil_data))
@@ -695,13 +696,13 @@ def coils_to_vtk(coils, filename, close=False, extra_data=None):
             if close:
                 coil_force_temp = np.vstack((coil_force_temp, coil_force_temp[0, :]))
                 coil_torque_temp = np.vstack((coil_torque_temp, coil_torque_temp[0, :]))
-            coil_forces[i * ppl[i]: (i + 1) * ppl[i], :] = coil_force_temp
-            coil_torques[i * ppl[i]: (i + 1) * ppl[i], :] = coil_torque_temp
+            coil_forces[ppl_cumsum[i]:ppl_cumsum[i + 1], :] = coil_force_temp
+            coil_torques[ppl_cumsum[i]:ppl_cumsum[i + 1], :] = coil_torque_temp
 
         # copy force and torque data over to pointwise data on a coil curve
         coil_data = np.zeros((data.shape[0], 3))
         for i in range(len(coils)):
-            coil_data[i * ppl[i]: (i + 1) * ppl[i], :] = net_forces[i, :]
+            coil_data[ppl_cumsum[i]:ppl_cumsum[i + 1], :] = net_forces[i, :]
         coil_data = np.ascontiguousarray(coil_data)
         pointData["NetForces"] = (
             contig(coil_data[:, 0]),
@@ -710,7 +711,7 @@ def coils_to_vtk(coils, filename, close=False, extra_data=None):
         )
         coil_data = np.zeros((data.shape[0], 3))
         for i in range(len(coils)):
-            coil_data[i * ppl[i]: (i + 1) * ppl[i], :] = net_torques[i, :]
+            coil_data[ppl_cumsum[i]:ppl_cumsum[i + 1], :] = net_torques[i, :]
         coil_data = np.ascontiguousarray(coil_data)
 
         # Add pointwise force and torque data to the dictionary

--- a/src/simsopt/field/selffield.py
+++ b/src/simsopt/field/selffield.py
@@ -2,13 +2,13 @@
 This module contains functions for computing the self-field of a coil using the
 methods from:
 
-    Hurwitz, Siena, Matt Landreman, and Thomas M. Antonsen. 
-    "Efficient calculation of the self magnetic field, self-force, and self-inductance for 
+    Hurwitz, Siena, Matt Landreman, and Thomas M. Antonsen.
+    "Efficient calculation of the self magnetic field, self-force, and self-inductance for
     electromagnetic coils." IEEE Transactions on Magnetics (2024).
 
-    Landreman, Matt, Siena Hurwitz, and Thomas M. Antonsen. 
-    "Efficient calculation of self magnetic field, self-force, and self-inductance for 
-    electromagnetic coils with rectangular cross-section." 
+    Landreman, Matt, Siena Hurwitz, and Thomas M. Antonsen.
+    "Efficient calculation of self magnetic field, self-force, and self-inductance for
+    electromagnetic coils with rectangular cross-section."
     Nuclear Fusion 65.3 (2025): 036008.
 
 """
@@ -20,7 +20,7 @@ from ..geo.jit import jit
 
 Biot_savart_prefactor = constants.mu_0 / (4 * np.pi)
 
-__all__ = ['B_regularized_pure', 'regularization_rect', 'regularization_circ']
+__all__ = ["B_regularized_pure", "regularization_rect", "regularization_circ"]
 
 
 def _rectangular_xsection_k(a, b):
@@ -30,7 +30,7 @@ def _rectangular_xsection_k(a, b):
         k = \frac{4 b}{3 a} \arctan \left( \frac a b \right) + \frac{4 a}{3 b} \arctan \left( \frac b a \right) + \frac{b^2}{6 a^2} \log \left( \frac b a \right) + \frac{a^2}{6 b^2} \log \left( \frac a b \right) - \frac{a^4 - 6 a^2 b^2 + b^4}{6 a^2 b^2} \log \left( \frac a b + \frac b a \right)
 
     where a is the width of the rectangular conductor and b is the height.
-    
+
     Args:
         a (float): The width of the rectangular conductor.
         b (float): The height of the rectangular conductor.
@@ -38,9 +38,13 @@ def _rectangular_xsection_k(a, b):
     Returns:
         float: The regularization parameter.
     """
-    return (4 * b) / (3 * a) * jnp.arctan(a/b) + (4*a)/(3*b)*jnp.arctan(b/a) + \
-        (b**2)/(6*a**2)*jnp.log(b/a) + (a**2)/(6*b**2)*jnp.log(a/b) - \
-        (a**4 - 6*a**2*b**2 + b**4)/(6*a**2*b**2)*jnp.log(a/b+b/a)
+    return (
+        (4 * b) / (3 * a) * jnp.arctan(a / b)
+        + (4 * a) / (3 * b) * jnp.arctan(b / a)
+        + (b**2) / (6 * a**2) * jnp.log(b / a)
+        + (a**2) / (6 * b**2) * jnp.log(a / b)
+        - (a**4 - 6 * a**2 * b**2 + b**4) / (6 * a**2 * b**2) * jnp.log(a / b + b / a)
+    )
 
 
 def _rectangular_xsection_delta(a, b):
@@ -49,7 +53,7 @@ def _rectangular_xsection_delta(a, b):
     .. math::
         \delta = \exp \left( - \frac{25}{6} + K \right)
     where K is the auxiliary function defined above.
-    
+
     Args:
         a (float): The width of the rectangular conductor.
         b (float): The height of the rectangular conductor.
@@ -57,7 +61,7 @@ def _rectangular_xsection_delta(a, b):
     Returns:
         float: The regularization parameter.
     """
-    return jnp.exp(-25/6 + _rectangular_xsection_k(a, b))
+    return jnp.exp(-25 / 6 + _rectangular_xsection_k(a, b))
 
 
 def regularization_circ(a):
@@ -94,6 +98,7 @@ def regularization_rect(a, b):
     """
     return a * b * _rectangular_xsection_delta(a, b)
 
+
 @jit
 def B_regularized_singularity_term(rc_prime, rc_prime_prime, regularization):
     """The term in the regularized Biot-Savart law in which the near-singularity
@@ -108,16 +113,23 @@ def B_regularized_singularity_term(rc_prime, rc_prime_prime, regularization):
     2π, not up to 1.
     """
     norm_rc_prime = jnp.linalg.norm(rc_prime, axis=1)
-    return jnp.cross(rc_prime, rc_prime_prime) * (
-        0.5 * (-2 + jnp.log(64 * norm_rc_prime * norm_rc_prime / regularization)) / (norm_rc_prime**3)
-    )[:, None]
+    return (
+        jnp.cross(rc_prime, rc_prime_prime)
+        * (
+            0.5
+            * (-2 + jnp.log(64 * norm_rc_prime * norm_rc_prime / regularization))
+            / (norm_rc_prime**3)
+        )[:, None]
+    )
 
 
 @jit
-def B_regularized_pure(gamma, gammadash, gammadashdash, quadpoints, current, regularization):
+def B_regularized_pure(
+    gamma, gammadash, gammadashdash, quadpoints, current, regularization
+):
     """
     Compute the regularized field on a coil following the Landreman and Hurwitz method
-    
+
     Args:
         gamma (array (shape (n,3))): The curve of the coil.
         gammadash (array (shape (n,3))): The first derivative of the curve.
@@ -137,13 +149,221 @@ def B_regularized_pure(gamma, gammadash, gammadashdash, quadpoints, current, reg
     rc_prime = gammadash / 2 / jnp.pi
     rc_prime_prime = gammadashdash / 4 / jnp.pi**2
     dphi = 2 * jnp.pi / phi.shape[0]
-    analytic_term = B_regularized_singularity_term(rc_prime, rc_prime_prime, regularization)
+    analytic_term = B_regularized_singularity_term(
+        rc_prime, rc_prime_prime, regularization
+    )
     dr = rc[:, None] - rc[None, :]
-    first_term = jnp.cross(rc_prime[None, :], dr) / ((jnp.sum(dr * dr, axis=2) + regularization) ** 1.5)[:, :, None]
+    first_term = (
+        jnp.cross(rc_prime[None, :], dr)
+        / ((jnp.sum(dr * dr, axis=2) + regularization) ** 1.5)[:, :, None]
+    )
     cos_fac = 2.0 - 2.0 * jnp.cos(phi[None, :] - phi[:, None])
-    second_term = jnp.cross(rc_prime_prime, rc_prime)[:, None, :] * (
-        0.5 * cos_fac / (cos_fac * jnp.sum(rc_prime * rc_prime, axis=1)[:, None] + regularization)**1.5)[:, :, None]
+    second_term = (
+        jnp.cross(rc_prime_prime, rc_prime)[:, None, :]
+        * (
+            0.5
+            * cos_fac
+            / (cos_fac * jnp.sum(rc_prime * rc_prime, axis=1)[:, None] + regularization)
+            ** 1.5
+        )[:, :, None]
+    )
     integral_term = dphi * jnp.sum(first_term + second_term, 1)
     return current * Biot_savart_prefactor * (analytic_term + integral_term)
 
 
+@jit
+def B_bimpl(a, b, current, gammadash, gammadashdash):
+    """
+    Compute B_b on a coil following the Landreman and Hurwitz method (equation 21)
+
+    Args:
+        a, b  (float) : width and height of the conductor
+        current (float): The current in the coil.
+        gammadash (array (shape (n,3))): The first derivative of the curve.
+        gammadashdash (array (shape (n,3))): The second derivative of the curve.
+
+        The factors of 2π in the next few lines come from the fact that simsopt
+        uses a curve parameter that goes up to 1 rather than 2π.
+
+    Returns:
+        array (shape (n,3)): Bb field on the coil.
+    """
+
+    rc_prime = gammadash / (2 * jnp.pi)
+    rc_prime_prime = gammadashdash / (4 * jnp.pi**2)
+
+    norm_rc_prime = jnp.linalg.norm(rc_prime, axis=1, keepdims=True)
+    delta = _rectangular_xsection_delta(a, b)
+
+    prefac = current * Biot_savart_prefactor * (2 + jnp.log(2) + jnp.log(delta))
+
+    return prefac * jnp.cross(rc_prime, rc_prime_prime) / (norm_rc_prime**3)
+
+
+def G_func(x, y):
+    """
+    Compute G function in the Landreman and Hurwitz method (formula 18) used in B0 computation
+    """
+
+    return y * jnp.arctan(x / y) + 0.5 * x * jnp.log(1 + (y * y) / (x * x))
+
+
+@jit
+def compute_frame(gamma, gammadash):
+    """
+    Compute t, p, q vectors (local cross-section coordinates) using equation (40) of Landreman (2025).
+    See also figure 3 on the paper for conventions
+
+    Args:
+        gamma (array (n,3)): coil curve
+        gammadash (array (n,3)): first derivative of the curve
+
+    Returns:
+        p (array (n,3))
+        q (array (n,3))
+        t (array (n,3))
+    """
+    rc_prime = gammadash / 2 / jnp.pi
+
+    # unit tangent
+    t = rc_prime / jnp.linalg.norm(rc_prime, axis=1)[:, None]
+
+    # centroid of the coil
+    C = jnp.mean(gamma, axis=0)
+
+    # vector from centroid
+    w = gamma - C
+
+    # remove tangent component
+    w_perp = w - (jnp.sum(w * t, axis=1)[:, None]) * t
+
+    # normalize
+    p = w_perp / jnp.linalg.norm(w_perp, axis=1)[:, None]
+
+    # second perpendicular direction
+    q = jnp.cross(t, p)
+
+    return t, p, q
+
+
+@jit
+def B0_impl(u, v, a, b, current, p, q):
+    """
+
+    Compute B0 (formaula 17) on a coil following the Landreman and Hurwitz method
+
+    The derivatives rc_prime, rc_prime_prime refer to an angle that goes up to
+    2π, not up to 1.
+
+    Args:
+        u,v (floats, norm(u)<1, norm(v)<1) : position on the rectangular cross-section (see formula 6)
+        a (float): The width of the rectangular conductor.
+        b (float): The height of the rectangular conductor.
+        current (float) : current in the conductor
+        p,q (array (n,3)) : local coordinates on the cross section
+
+    Returns:
+        array (shape (n,3)): The magnetic field Bb (formula 21) on the coil."""
+
+    su = jnp.array([-1.0, 1.0])
+    sv = jnp.array([-1.0, 1.0])
+
+    U = u[None, None, :] - su[:, None, None]  # (2,1,n)
+    V = v[None, None, :] - sv[None, :, None]  # (1,2,n)
+
+    G1 = G_func(b * V, a * U)[..., None]  # (2,2,n,1)
+    G2 = G_func(a * U, b * V)[..., None]
+
+    term = G1 * q - G2 * p  # broadcast (2,2,n,3)
+
+    sign = (su[:, None] * sv[None, :])[..., None, None]  # (2,2,1,1)
+
+    B = jnp.sum(sign * term, axis=(0, 1))  # (n,3)
+
+    return current * Biot_savart_prefactor / (a * b) * B
+
+
+@jit
+def K_func(a, b, U, V, rc_prime, rc_prime_prime, t, p, q):
+
+    norm_rc_prime = jnp.linalg.norm(rc_prime, axis=1, keepdims=True)
+    kappa_b = jnp.cross(rc_prime, rc_prime_prime) / (norm_rc_prime**3)
+
+    kappa_1 = jnp.sum(kappa_b * q, axis=1, keepdims=True)
+    kappa_2 = jnp.sum(-kappa_b * p, axis=1, keepdims=True)
+
+    U = U[:, None]
+    V = V[:, None]
+
+    base = a * U**2 / b + b * V**2 / a
+    log_term = jnp.log(base)
+
+    return (
+        -2 * U * V * kappa_b * log_term
+        + kappa_b * base * log_term
+        + 4 * a * U**2 * kappa_2 * p * jnp.arctan(b * V / (a * U)) / b
+        + 4 * b * V**2 * kappa_1 * q * jnp.arctan(a * U / (b * V)) / a
+    )
+
+
+@jit
+def Bkappa_impl(u, v, a, b, current, gammadash, gammadashdash, t, p, q):
+    """
+    Computes Bkappa (formula 19)
+
+    Args:
+        u,v (floats, norm(u)<1, norm(v)<1) : position on the rectangular cross-section (see formula 6)
+        a (float): The width of the rectangular conductor.
+        b (float): The height of the rectangular conductor.
+        current (float) : current in the conductor
+        gammadash (array (shape (n,3))): The first derivative of the curve.
+        gammadashdash (array (shape (n,3))): The second derivative of the curve.
+        t,p,q (array (n,3)) : local coordinates on the cross section
+
+    returns:
+        array(n,3), Bkappa field
+    """
+
+    rc_prime = gammadash / 2 / jnp.pi
+    rc_prime_prime = gammadashdash / 4 / jnp.pi**2
+
+    B = jnp.zeros_like(p)
+
+    for su in [-1, 1]:
+        for sv in [-1, 1]:
+            U = u - su
+            V = v - sv
+
+            term = K_func(a, b, U, V, rc_prime, rc_prime_prime, t, p, q)
+
+            B += su * sv * term
+
+    return current * Biot_savart_prefactor / 16 * B
+
+
+def B_total_impl(
+    gamma,
+    gamma_dash,
+    gamma_dashdash,
+    quadpoints,
+    u,
+    v,
+    a,
+    b,
+    t,
+    p,
+    q,
+    current,
+    regularization,
+):
+    """
+    Compute the total field using B_regularized, B0, Bkappa and Bb
+    """
+    return (
+        B_regularized_pure(
+            gamma, gamma_dash, gamma_dashdash, quadpoints, current, regularization
+        )
+        + B0_impl(u, v, a, b, current, p, q)
+        + Bkappa_impl(u, v, a, b, current, gamma_dash, gamma_dashdash, t, p, q)
+        + B_bimpl(a, b, current, gamma_dash, gamma_dashdash)
+    )

--- a/tests/field/test_selffieldforces.py
+++ b/tests/field/test_selffieldforces.py
@@ -563,9 +563,6 @@ class CoilForcesTest(unittest.TestCase):
             )
             np.testing.assert_allclose(force_test[:, 2], 0.0)
 
-            # MODIFICATION: Full B-Field Evaluation Integration Tests
-            # =================================================================
-            # Pass as 1D arrays of size 1 so that your `u[None, None, :]` slicing works perfectly!
             u_scalar = jnp.array([0.5])
             v_scalar = jnp.array([-0.2])
 

--- a/tests/field/test_selffieldforces.py
+++ b/tests/field/test_selffieldforces.py
@@ -5,10 +5,15 @@ import numpy as np
 from scipy import constants
 from scipy.interpolate import interp1d
 from scipy.special import ellipk, ellipe
+import jax.numpy as jnp
 
 from simsopt.field import (
-    Coil, RegularizedCoil, CircularRegularizedCoil, RectangularRegularizedCoil, 
-    Current, coils_via_symmetries,
+    Coil,
+    RegularizedCoil,
+    CircularRegularizedCoil,
+    RectangularRegularizedCoil,
+    Current,
+    coils_via_symmetries,
     _coil_coil_inductances_pure,
     _coil_coil_inductances_inv_pure,
     _induced_currents_pure,
@@ -21,7 +26,12 @@ from simsopt.field import (
 )
 from simsopt.geo.curve import create_equally_spaced_curves
 from simsopt.configs import get_data
-from simsopt.geo import CurveXYZFourier, JaxCurveXYZFourier, CurvePlanarFourier, JaxCurvePlanarFourier
+from simsopt.geo import (
+    CurveXYZFourier,
+    JaxCurveXYZFourier,
+    CurvePlanarFourier,
+    JaxCurvePlanarFourier,
+)
 from simsopt.field.selffield import (
     _rectangular_xsection_k,
     _rectangular_xsection_delta,
@@ -72,14 +82,22 @@ class SpecialFunctionsTests(unittest.TestCase):
                 # a >> b
                 b = x
                 a = b * ratio
-                np.testing.assert_allclose(_rectangular_xsection_k(a, b), (7.0 / 6) + np.log(a / b), rtol=1e-3)
-                np.testing.assert_allclose(_rectangular_xsection_delta(a, b), a / (b * np.exp(3)), rtol=1e-3)
+                np.testing.assert_allclose(
+                    _rectangular_xsection_k(a, b), (7.0 / 6) + np.log(a / b), rtol=1e-3
+                )
+                np.testing.assert_allclose(
+                    _rectangular_xsection_delta(a, b), a / (b * np.exp(3)), rtol=1e-3
+                )
 
                 # b >> a
                 a = x
                 b = ratio * a
-                np.testing.assert_allclose(_rectangular_xsection_k(a, b), (7.0 / 6) + np.log(b / a), rtol=1e-3)
-                np.testing.assert_allclose(_rectangular_xsection_delta(a, b), b / (a * np.exp(3)), rtol=1e-3)
+                np.testing.assert_allclose(
+                    _rectangular_xsection_k(a, b), (7.0 / 6) + np.log(b / a), rtol=1e-3
+                )
+                np.testing.assert_allclose(
+                    _rectangular_xsection_delta(a, b), b / (a * np.exp(3)), rtol=1e-3
+                )
 
     def test_regularization_circ(self):
         """Test regularization_circ function."""
@@ -87,21 +105,21 @@ class SpecialFunctionsTests(unittest.TestCase):
         reg_circ = regularization_circ(a)
         expected = a**2 / np.sqrt(np.e)
         np.testing.assert_allclose(reg_circ, expected, rtol=1e-10)
-        
+
         # Test with different radius
         a2 = 0.05
         reg_circ2 = regularization_circ(a2)
         expected2 = a2**2 / np.sqrt(np.e)
         np.testing.assert_allclose(reg_circ2, expected2, rtol=1e-10)
-        
+
         # Verify scaling: should scale as a^2
-        np.testing.assert_allclose(reg_circ2 / reg_circ, (a2 / a)**2, rtol=1e-10)
+        np.testing.assert_allclose(reg_circ2 / reg_circ, (a2 / a) ** 2, rtol=1e-10)
 
     def test_regularization_rect(self):
         """Test regularization_rect function."""
         a = 0.01
         b = 0.023
-        
+
         # Test square cross-section
         reg_rect_square = regularization_rect(a, a)
         reg_circ_equiv = regularization_circ(a)
@@ -109,28 +127,29 @@ class SpecialFunctionsTests(unittest.TestCase):
         # (not exact, but should be similar order of magnitude)
         assert reg_rect_square > 0
         assert reg_circ_equiv > 0
-        
+
         # Test rectangular cross-section
         reg_rect = regularization_rect(a, b)
         expected_delta = _rectangular_xsection_delta(a, b)
         expected = a * b * expected_delta
         np.testing.assert_allclose(reg_rect, expected, rtol=1e-10)
-        
+
         # Test symmetry: should be same if a and b are swapped
         reg_rect_swapped = regularization_rect(b, a)
         np.testing.assert_allclose(reg_rect, reg_rect_swapped, rtol=1e-10)
-        
+
         # Test with different dimensions
         a2 = 0.02
         b2 = 0.03
         reg_rect2 = regularization_rect(a2, b2)
         assert reg_rect2 > 0
         # Should scale roughly with area
-        assert reg_rect2 > reg_rect  # Larger dimensions should give larger regularization
+        assert (
+            reg_rect2 > reg_rect
+        )  # Larger dimensions should give larger regularization
 
 
 class CoilForcesTest(unittest.TestCase):
-
     def test_circular_coil(self):
         """Check whether B_reg and hoop force on a circular-centerline coil are correct."""
         R0 = 1.7
@@ -143,36 +162,46 @@ class CoilForcesTest(unittest.TestCase):
         d = 5.0
 
         # Analytic field has only a z component
-        B_reg_analytic_circ = constants.mu_0 * I / (4 * np.pi * R0) * (np.log(8 * R0 / a) - 3 / 4)
+        B_reg_analytic_circ = (
+            constants.mu_0 * I / (4 * np.pi * R0) * (np.log(8 * R0 / a) - 3 / 4)
+        )
         force_analytic_circ = B_reg_analytic_circ * I
 
         # For two concentric circular coils, only "analytic" for R1 >> R0
-        Lij_analytic = constants.mu_0 * np.pi * R0 ** 2 / (2 * R1)
+        Lij_analytic = constants.mu_0 * np.pi * R0**2 / (2 * R1)
         # self_inductance_analytic = constants.mu_0 * R0 * (np.log(8 * R0 / a) - 7.0 / 4.0)
 
         # For two coils that share a common axis
-        k = np.sqrt(4.0 * R0 * R2 / ((R0 + R2) ** 2 + d ** 2))
-        Lij_analytic2 = constants.mu_0 * np.sqrt(R0 * R2) * (
-            (2 / k - k) * ellipk(k ** 2) - (2 / k) * ellipe(k ** 2)
+        k = np.sqrt(4.0 * R0 * R2 / ((R0 + R2) ** 2 + d**2))
+        Lij_analytic2 = (
+            constants.mu_0
+            * np.sqrt(R0 * R2)
+            * ((2 / k - k) * ellipk(k**2) - (2 / k) * ellipe(k**2))
         )
 
         # Eq (98) in Landreman Hurwitz Antonsen:
-        B_reg_analytic_rect = constants.mu_0 * I / (4 * np.pi * R0) * (
-            np.log(8 * R0 / np.sqrt(a * b)) + 13.0 / 12 - _rectangular_xsection_k(a, b) / 2
+        B_reg_analytic_rect = (
+            constants.mu_0
+            * I
+            / (4 * np.pi * R0)
+            * (
+                np.log(8 * R0 / np.sqrt(a * b))
+                + 13.0 / 12
+                - _rectangular_xsection_k(a, b) / 2
+            )
         )
         force_analytic_rect = B_reg_analytic_rect * I
 
         # Very large number of quadrature points is required to accurately compute the self-inductance
-        # so need to implement Siena's fast quadrature scheme. Not testing the self-inductance here 
+        # so need to implement Siena's fast quadrature scheme. Not testing the self-inductance here
         # for that reason.
         for N_quad in [500]:
             for downsample in [2, 3, 4]:
-
                 # Create a circle of radius R0 in the x-y plane:
                 curve = CurveXYZFourier(N_quad, order)
-                curve.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * R0
+                curve.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * R0
                 curve2 = CurveXYZFourier(N_quad, order)
-                curve2.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * R0
+                curve2.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * R0
                 phi = 2 * np.pi * curve.quadpoints
 
                 current = Current(I)
@@ -185,8 +214,12 @@ class CoilForcesTest(unittest.TestCase):
 
                 # Test self-force for circular coil
                 force_test = coil.self_force()
-                np.testing.assert_allclose(force_test[:, 0], force_analytic_circ * np.cos(phi))
-                np.testing.assert_allclose(force_test[:, 1], force_analytic_circ * np.sin(phi))
+                np.testing.assert_allclose(
+                    force_test[:, 0], force_analytic_circ * np.cos(phi)
+                )
+                np.testing.assert_allclose(
+                    force_test[:, 1], force_analytic_circ * np.sin(phi)
+                )
                 np.testing.assert_allclose(force_test[:, 2], 0.0)
 
                 # Test self-torque for circular coil (should be zero by symmetry)
@@ -228,7 +261,7 @@ class CoilForcesTest(unittest.TestCase):
                 curve3 = CurvePlanarFourier(N_quad, 0)
                 dofs3 = np.zeros(8)
                 dofs3[0] = R2
-                dofs3[1] = np.cos(alpha / 2.0) * np.cos(delta / 2.0)    
+                dofs3[1] = np.cos(alpha / 2.0) * np.cos(delta / 2.0)
                 dofs3[2] = np.sin(alpha / 2.0) * np.cos(delta / 2.0)
                 dofs3[3] = np.cos(alpha / 2.0) * np.sin(delta / 2.0)
                 dofs3[4] = -np.sin(alpha / 2.0) * np.sin(delta / 2.0)
@@ -242,7 +275,9 @@ class CoilForcesTest(unittest.TestCase):
                     np.array([curve.gamma(), curve2.gamma()]),
                     np.array([curve.gammadash(), curve2.gammadash()]),
                     downsample=downsample,
-                    regularizations=np.array([regularization_circ(a), regularization_circ(a)]),
+                    regularizations=np.array(
+                        [regularization_circ(a), regularization_circ(a)]
+                    ),
                 )
                 np.testing.assert_allclose(Lij[1, 0], Lij_analytic, rtol=1e-2)
                 # np.testing.assert_allclose(Lij[0, 0], self_inductance_analytic, rtol=1e-2)
@@ -251,34 +286,48 @@ class CoilForcesTest(unittest.TestCase):
                     np.array([curve.gamma(), curve2.gamma()]),
                     np.array([curve.gammadash(), curve2.gammadash()]),
                     downsample=1,
-                    regularizations=np.array([regularization_circ(a), regularization_circ(a)]),
+                    regularizations=np.array(
+                        [regularization_circ(a), regularization_circ(a)]
+                    ),
                 )
                 # Only off-diagonal will agree because self-inductance accuracy needs many more quadrature points
-                np.testing.assert_allclose(Lij_no_downsample[1, 0], Lij[1, 0], rtol=1e-2)
+                np.testing.assert_allclose(
+                    Lij_no_downsample[1, 0], Lij[1, 0], rtol=1e-2
+                )
 
                 # Test rectangular cross section for a << R
                 Lij_rect = _coil_coil_inductances_pure(
                     np.array([curve.gamma(), curve2.gamma()]),
                     np.array([curve.gammadash(), curve2.gammadash()]),
                     downsample=downsample,
-                    regularizations=np.array([regularization_rect(a, b), regularization_rect(a, b)]),
+                    regularizations=np.array(
+                        [regularization_rect(a, b), regularization_rect(a, b)]
+                    ),
                 )
-                np.testing.assert_allclose(Lij_rect[1, 0], Lij[1, 0], rtol=1e-2)  # rectangular is not so different from circular
+                np.testing.assert_allclose(
+                    Lij_rect[1, 0], Lij[1, 0], rtol=1e-2
+                )  # rectangular is not so different from circular
 
                 Lij_rect_no_downsample = _coil_coil_inductances_pure(
                     np.array([curve.gamma(), curve2.gamma()]),
                     np.array([curve.gammadash(), curve2.gammadash()]),
                     downsample=1,
-                    regularizations=np.array([regularization_rect(a, b), regularization_rect(a, b)]),
+                    regularizations=np.array(
+                        [regularization_rect(a, b), regularization_rect(a, b)]
+                    ),
                 )
-                np.testing.assert_allclose(Lij_rect_no_downsample[1, 0], Lij_rect[1, 0], rtol=1e-2)
+                np.testing.assert_allclose(
+                    Lij_rect_no_downsample[1, 0], Lij_rect[1, 0], rtol=1e-2
+                )
 
                 # retry but swap the coils
                 Lji = _coil_coil_inductances_pure(
                     np.array([curve2.gamma(), curve.gamma()]),
                     np.array([curve2.gammadash(), curve.gammadash()]),
                     downsample=downsample,
-                    regularizations=np.array([regularization_circ(a), regularization_circ(a)]),
+                    regularizations=np.array(
+                        [regularization_circ(a), regularization_circ(a)]
+                    ),
                 )
                 print(Lij)
                 print(Lji)
@@ -292,7 +341,9 @@ class CoilForcesTest(unittest.TestCase):
                     [curve.gamma(), curve3.gamma()],
                     [curve.gammadash(), curve3.gammadash()],
                     downsample=downsample,
-                    regularizations=np.array([regularization_circ(a), regularization_circ(a)]),
+                    regularizations=np.array(
+                        [regularization_circ(a), regularization_circ(a)]
+                    ),
                 )
                 np.testing.assert_allclose(Lij3[1, 0], Lij_analytic2, rtol=1e-2)
 
@@ -300,11 +351,15 @@ class CoilForcesTest(unittest.TestCase):
                     [curve.gamma(), curve3.gamma()],
                     [curve.gammadash(), curve3.gammadash()],
                     downsample=1,
-                    regularizations=np.array([regularization_circ(a), regularization_circ(a)]),
+                    regularizations=np.array(
+                        [regularization_circ(a), regularization_circ(a)]
+                    ),
                 )
-                np.testing.assert_allclose(Lij3[1, 0], Lij3_no_downsample[1, 0], rtol=1e-2)
+                np.testing.assert_allclose(
+                    Lij3[1, 0], Lij3_no_downsample[1, 0], rtol=1e-2
+                )
 
-                # This function is really for passive coils 
+                # This function is really for passive coils
                 # but just checking we can compute the induced currents correctly
                 induced_currents_test = _induced_currents_pure(
                     np.array([curve.gamma()]),
@@ -322,7 +377,9 @@ class CoilForcesTest(unittest.TestCase):
                     [curve.gamma(), curve3.gamma()],
                     [curve.gammadash(), curve3.gammadash()],
                     downsample=downsample,
-                    regularizations=np.array([regularization_circ(a), regularization_circ(a)]),
+                    regularizations=np.array(
+                        [regularization_circ(a), regularization_circ(a)]
+                    ),
                 )
                 assert np.allclose(np.linalg.inv(Lij3), Lij_inv)
 
@@ -333,8 +390,12 @@ class CoilForcesTest(unittest.TestCase):
                 np.testing.assert_allclose(B_reg_test[:, 0:2], 0)
 
                 force_test = coil_rect.self_force()
-                np.testing.assert_allclose(force_test[:, 0], force_analytic_rect * np.cos(phi))
-                np.testing.assert_allclose(force_test[:, 1], force_analytic_rect * np.sin(phi))
+                np.testing.assert_allclose(
+                    force_test[:, 0], force_analytic_rect * np.cos(phi)
+                )
+                np.testing.assert_allclose(
+                    force_test[:, 1], force_analytic_rect * np.sin(phi)
+                )
                 np.testing.assert_allclose(force_test[:, 2], 0.0)
 
                 # Test self-torque for rectangular cross-section coil (should also be zero by symmetry)
@@ -345,13 +406,17 @@ class CoilForcesTest(unittest.TestCase):
                 # --- Two concentric circular coils: test mutual torque ---
                 # Both in xy-plane, same center, different radii
                 curve_inner = CurveXYZFourier(N_quad, order)
-                curve_inner.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * R0
+                curve_inner.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * R0
                 curve_outer = CurveXYZFourier(N_quad, order)
-                curve_outer.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * R1
+                curve_outer.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * R1
                 current_inner = Current(I)
                 current_outer = Current(I)
-                coil_inner = RegularizedCoil(curve_inner, current_inner, regularization_circ(a))
-                coil_outer = RegularizedCoil(curve_outer, current_outer, regularization_circ(a))
+                coil_inner = RegularizedCoil(
+                    curve_inner, current_inner, regularization_circ(a)
+                )
+                coil_outer = RegularizedCoil(
+                    curve_outer, current_outer, regularization_circ(a)
+                )
                 # Compute torque on each coil due to both
                 torque_inner = coil_inner.torque([coil_inner, coil_outer])
                 torque_outer = coil_outer.torque([coil_inner, coil_outer])
@@ -369,8 +434,12 @@ class CoilForcesTest(unittest.TestCase):
                 np.testing.assert_allclose(val2, 0.0, atol=1e-1)
 
                 # --- Net force on each coil should also be zero ---
-                net_force_inner = np.sum(coil_inner.force([coil_inner, coil_outer]), axis=0)
-                net_force_outer = np.sum(coil_outer.force([coil_inner, coil_outer]), axis=0)
+                net_force_inner = np.sum(
+                    coil_inner.force([coil_inner, coil_outer]), axis=0
+                )
+                net_force_outer = np.sum(
+                    coil_outer.force([coil_inner, coil_outer]), axis=0
+                )
                 np.testing.assert_allclose(net_force_inner, 0.0, atol=1e-6)
                 np.testing.assert_allclose(net_force_outer, 0.0, atol=1e-6)
 
@@ -386,7 +455,7 @@ class CoilForcesTest(unittest.TestCase):
 
                 # --- JAX CurveXYZFourier: check equivalence ---
                 jax_curve = JaxCurveXYZFourier(N_quad, order)
-                jax_curve.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * R0
+                jax_curve.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * R0
                 jax_coil = RegularizedCoil(jax_curve, current, regularization_circ(a))
                 # B_regularized_circ
                 B_reg_jax = jax_coil.B_regularized()
@@ -396,7 +465,9 @@ class CoilForcesTest(unittest.TestCase):
                 np.testing.assert_allclose(force_jax, force_test, rtol=1e-2, atol=1e-12)
                 # self-torque
                 torque_jax = jax_coil.torque([jax_coil])
-                np.testing.assert_allclose(torque_jax, torque_test, rtol=1e-2, atol=1e-10)
+                np.testing.assert_allclose(
+                    torque_jax, torque_test, rtol=1e-2, atol=1e-10
+                )
 
                 # --- JAX CurvePlanarFourier: check equivalence ---
                 jax_curve_p = JaxCurvePlanarFourier(N_quad, 0)
@@ -406,16 +477,26 @@ class CoilForcesTest(unittest.TestCase):
                 jax_curve3_p = JaxCurvePlanarFourier(N_quad, 0)
                 jax_curve3_p.set_dofs(dofs3)
                 # Check JAX and non-JAX curves are equivalent
-                np.testing.assert_allclose(jax_curve_p.gamma(), curve.gamma(), rtol=1e-12, atol=1e-12)
-                np.testing.assert_allclose(jax_curve_p.gammadash(), curve.gammadash(), rtol=1e-12, atol=1e-12)
-                np.testing.assert_allclose(jax_curve2_p.gamma(), curve2.gamma(), rtol=1e-12, atol=1e-12)
-                np.testing.assert_allclose(jax_curve2_p.gammadash(), curve2.gammadash(), rtol=1e-12, atol=1e-12)
+                np.testing.assert_allclose(
+                    jax_curve_p.gamma(), curve.gamma(), rtol=1e-12, atol=1e-12
+                )
+                np.testing.assert_allclose(
+                    jax_curve_p.gammadash(), curve.gammadash(), rtol=1e-12, atol=1e-12
+                )
+                np.testing.assert_allclose(
+                    jax_curve2_p.gamma(), curve2.gamma(), rtol=1e-12, atol=1e-12
+                )
+                np.testing.assert_allclose(
+                    jax_curve2_p.gammadash(), curve2.gammadash(), rtol=1e-12, atol=1e-12
+                )
                 # Inductance
                 Lij_jax = _coil_coil_inductances_pure(
                     np.array([jax_curve_p.gamma(), jax_curve2_p.gamma()]),
                     np.array([jax_curve_p.gammadash(), jax_curve2_p.gammadash()]),
                     downsample=downsample,
-                    regularizations=np.array([regularization_circ(a), regularization_circ(a)]),
+                    regularizations=np.array(
+                        [regularization_circ(a), regularization_circ(a)]
+                    ),
                 )
                 np.testing.assert_allclose(Lij_jax, Lij, rtol=1e-2, atol=1e-12)
                 # Rectangular cross section
@@ -423,20 +504,32 @@ class CoilForcesTest(unittest.TestCase):
                     np.array([jax_curve_p.gamma(), jax_curve2_p.gamma()]),
                     np.array([jax_curve_p.gammadash(), jax_curve2_p.gammadash()]),
                     downsample=downsample,
-                    regularizations=np.array([regularization_rect(a, b), regularization_rect(a, b)]),
+                    regularizations=np.array(
+                        [regularization_rect(a, b), regularization_rect(a, b)]
+                    ),
                 )
-                np.testing.assert_allclose(Lij_rect_jax, Lij_rect, rtol=1e-2, atol=1e-12)
+                np.testing.assert_allclose(
+                    Lij_rect_jax, Lij_rect, rtol=1e-2, atol=1e-12
+                )
                 # B_regularized_rect
-                jax_coil_rect = RegularizedCoil(jax_curve_p, current, regularization_rect(a, b))
+                jax_coil_rect = RegularizedCoil(
+                    jax_curve_p, current, regularization_rect(a, b)
+                )
                 B_reg_rect_jax = jax_coil_rect.B_regularized()
-                np.testing.assert_allclose(B_reg_rect_jax, B_reg_test, rtol=1e-2, atol=1e-12)
+                np.testing.assert_allclose(
+                    B_reg_rect_jax, B_reg_test, rtol=1e-2, atol=1e-12
+                )
                 # self_force_rect
                 force_rect_jax = jax_coil_rect.self_force()
-                np.testing.assert_allclose(force_rect_jax, force_test, rtol=1e-2, atol=1e-12)
+                np.testing.assert_allclose(
+                    force_rect_jax, force_test, rtol=1e-2, atol=1e-12
+                )
                 # self-torque rect
                 torque_rect_jax = jax_coil_rect.torque([jax_coil_rect])
-                np.testing.assert_allclose(torque_rect_jax, torque_test_rect, rtol=1e-2, atol=1e-10)
-            
+                np.testing.assert_allclose(
+                    torque_rect_jax, torque_test_rect, rtol=1e-2, atol=1e-10
+                )
+
             current = Current(I)
             _ = Coil(curve, current)
 
@@ -447,8 +540,12 @@ class CoilForcesTest(unittest.TestCase):
             np.testing.assert_allclose(B_reg_test[:, 0:2], 0)
 
             force_test = coil_circ.self_force()
-            np.testing.assert_allclose(force_test[:, 0], force_analytic_circ * np.cos(phi))
-            np.testing.assert_allclose(force_test[:, 1], force_analytic_circ * np.sin(phi))
+            np.testing.assert_allclose(
+                force_test[:, 0], force_analytic_circ * np.cos(phi)
+            )
+            np.testing.assert_allclose(
+                force_test[:, 1], force_analytic_circ * np.sin(phi)
+            )
             np.testing.assert_allclose(force_test[:, 2], 0.0)
 
             # Check the case of rectangular cross-section:
@@ -458,15 +555,49 @@ class CoilForcesTest(unittest.TestCase):
             np.testing.assert_allclose(B_reg_test[:, 0:2], 0)
 
             force_test = coil_rect.self_force()
-            np.testing.assert_allclose(force_test[:, 0], force_analytic_rect * np.cos(phi))
-            np.testing.assert_allclose(force_test[:, 1], force_analytic_rect * np.sin(phi))
+            np.testing.assert_allclose(
+                force_test[:, 0], force_analytic_rect * np.cos(phi)
+            )
+            np.testing.assert_allclose(
+                force_test[:, 1], force_analytic_rect * np.sin(phi)
+            )
             np.testing.assert_allclose(force_test[:, 2], 0.0)
+
+            # MODIFICATION: Full B-Field Evaluation Integration Tests
+            # =================================================================
+            # Pass as 1D arrays of size 1 so that your `u[None, None, :]` slicing works perfectly!
+            u_scalar = jnp.array([0.5])
+            v_scalar = jnp.array([-0.2])
+
+            # 1. Evaluate total field and its sub-components
+            B_total_grid = coil_rect.B_total(u_scalar, v_scalar, a, b)
+            B_kappa_grid = coil_rect.Bkappa(u_scalar, v_scalar, a, b)
+            B_0_grid = coil_rect.B0(u_scalar, v_scalar, a, b)
+            B_b_grid = coil_rect.B_b(a, b)
+
+            # 2. Check shapes: should return a vector (N_quad, 3) matching the loop points
+            self.assertEqual(B_total_grid.shape, (N_quad, 3))
+            self.assertEqual(B_kappa_grid.shape, (N_quad, 3))
+            self.assertEqual(B_0_grid.shape, (N_quad, 3))
+            self.assertEqual(B_b_grid.shape, (N_quad, 3))
+
+            # 3. Check for numerical safety (should be free of NaNs/Infs)
+            self.assertTrue(np.all(np.isfinite(B_total_grid)))
+            self.assertTrue(np.all(np.isfinite(B_kappa_grid)))
+            self.assertTrue(np.all(np.isfinite(B_0_grid)))
+            self.assertTrue(np.all(np.isfinite(B_b_grid)))
+
+            # 4. Check the central magnetic axis explicitly
+            B_center_axis = coil_rect.B_total(jnp.array([0.0]), jnp.array([0.0]), a, b)
+            self.assertTrue(np.all(np.isfinite(B_center_axis)))
 
     def test_force_convergence(self):
         """Check that the self-force is approximately independent of the number of quadrature points"""
         points_per_periods = [8, 4, 2, 7, 5]
         for j, points_per_period in enumerate(points_per_periods):
-            base_curves, base_currents, ma, nfp, bs = get_data("hsx", points_per_period=points_per_period)
+            base_curves, base_currents, ma, nfp, bs = get_data(
+                "hsx", points_per_period=points_per_period
+            )
             curve = base_curves[0]
             I = 1.5e3
             a = 0.01
@@ -477,11 +608,13 @@ class CoilForcesTest(unittest.TestCase):
                 interpolant = interp1d(curve.quadpoints, force, axis=0)
                 max_force_ref = max_force
             else:
-                np.testing.assert_allclose(force, interpolant(curve.quadpoints), atol=max_force_ref / 60)
+                np.testing.assert_allclose(
+                    force, interpolant(curve.quadpoints), atol=max_force_ref / 60
+                )
 
     def test_hsx_coil(self):
         """Compare self-force for HSX coil 1 to result from CoilForces.jl"""
-        base_curves, base_currents, ma, nfp, bs  = get_data("hsx")
+        base_curves, base_currents, ma, nfp, bs = get_data("hsx")
         assert len(base_curves[0].quadpoints) == 160
         I = 150e3
         a = 0.01
@@ -494,7 +627,168 @@ class CoilForcesTest(unittest.TestCase):
         # The data from CoilForces.jl were generated with the command
         # CoilForces.reference_HSX_force_for_simsopt_test()
         F_x_benchmark = np.array(
-            [-15624.06752062059, -21673.892879345873, -27805.92218896322, -33138.2025931857, -36514.62850757798, -37154.811045050716, -35224.36483811566, -31790.6909934216, -28271.570764376913, -25877.063414550663, -25275.54000792784, -26426.552957555898, -28608.08732785721, -30742.66146788618, -31901.1192650387, -31658.2982018783, -30115.01252455622, -27693.625158453917, -24916.97602450875, -22268.001550194127, -20113.123569572494, -18657.02934190755, -17925.729621918534, -17787.670352261383, -18012.98424762069, -18355.612668419068, -18631.130455525174, -18762.19098176415, -18778.162916012046, -18776.500656205895, -18866.881771744567, -19120.832848894337, -19543.090214569205, -20070.954769137115, -20598.194181114803, -21013.020202255055, -21236.028702664324, -21244.690600996386, -21076.947768954156, -20815.355048694666, -20560.007956111527, -20400.310604802795, -20393.566682281307, -20554.83647318684, -20858.986285059094, -21253.088938981215, -21675.620708707665, -22078.139271497712, -22445.18444801059, -22808.75225496607, -23254.130115531163, -23913.827617806084, -24946.957266144746, -26504.403695291898, -28685.32300927181, -31495.471071978012, -34819.49374359714, -38414.82789487393, -41923.29333627555, -44885.22293635466, -46749.75134352123, -46917.59025432583, -44896.50887106118, -40598.462003586974, -34608.57105847433, -28108.332731765862, -22356.321253373, -18075.405570497107, -15192.820251877345, -13027.925896696135, -10728.68775277632, -7731.104577216556, -4026.458734812997, -67.65800705092924, 3603.7480987311537, 6685.7274727329805, 9170.743233515725, 11193.25631660189, 12863.446736995473, 14199.174999621611, 15157.063376046968, 15709.513692788054, 15907.086239630167, 15889.032882713132, 15843.097529146156, 15944.109516240991, 16304.199171854023, 16953.280592130628, 17852.57440796256, 18932.066168700923, 20133.516941300426, 21437.167716977303, 22858.402963585464, 24417.568974489524, 26100.277202379944, 27828.811426061613, 29459.771430218898, 30813.7836860175, 31730.62350657151, 32128.502820609796, 32038.429339023023, 31593.803847403953, 30979.028723505002, 30362.077268204735, 29840.850204702965, 29422.877198133527, 29042.28057709125, 28604.02774189412, 28036.121314230902, 27327.793860493435, 26538.11580899982, 25773.01411179288, 25142.696104375616, 24718.6066327647, 24507.334842447635, 24451.10991168722, 24454.085831995577, 24423.536258237124, 24308.931868210013, 24122.627773352768, 23933.764307662732, 23838.57162949479, 23919.941100154054, 24212.798983180386, 24689.158548635372, 25269.212310785344, 25854.347267952628, 26368.228758087153, 26787.918123459167, 27150.79244000832, 27533.348289627098, 28010.279752667528, 28611.021858534772, 29293.073660468486, 29946.40958260143, 30430.92513540546, 30631.564524187717, 30503.197269324868, 30080.279217014842, 29444.6938562621, 28667.38229651914, 27753.348490269695, 26621.137071620036, 25137.82866539427, 23205.371963209964, 20853.92976118877, 18273.842305983166, 15753.018584850472, 13562.095187201534, 11864.517807863573, 10688.16332321768, 9935.766441264674, 9398.023223792645, 8766.844594289494, 7680.841209848606, 5824.4042671660145, 3040.702284846631, -630.2054351866387, -5035.57692055936, -10048.785939525675]
+            [
+                -15624.06752062059,
+                -21673.892879345873,
+                -27805.92218896322,
+                -33138.2025931857,
+                -36514.62850757798,
+                -37154.811045050716,
+                -35224.36483811566,
+                -31790.6909934216,
+                -28271.570764376913,
+                -25877.063414550663,
+                -25275.54000792784,
+                -26426.552957555898,
+                -28608.08732785721,
+                -30742.66146788618,
+                -31901.1192650387,
+                -31658.2982018783,
+                -30115.01252455622,
+                -27693.625158453917,
+                -24916.97602450875,
+                -22268.001550194127,
+                -20113.123569572494,
+                -18657.02934190755,
+                -17925.729621918534,
+                -17787.670352261383,
+                -18012.98424762069,
+                -18355.612668419068,
+                -18631.130455525174,
+                -18762.19098176415,
+                -18778.162916012046,
+                -18776.500656205895,
+                -18866.881771744567,
+                -19120.832848894337,
+                -19543.090214569205,
+                -20070.954769137115,
+                -20598.194181114803,
+                -21013.020202255055,
+                -21236.028702664324,
+                -21244.690600996386,
+                -21076.947768954156,
+                -20815.355048694666,
+                -20560.007956111527,
+                -20400.310604802795,
+                -20393.566682281307,
+                -20554.83647318684,
+                -20858.986285059094,
+                -21253.088938981215,
+                -21675.620708707665,
+                -22078.139271497712,
+                -22445.18444801059,
+                -22808.75225496607,
+                -23254.130115531163,
+                -23913.827617806084,
+                -24946.957266144746,
+                -26504.403695291898,
+                -28685.32300927181,
+                -31495.471071978012,
+                -34819.49374359714,
+                -38414.82789487393,
+                -41923.29333627555,
+                -44885.22293635466,
+                -46749.75134352123,
+                -46917.59025432583,
+                -44896.50887106118,
+                -40598.462003586974,
+                -34608.57105847433,
+                -28108.332731765862,
+                -22356.321253373,
+                -18075.405570497107,
+                -15192.820251877345,
+                -13027.925896696135,
+                -10728.68775277632,
+                -7731.104577216556,
+                -4026.458734812997,
+                -67.65800705092924,
+                3603.7480987311537,
+                6685.7274727329805,
+                9170.743233515725,
+                11193.25631660189,
+                12863.446736995473,
+                14199.174999621611,
+                15157.063376046968,
+                15709.513692788054,
+                15907.086239630167,
+                15889.032882713132,
+                15843.097529146156,
+                15944.109516240991,
+                16304.199171854023,
+                16953.280592130628,
+                17852.57440796256,
+                18932.066168700923,
+                20133.516941300426,
+                21437.167716977303,
+                22858.402963585464,
+                24417.568974489524,
+                26100.277202379944,
+                27828.811426061613,
+                29459.771430218898,
+                30813.7836860175,
+                31730.62350657151,
+                32128.502820609796,
+                32038.429339023023,
+                31593.803847403953,
+                30979.028723505002,
+                30362.077268204735,
+                29840.850204702965,
+                29422.877198133527,
+                29042.28057709125,
+                28604.02774189412,
+                28036.121314230902,
+                27327.793860493435,
+                26538.11580899982,
+                25773.01411179288,
+                25142.696104375616,
+                24718.6066327647,
+                24507.334842447635,
+                24451.10991168722,
+                24454.085831995577,
+                24423.536258237124,
+                24308.931868210013,
+                24122.627773352768,
+                23933.764307662732,
+                23838.57162949479,
+                23919.941100154054,
+                24212.798983180386,
+                24689.158548635372,
+                25269.212310785344,
+                25854.347267952628,
+                26368.228758087153,
+                26787.918123459167,
+                27150.79244000832,
+                27533.348289627098,
+                28010.279752667528,
+                28611.021858534772,
+                29293.073660468486,
+                29946.40958260143,
+                30430.92513540546,
+                30631.564524187717,
+                30503.197269324868,
+                30080.279217014842,
+                29444.6938562621,
+                28667.38229651914,
+                27753.348490269695,
+                26621.137071620036,
+                25137.82866539427,
+                23205.371963209964,
+                20853.92976118877,
+                18273.842305983166,
+                15753.018584850472,
+                13562.095187201534,
+                11864.517807863573,
+                10688.16332321768,
+                9935.766441264674,
+                9398.023223792645,
+                8766.844594289494,
+                7680.841209848606,
+                5824.4042671660145,
+                3040.702284846631,
+                -630.2054351866387,
+                -5035.57692055936,
+                -10048.785939525675,
+            ]
         )
 
         F_x_test = coil_circ.self_force()[:, 0]
@@ -503,7 +797,168 @@ class CoilForcesTest(unittest.TestCase):
         # Case of rectangular cross-section
 
         F_x_benchmark = np.array(
-            [-15905.20099921593, -22089.84960387874, -28376.348489470365, -33849.08438046449, -37297.138833218974, -37901.3580214951, -35838.71064362283, -32228.643120480687, -28546.9118841109, -26046.96628692484, -25421.777194138715, -26630.791911489407, -28919.842325785943, -31157.40078884933, -32368.19957740524, -32111.184287572887, -30498.330514718982, -27974.45692852191, -25085.400672446423, -22334.49737678633, -20104.78648017159, -18610.931535243944, -17878.995292047493, -17767.35330442759, -18030.259902092654, -18406.512856357545, -18702.39969540496, -18838.862854941028, -18849.823944445518, -18840.62799920807, -18928.85330885538, -19191.02138695175, -19632.210519767978, -20185.474968977625, -20737.621297822592, -21169.977809582055, -21398.747768091078, -21400.62658689198, -21216.133558586924, -20932.595132161085, -20655.60793743372, -20479.40191077005, -20464.28582628529, -20625.83431400738, -20936.962932518098, -21341.067527434556, -21772.38656616101, -22178.862986210577, -22542.999300185398, -22897.045487538875, -23329.342412912913, -23978.387795050137, -25011.595805992223, -26588.8272541588, -28816.499234411625, -31703.566987071903, -35132.3971671138, -38852.71510558583, -42494.50815372789, -45583.48852415488, -47551.1577527285, -47776.415427331594, -45743.97982645536, -41354.37991615283, -35210.20495138465, -28540.23742988024, -22654.55869049082, -18301.96907423793, -15401.963398143102, -13243.762349314706, -10939.450828758423, -7900.820612170931, -4120.028225769904, -72.86209546891608, 3674.253747922276, 6809.0803070326565, 9328.115750414787, 11374.122069162511, 13062.097330371573, 14409.383808494194, 15369.251684718018, 15911.988418337934, 16090.021555975769, 16048.21613878066, 15981.151899412167, 16068.941633738388, 16425.88464448961, 17080.88532516404, 17992.129241265648, 19086.46631302506, 20304.322975363317, 21627.219065732254, 23073.563938875737, 24666.38845701993, 26391.47816311481, 28167.521012668185, 29843.93199662863, 31232.367301229497, 32164.969954389788, 32556.923587447265, 32442.446350951064, 31963.284032424053, 31314.01211399212, 30670.79551082286, 30135.039340095944, 29712.330052677768, 29330.71025802117, 28887.8200773726, 28306.412420411067, 27574.83013193789, 26755.843397583598, 25961.936385889934, 25310.01540139794, 24875.789463354584, 24666.066357125907, 24619.136261928328, 24632.619408002214, 24607.413073397413, 24489.503028993608, 24292.044623409187, 24088.74651990258, 23982.195361428472, 24060.929104794097, 24362.6460843878, 24858.082439252874, 25462.457564195745, 26070.50973682213, 26600.547196554344, 27028.01270305341, 27393.03996450607, 27777.872708277075, 28263.357416931998, 28882.7902495421, 29593.307386932454, 30279.887846398404, 30794.507327329207, 31014.791285198782, 30892.485429183558, 30464.50108998591, 29819.03800239511, 29033.577206319136, 28116.32127507844, 26983.626000124084, 25495.394951521277, 23544.852551314456, 21157.350595114454, 18526.131317622883, 15948.394109661942, 13705.248433750054, 11967.480036214449, 10766.293968812726, 10004.685998499026, 9470.706025372589, 8849.607342610005, 7769.149525451194, 5902.017638994769, 3084.6416074691333, -641.878548205229, -5119.944566458021, -10221.371299891642]
+            [
+                -15905.20099921593,
+                -22089.84960387874,
+                -28376.348489470365,
+                -33849.08438046449,
+                -37297.138833218974,
+                -37901.3580214951,
+                -35838.71064362283,
+                -32228.643120480687,
+                -28546.9118841109,
+                -26046.96628692484,
+                -25421.777194138715,
+                -26630.791911489407,
+                -28919.842325785943,
+                -31157.40078884933,
+                -32368.19957740524,
+                -32111.184287572887,
+                -30498.330514718982,
+                -27974.45692852191,
+                -25085.400672446423,
+                -22334.49737678633,
+                -20104.78648017159,
+                -18610.931535243944,
+                -17878.995292047493,
+                -17767.35330442759,
+                -18030.259902092654,
+                -18406.512856357545,
+                -18702.39969540496,
+                -18838.862854941028,
+                -18849.823944445518,
+                -18840.62799920807,
+                -18928.85330885538,
+                -19191.02138695175,
+                -19632.210519767978,
+                -20185.474968977625,
+                -20737.621297822592,
+                -21169.977809582055,
+                -21398.747768091078,
+                -21400.62658689198,
+                -21216.133558586924,
+                -20932.595132161085,
+                -20655.60793743372,
+                -20479.40191077005,
+                -20464.28582628529,
+                -20625.83431400738,
+                -20936.962932518098,
+                -21341.067527434556,
+                -21772.38656616101,
+                -22178.862986210577,
+                -22542.999300185398,
+                -22897.045487538875,
+                -23329.342412912913,
+                -23978.387795050137,
+                -25011.595805992223,
+                -26588.8272541588,
+                -28816.499234411625,
+                -31703.566987071903,
+                -35132.3971671138,
+                -38852.71510558583,
+                -42494.50815372789,
+                -45583.48852415488,
+                -47551.1577527285,
+                -47776.415427331594,
+                -45743.97982645536,
+                -41354.37991615283,
+                -35210.20495138465,
+                -28540.23742988024,
+                -22654.55869049082,
+                -18301.96907423793,
+                -15401.963398143102,
+                -13243.762349314706,
+                -10939.450828758423,
+                -7900.820612170931,
+                -4120.028225769904,
+                -72.86209546891608,
+                3674.253747922276,
+                6809.0803070326565,
+                9328.115750414787,
+                11374.122069162511,
+                13062.097330371573,
+                14409.383808494194,
+                15369.251684718018,
+                15911.988418337934,
+                16090.021555975769,
+                16048.21613878066,
+                15981.151899412167,
+                16068.941633738388,
+                16425.88464448961,
+                17080.88532516404,
+                17992.129241265648,
+                19086.46631302506,
+                20304.322975363317,
+                21627.219065732254,
+                23073.563938875737,
+                24666.38845701993,
+                26391.47816311481,
+                28167.521012668185,
+                29843.93199662863,
+                31232.367301229497,
+                32164.969954389788,
+                32556.923587447265,
+                32442.446350951064,
+                31963.284032424053,
+                31314.01211399212,
+                30670.79551082286,
+                30135.039340095944,
+                29712.330052677768,
+                29330.71025802117,
+                28887.8200773726,
+                28306.412420411067,
+                27574.83013193789,
+                26755.843397583598,
+                25961.936385889934,
+                25310.01540139794,
+                24875.789463354584,
+                24666.066357125907,
+                24619.136261928328,
+                24632.619408002214,
+                24607.413073397413,
+                24489.503028993608,
+                24292.044623409187,
+                24088.74651990258,
+                23982.195361428472,
+                24060.929104794097,
+                24362.6460843878,
+                24858.082439252874,
+                25462.457564195745,
+                26070.50973682213,
+                26600.547196554344,
+                27028.01270305341,
+                27393.03996450607,
+                27777.872708277075,
+                28263.357416931998,
+                28882.7902495421,
+                29593.307386932454,
+                30279.887846398404,
+                30794.507327329207,
+                31014.791285198782,
+                30892.485429183558,
+                30464.50108998591,
+                29819.03800239511,
+                29033.577206319136,
+                28116.32127507844,
+                26983.626000124084,
+                25495.394951521277,
+                23544.852551314456,
+                21157.350595114454,
+                18526.131317622883,
+                15948.394109661942,
+                13705.248433750054,
+                11967.480036214449,
+                10766.293968812726,
+                10004.685998499026,
+                9470.706025372589,
+                8849.607342610005,
+                7769.149525451194,
+                5902.017638994769,
+                3084.6416074691333,
+                -641.878548205229,
+                -5119.944566458021,
+                -10221.371299891642,
+            ]
         )
 
         F_x_test = coil_rect.self_force()[:, 0]
@@ -541,74 +996,114 @@ class CoilForcesTest(unittest.TestCase):
 
         base_curves = create_equally_spaced_curves(ncoils, nfp, True)
         base_currents = [Current(I) for j in range(ncoils)]
-        coils = coils_via_symmetries(base_curves, base_currents, nfp, True,
-                                     regularizations=[regularization] * ncoils)
+        coils = coils_via_symmetries(
+            base_curves,
+            base_currents,
+            nfp,
+            True,
+            regularizations=[regularization] * ncoils,
+        )
 
         # Test coil_net_force: should be the integral of pointwise forces
         target_coil = coils[0]
         source_coils = coils
-        
+
         # Compute pointwise forces
         pointwise_forces = target_coil.force(source_coils)
-        
+
         # Compute net force using the method
         net_force = target_coil.net_force(source_coils)
-        
+
         # Compute net force manually by integrating pointwise forces
         gammadash = target_coil.curve.gammadash()
         gammadash_norm = np.linalg.norm(gammadash, axis=1)[:, None]
-        net_force_manual = np.sum(gammadash_norm * pointwise_forces, axis=0) / gammadash.shape[0]
-        
-        np.testing.assert_allclose(net_force, net_force_manual, rtol=1e-10,
-                                   err_msg="net_force should match manual integration")
-        
+        net_force_manual = (
+            np.sum(gammadash_norm * pointwise_forces, axis=0) / gammadash.shape[0]
+        )
+
+        np.testing.assert_allclose(
+            net_force,
+            net_force_manual,
+            rtol=1e-10,
+            err_msg="net_force should match manual integration",
+        )
+
         # Test coil_net_torque: should be the integral of pointwise torques
         pointwise_torques = target_coil.torque(source_coils)
-        
+
         # Compute net torque using the method
         net_torque = target_coil.net_torque(source_coils)
-        
+
         # Compute net torque manually by integrating pointwise torques
-        net_torque_manual = np.sum(gammadash_norm * pointwise_torques, axis=0) / gammadash.shape[0]
-        
-        np.testing.assert_allclose(net_torque, net_torque_manual, rtol=1e-10,
-                                   err_msg="net_torque should match manual integration")
-        
+        net_torque_manual = (
+            np.sum(gammadash_norm * pointwise_torques, axis=0) / gammadash.shape[0]
+        )
+
+        np.testing.assert_allclose(
+            net_torque,
+            net_torque_manual,
+            rtol=1e-10,
+            err_msg="net_torque should match manual integration",
+        )
+
         # Test with rectangular regularization
         regularization_rect_val = regularization_rect(0.01, 0.023)
-        coils_rect = coils_via_symmetries(base_curves, base_currents, nfp, True,
-                                          regularizations=[regularization_rect_val] * ncoils)
-        
+        coils_rect = coils_via_symmetries(
+            base_curves,
+            base_currents,
+            nfp,
+            True,
+            regularizations=[regularization_rect_val] * ncoils,
+        )
+
         target_coil_rect = coils_rect[0]
         source_coils_rect = coils_rect
-        
+
         # Test coil_net_force with rectangular regularization: should be the integral of pointwise forces
         pointwise_forces_rect = target_coil_rect.force(source_coils_rect)
         net_force_rect = target_coil_rect.net_force(source_coils_rect)
-        
+
         # Compute net force manually by integrating pointwise forces
         gammadash_rect = target_coil_rect.curve.gammadash()
         gammadash_norm_rect = np.linalg.norm(gammadash_rect, axis=1)[:, None]
-        net_force_manual_rect = np.sum(gammadash_norm_rect * pointwise_forces_rect, axis=0) / gammadash_rect.shape[0]
-        
-        np.testing.assert_allclose(net_force_rect, net_force_manual_rect, rtol=1e-10,
-                                   err_msg="net_force with rectangular regularization should match manual integration")
-        
+        net_force_manual_rect = (
+            np.sum(gammadash_norm_rect * pointwise_forces_rect, axis=0)
+            / gammadash_rect.shape[0]
+        )
+
+        np.testing.assert_allclose(
+            net_force_rect,
+            net_force_manual_rect,
+            rtol=1e-10,
+            err_msg="net_force with rectangular regularization should match manual integration",
+        )
+
         # Test coil_net_torque with rectangular regularization: should be the integral of pointwise torques
         pointwise_torques_rect = target_coil_rect.torque(source_coils_rect)
         net_torque_rect = target_coil_rect.net_torque(source_coils_rect)
-        
+
         # Compute net torque manually by integrating pointwise torques
-        net_torque_manual_rect = np.sum(gammadash_norm_rect * pointwise_torques_rect, axis=0) / gammadash_rect.shape[0]
-        
-        np.testing.assert_allclose(net_torque_rect, net_torque_manual_rect, rtol=1e-10,
-                                   err_msg="net_torque with rectangular regularization should match manual integration")
-        
+        net_torque_manual_rect = (
+            np.sum(gammadash_norm_rect * pointwise_torques_rect, axis=0)
+            / gammadash_rect.shape[0]
+        )
+
+        np.testing.assert_allclose(
+            net_torque_rect,
+            net_torque_manual_rect,
+            rtol=1e-10,
+            err_msg="net_torque with rectangular regularization should match manual integration",
+        )
+
         # Net force and torque should be finite and reasonable
         assert np.all(np.isfinite(net_force_rect))
         assert np.all(np.isfinite(net_torque_rect))
-        assert np.linalg.norm(net_force_rect) > 0  # Should be non-zero for interacting coils
-        assert np.linalg.norm(net_torque_rect) > 0  # Should be non-zero for interacting coils
+        assert (
+            np.linalg.norm(net_force_rect) > 0
+        )  # Should be non-zero for interacting coils
+        assert (
+            np.linalg.norm(net_torque_rect) > 0
+        )  # Should be non-zero for interacting coils
 
     def test_force_objectives(self):
         """Check whether objective function matches function for export"""
@@ -618,8 +1113,13 @@ class CoilForcesTest(unittest.TestCase):
 
         base_curves = create_equally_spaced_curves(ncoils, nfp, True)
         base_currents = [Current(I) for j in range(ncoils)]
-        coils = coils_via_symmetries(base_curves, base_currents, nfp, True, 
-                                     regularizations=[regularization_circ(0.05)] * ncoils)
+        coils = coils_via_symmetries(
+            base_curves,
+            base_currents,
+            nfp,
+            True,
+            regularizations=[regularization_circ(0.05)] * ncoils,
+        )
 
         # Test LpCurveForce
         p = 2.5
@@ -633,10 +1133,28 @@ class CoilForcesTest(unittest.TestCase):
         gammadash_norm = np.linalg.norm(coils[0].curve.gammadash(), axis=1)
         force_norm_N_per_m = np.linalg.norm(coils[0].force(coils), axis=1)
         force_norm_MN_per_m = force_norm_N_per_m / 1e6  # Convert to MN/m
-        print("force_norm mean:", np.mean(force_norm_N_per_m), "max:", np.max(force_norm_N_per_m))
-        objective_alt = (1 / p) * np.sum(np.maximum(force_norm_MN_per_m - threshold, 0)**p * gammadash_norm) / np.shape(gammadash_norm)[0]
+        print(
+            "force_norm mean:",
+            np.mean(force_norm_N_per_m),
+            "max:",
+            np.max(force_norm_N_per_m),
+        )
+        objective_alt = (
+            (1 / p)
+            * np.sum(
+                np.maximum(force_norm_MN_per_m - threshold, 0) ** p * gammadash_norm
+            )
+            / np.shape(gammadash_norm)[0]
+        )
 
-        print("objective:", objective, "objective_alt:", objective_alt, "diff:", objective - objective_alt)
+        print(
+            "objective:",
+            objective,
+            "objective_alt:",
+            objective_alt,
+            "diff:",
+            objective - objective_alt,
+        )
         np.testing.assert_allclose(objective, objective_alt, rtol=1e-6)
 
         # Test SquaredMeanForce
@@ -648,11 +1166,20 @@ class CoilForcesTest(unittest.TestCase):
         # force method
         # SquaredMeanForce computes: ||mean_force||^2 where mean_force = sum(force * gammadash_norm) / npts
         forces = coils[0].force(coils)
-        net_force_N_per_m = np.sum(forces * gammadash_norm[:, None], axis=0) / len(gammadash_norm)
+        net_force_N_per_m = np.sum(forces * gammadash_norm[:, None], axis=0) / len(
+            gammadash_norm
+        )
         net_force_MN_per_m = net_force_N_per_m / 1e6  # Convert to MN/m
         objective_alt = np.linalg.norm(net_force_MN_per_m) ** 2
 
-        print("objective:", objective, "objective_alt:", objective_alt, "diff:", objective - objective_alt)
+        print(
+            "objective:",
+            objective,
+            "objective_alt:",
+            objective_alt,
+            "diff:",
+            objective - objective_alt,
+        )
         np.testing.assert_allclose(objective, objective_alt, rtol=1e-6)
 
         # Test SquaredMeanForce
@@ -664,11 +1191,20 @@ class CoilForcesTest(unittest.TestCase):
         # SquaredMeanForce computes: ||mean_force||^2 where mean_force = sum(force * gammadash_norm) / npts
         gammadash_norm = np.linalg.norm(coils[0].curve.gammadash(), axis=1)
         forces = coils[0].force(coils)
-        net_force_N_per_m = np.sum(forces * gammadash_norm[:, None], axis=0) / len(gammadash_norm)
+        net_force_N_per_m = np.sum(forces * gammadash_norm[:, None], axis=0) / len(
+            gammadash_norm
+        )
         net_force_MN_per_m = net_force_N_per_m / 1e6  # Convert to MN/m
         objective_alt = np.linalg.norm(net_force_MN_per_m) ** 2
 
-        print("objective:", objective, "objective_alt:", objective_alt, "diff:", objective - objective_alt)
+        print(
+            "objective:",
+            objective,
+            "objective_alt:",
+            objective_alt,
+            "diff:",
+            objective - objective_alt,
+        )
         np.testing.assert_allclose(objective, objective_alt, rtol=1e-6)
 
         # Test SquaredMeanForce vs SquaredMeanForce
@@ -683,7 +1219,10 @@ class CoilForcesTest(unittest.TestCase):
             objective2 += float(SquaredMeanForce(coils[i], coils, downsample=2).J())
             objective3 += float(SquaredMeanForce(coils[i], coils, downsample=3).J())
             # Forces are in N/m, convert to MN/m before squaring
-            net_force_N_per_m = np.sum(coils[i].force(coils) * gammadash_norm[:, None], axis=0) / gammadash_norm.shape[0]
+            net_force_N_per_m = (
+                np.sum(coils[i].force(coils) * gammadash_norm[:, None], axis=0)
+                / gammadash_norm.shape[0]
+            )
             net_force_MN_per_m = net_force_N_per_m / 1e6
             objective_mixed += np.linalg.norm(net_force_MN_per_m) ** 2
             net_force_direct_N_per_m = coils[i].net_force(coils)
@@ -709,21 +1248,58 @@ class CoilForcesTest(unittest.TestCase):
         objective3 = 0.0
         objective_alt = 0.0
         for i in range(len(coils)):
-            objective += float(LpCurveForce(coils[i], coils, p=p, threshold=threshold).J())
-            objective2 += float(LpCurveForce(coils[i], coils, p=p, threshold=threshold, downsample=2).J())
-            objective3 += float(LpCurveForce(coils[i], coils, p=p, threshold=threshold, downsample=3).J())
+            objective += float(
+                LpCurveForce(coils[i], coils, p=p, threshold=threshold).J()
+            )
+            objective2 += float(
+                LpCurveForce(
+                    coils[i], coils, p=p, threshold=threshold, downsample=2
+                ).J()
+            )
+            objective3 += float(
+                LpCurveForce(
+                    coils[i], coils, p=p, threshold=threshold, downsample=3
+                ).J()
+            )
             force_norm_N_per_m = np.linalg.norm(coils[i].force(coils), axis=1)
             force_norm_MN_per_m = force_norm_N_per_m / 1e6  # Convert to MN/m
             gammadash_norm = np.linalg.norm(coils[i].curve.gammadash(), axis=1)
-            objective_alt += (1 / p) * np.sum(np.maximum(force_norm_MN_per_m - threshold, 0)**p * gammadash_norm) / gammadash_norm.shape[0]
+            objective_alt += (
+                (1 / p)
+                * np.sum(
+                    np.maximum(force_norm_MN_per_m - threshold, 0) ** p * gammadash_norm
+                )
+                / gammadash_norm.shape[0]
+            )
 
-        print("objective:", objective, "objective_alt:", objective_alt, "diff:", objective - objective_alt)
+        print(
+            "objective:",
+            objective,
+            "objective_alt:",
+            objective_alt,
+            "diff:",
+            objective - objective_alt,
+        )
         np.testing.assert_allclose(objective, objective_alt, rtol=1e-6)
 
-        print("objective:", objective, "objective2:", objective2, "diff:", objective - objective2)
+        print(
+            "objective:",
+            objective,
+            "objective2:",
+            objective2,
+            "diff:",
+            objective - objective2,
+        )
         np.testing.assert_allclose(objective, objective2, rtol=1e-2)
 
-        print("objective:", objective, "objective3:", objective3, "diff:", objective - objective3)
+        print(
+            "objective:",
+            objective,
+            "objective3:",
+            objective3,
+            "diff:",
+            objective - objective3,
+        )
         np.testing.assert_allclose(objective, objective3, rtol=1e-2)
 
         # Scramble the orientations so the torques are nonzero
@@ -738,11 +1314,21 @@ class CoilForcesTest(unittest.TestCase):
         # coil_force function
         gammadash_norm = np.linalg.norm(coils[0].curve.gammadash(), axis=1)
         torques_N = coils[0].torque(coils)
-        net_torque_N = np.sum(torques_N * gammadash_norm[:, None], axis=0) / gammadash_norm.shape[0]
+        net_torque_N = (
+            np.sum(torques_N * gammadash_norm[:, None], axis=0)
+            / gammadash_norm.shape[0]
+        )
         net_torque_MN = net_torque_N / 1e6  # Convert to MN
         objective_alt = np.linalg.norm(net_torque_MN, axis=-1) ** 2
 
-        print("objective:", objective, "objective_alt:", objective_alt, "diff:", objective - objective_alt)
+        print(
+            "objective:",
+            objective,
+            "objective_alt:",
+            objective_alt,
+            "diff:",
+            objective - objective_alt,
+        )
         np.testing.assert_allclose(objective, objective_alt, rtol=1e-2)
 
         objective = 0.0
@@ -755,23 +1341,54 @@ class CoilForcesTest(unittest.TestCase):
             objective2 += float(SquaredMeanTorque(coils[i], coils, downsample=2).J())
             objective3 += float(SquaredMeanTorque(coils[i], coils, downsample=3).J())
             gammadash_norm = np.linalg.norm(coils[i].curve.gammadash(), axis=1)
-            net_torque_N = np.sum(coils[i].torque(coils) * gammadash_norm[:, None], axis=0) / gammadash_norm.shape[0]
+            net_torque_N = (
+                np.sum(coils[i].torque(coils) * gammadash_norm[:, None], axis=0)
+                / gammadash_norm.shape[0]
+            )
             net_torque_MN = net_torque_N / 1e6
             objective_alt += np.linalg.norm(net_torque_MN) ** 2
             net_torque_direct_N = coils[i].net_torque(coils)
             net_torque_direct_MN = net_torque_direct_N / 1e6
             objective_direct += np.linalg.norm(net_torque_direct_MN) ** 2
 
-        print("objective:", objective, "objective_alt:", objective_alt, "diff:", objective - objective_alt)
+        print(
+            "objective:",
+            objective,
+            "objective_alt:",
+            objective_alt,
+            "diff:",
+            objective - objective_alt,
+        )
         np.testing.assert_allclose(objective, objective_alt, rtol=1e-2)
 
-        print("objective:", objective, "objective_direct:", objective_direct, "diff:", objective - objective_direct)
+        print(
+            "objective:",
+            objective,
+            "objective_direct:",
+            objective_direct,
+            "diff:",
+            objective - objective_direct,
+        )
         np.testing.assert_allclose(objective, objective_direct, rtol=1e-2)
 
-        print("objective:", objective, "downsampled:", objective2, "diff:", objective - objective2)
+        print(
+            "objective:",
+            objective,
+            "downsampled:",
+            objective2,
+            "diff:",
+            objective - objective2,
+        )
         np.testing.assert_allclose(objective, objective2, rtol=1e-2)
 
-        print("objective:", objective, "downsampled further:", objective3, "diff:", objective - objective3)
+        print(
+            "objective:",
+            objective,
+            "downsampled further:",
+            objective3,
+            "diff:",
+            objective - objective3,
+        )
         np.testing.assert_allclose(objective, objective3, rtol=1e-2)
 
         # Test LpCurveTorque
@@ -782,21 +1399,58 @@ class CoilForcesTest(unittest.TestCase):
         threshold = 0.0
         objective_mixed = 0.0
         for i in range(len(coils)):
-            objective += float(LpCurveTorque(coils[i], coils, p=p, threshold=threshold).J())
-            objective2 += float(LpCurveTorque(coils[i], coils, p=p, threshold=threshold, downsample=2).J())
-            objective3 += float(LpCurveTorque(coils[i], coils, p=p, threshold=threshold, downsample=3).J())
+            objective += float(
+                LpCurveTorque(coils[i], coils, p=p, threshold=threshold).J()
+            )
+            objective2 += float(
+                LpCurveTorque(
+                    coils[i], coils, p=p, threshold=threshold, downsample=2
+                ).J()
+            )
+            objective3 += float(
+                LpCurveTorque(
+                    coils[i], coils, p=p, threshold=threshold, downsample=3
+                ).J()
+            )
             torque_norm_N = np.linalg.norm(coils[i].torque(coils), axis=1)
             torque_norm_MN = torque_norm_N / 1e6  # Convert to MN
             gammadash_norm = np.linalg.norm(coils[i].curve.gammadash(), axis=1)
-            objective_alt += (1 / p) * np.sum(np.maximum(torque_norm_MN - threshold, 0)**p * gammadash_norm) / gammadash_norm.shape[0]
+            objective_alt += (
+                (1 / p)
+                * np.sum(
+                    np.maximum(torque_norm_MN - threshold, 0) ** p * gammadash_norm
+                )
+                / gammadash_norm.shape[0]
+            )
 
-        print("objective:", objective, "objective_alt:", objective_alt, "diff:", objective - objective_alt)
+        print(
+            "objective:",
+            objective,
+            "objective_alt:",
+            objective_alt,
+            "diff:",
+            objective - objective_alt,
+        )
         np.testing.assert_allclose(objective, objective_alt, rtol=1e-6)
 
-        print("objective:", objective, "downsampled:", objective2, "diff:", objective - objective2)
+        print(
+            "objective:",
+            objective,
+            "downsampled:",
+            objective2,
+            "diff:",
+            objective - objective2,
+        )
         np.testing.assert_allclose(objective, objective2, rtol=1e-4)
 
-        print("objective:", objective, "downsampled further:", objective3, "diff:", objective - objective3)
+        print(
+            "objective:",
+            objective,
+            "downsampled further:",
+            objective3,
+            "diff:",
+            objective - objective3,
+        )
         np.testing.assert_allclose(objective, objective3, rtol=1e-2)
 
     def test_force_and_torque_objectives_with_different_quadpoints(self):
@@ -804,14 +1458,14 @@ class CoilForcesTest(unittest.TestCase):
         I = 1.7e4
         # Group A: two coils with 40 quadrature points
         curve_a1 = CurveXYZFourier(40, 1)
-        curve_a1.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * 1.0
+        curve_a1.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * 1.0
         curve_a2 = CurveXYZFourier(40, 1)
-        curve_a2.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * 1.2
+        curve_a2.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * 1.2
         # Group B: two coils with 60 quadrature points
         curve_b1 = CurveXYZFourier(60, 1)
-        curve_b1.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * 0.8
+        curve_b1.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * 0.8
         curve_b2 = CurveXYZFourier(60, 1)
-        curve_b2.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * 1.5
+        curve_b2.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * 1.5
         coil_a1 = RegularizedCoil(curve_a1, Current(I), regularization_circ(0.05))
         coil_a2 = RegularizedCoil(curve_a2, Current(I), regularization_circ(0.05))
         coil_b1 = RegularizedCoil(curve_b1, Current(I), regularization_circ(0.05))
@@ -822,7 +1476,9 @@ class CoilForcesTest(unittest.TestCase):
         self.assertTrue(np.isfinite(val))
         val = LpCurveForce(coil_a1, [coil_b1, coil_b2], p=2.5, threshold=threshold).J()
         self.assertTrue(np.isfinite(val))
-        val = LpCurveForce([coil_a1, coil_a2], [coil_b1, coil_b2], p=2.5, threshold=threshold).J()
+        val = LpCurveForce(
+            [coil_a1, coil_a2], [coil_b1, coil_b2], p=2.5, threshold=threshold
+        ).J()
         self.assertTrue(np.isfinite(val))
         # SquaredMeanForce: target group A, source group B
         val = SquaredMeanForce(coil_a1, coil_b1).J()
@@ -835,7 +1491,9 @@ class CoilForcesTest(unittest.TestCase):
         threshold = 1e-3  # Threshold in MN
         val = LpCurveTorque(coil_a1, [coil_b1, coil_b2], p=2.5, threshold=threshold).J()
         self.assertTrue(np.isfinite(val))
-        val = LpCurveTorque([coil_a1, coil_a2], [coil_b1, coil_b2], p=2.5, threshold=threshold).J()
+        val = LpCurveTorque(
+            [coil_a1, coil_a2], [coil_b1, coil_b2], p=2.5, threshold=threshold
+        ).J()
         self.assertTrue(np.isfinite(val))
         val = LpCurveTorque(coil_b1, coil_a1, p=2.5, threshold=threshold).J()
         self.assertTrue(np.isfinite(val))
@@ -849,14 +1507,23 @@ class CoilForcesTest(unittest.TestCase):
 
         # Target coils with different quadpoints: construct one objective per target via list comprehension
         target_coils = [coil_a1, coil_b1]  # 40 and 60 quadpoints respectively
-        source_coils_coarse = [coil_b1, coil_b2]  # 60 quadpoints (consistent within group)
+        source_coils_coarse = [
+            coil_b1,
+            coil_b2,
+        ]  # 60 quadpoints (consistent within group)
         threshold = 1e-3
         p = 2.5
-        J_lp = sum(LpCurveForce(c, source_coils_coarse, p=p, threshold=threshold).J() for c in target_coils)
+        J_lp = sum(
+            LpCurveForce(c, source_coils_coarse, p=p, threshold=threshold).J()
+            for c in target_coils
+        )
         self.assertTrue(np.isfinite(float(J_lp)))
         J_smf = sum(SquaredMeanForce(c, source_coils_coarse).J() for c in target_coils)
         self.assertTrue(np.isfinite(float(J_smf)))
-        J_lpt = sum(LpCurveTorque(c, source_coils_coarse, p=p, threshold=threshold).J() for c in target_coils)
+        J_lpt = sum(
+            LpCurveTorque(c, source_coils_coarse, p=p, threshold=threshold).J()
+            for c in target_coils
+        )
         self.assertTrue(np.isfinite(float(J_lpt)))
         J_smt = sum(SquaredMeanTorque(c, source_coils_coarse).J() for c in target_coils)
         self.assertTrue(np.isfinite(float(J_smt)))
@@ -868,9 +1535,9 @@ class CoilForcesTest(unittest.TestCase):
         # Per-coil vs combined: same J and dJ when all coils have same quadpoints.
         # Use 40-quad coils so we can pass other targets + external in source_coils_coarse (no coarse/fine split).
         curve_b1_40 = CurveXYZFourier(40, 1)
-        curve_b1_40.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * 0.8
+        curve_b1_40.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * 0.8
         curve_b2_40 = CurveXYZFourier(40, 1)
-        curve_b2_40.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * 1.5
+        curve_b2_40.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * 1.5
         coil_b1_40 = RegularizedCoil(curve_b1_40, Current(I), regularization_circ(0.05))
         coil_b2_40 = RegularizedCoil(curve_b2_40, Current(I), regularization_circ(0.05))
         target_same_quad = [coil_a1, coil_a2]  # both 40 quadpoints
@@ -883,33 +1550,72 @@ class CoilForcesTest(unittest.TestCase):
             (SquaredMeanTorque, {}),
         ]:
             J_pc = sum(
-                float(ForceClass(c, [c2 for c2 in target_same_quad if c2 is not c] + source_external_40, **kwargs).J())
+                float(
+                    ForceClass(
+                        c,
+                        [c2 for c2 in target_same_quad if c2 is not c]
+                        + source_external_40,
+                        **kwargs,
+                    ).J()
+                )
                 for c in target_same_quad
             )
             J_cb = float(ForceClass(target_same_quad, source_external_40, **kwargs).J())
-            np.testing.assert_allclose(J_pc, J_cb, rtol=1e-10, atol=1e-30,
-                                       err_msg=f"{ForceClass.__name__}: sum(per-coil J) should equal combined J")
+            np.testing.assert_allclose(
+                J_pc,
+                J_cb,
+                rtol=1e-10,
+                atol=1e-30,
+                err_msg=f"{ForceClass.__name__}: sum(per-coil J) should equal combined J",
+            )
             dJ_cb = ForceClass(target_same_quad, source_external_40, **kwargs).dJ()
             dJ_pc = sum(
-                ForceClass(c, [c2 for c2 in target_same_quad if c2 is not c] + source_external_40, **kwargs).dJ(partials=True)
+                ForceClass(
+                    c,
+                    [c2 for c2 in target_same_quad if c2 is not c] + source_external_40,
+                    **kwargs,
+                ).dJ(partials=True)
                 for c in target_same_quad
             )
             obj_cb = ForceClass(target_same_quad, source_external_40, **kwargs)
             # Relax tolerance for dJ: per-coil vs combined can differ due to floating-point order of ops
             # and VJP aggregation; use atol for small-magnitude components
-            np.testing.assert_allclose(dJ_cb, dJ_pc(obj_cb), rtol=1e-5, atol=2e-24,
-                                       err_msg=f"{ForceClass.__name__}: sum(per-coil dJ) should equal combined dJ")
+            np.testing.assert_allclose(
+                dJ_cb,
+                dJ_pc(obj_cb),
+                rtol=1e-5,
+                atol=2e-24,
+                err_msg=f"{ForceClass.__name__}: sum(per-coil dJ) should equal combined dJ",
+            )
 
         # Coarse vs coarse+fine split: same J and dJ when all sources have same quadpoints
         sources_all = [coil_b1, coil_b2]
         sources_coarse = [coil_b1]
         sources_fine = [coil_b2]
         J_all = float(LpCurveForce(coil_a1, sources_all, p=p, threshold=threshold).J())
-        J_split = float(LpCurveForce(coil_a1, sources_coarse, source_coils_fine=sources_fine, p=p, threshold=threshold).J())
-        np.testing.assert_allclose(J_all, J_split, rtol=1e-10,
-                                   err_msg="LpCurveForce: all-coarse vs coarse+fine split")
+        J_split = float(
+            LpCurveForce(
+                coil_a1,
+                sources_coarse,
+                source_coils_fine=sources_fine,
+                p=p,
+                threshold=threshold,
+            ).J()
+        )
+        np.testing.assert_allclose(
+            J_all,
+            J_split,
+            rtol=1e-10,
+            err_msg="LpCurveForce: all-coarse vs coarse+fine split",
+        )
         obj_all = LpCurveForce(coil_a1, sources_all, p=p, threshold=threshold)
-        obj_split = LpCurveForce(coil_a1, sources_coarse, source_coils_fine=sources_fine, p=p, threshold=threshold)
+        obj_split = LpCurveForce(
+            coil_a1,
+            sources_coarse,
+            source_coils_fine=sources_fine,
+            p=p,
+            threshold=threshold,
+        )
         np.testing.assert_allclose(obj_all.dJ(), obj_split.dJ(), rtol=1e-10)
         for ForceClass, kwargs in [
             (SquaredMeanForce, {}),
@@ -917,11 +1623,19 @@ class CoilForcesTest(unittest.TestCase):
             (SquaredMeanTorque, {}),
         ]:
             J_all = float(ForceClass(coil_a1, sources_all, **kwargs).J())
-            J_split = float(ForceClass(coil_a1, sources_coarse, source_coils_fine=sources_fine, **kwargs).J())
+            J_split = float(
+                ForceClass(
+                    coil_a1, sources_coarse, source_coils_fine=sources_fine, **kwargs
+                ).J()
+            )
             np.testing.assert_allclose(J_all, J_split, rtol=1e-10, atol=1e-30)
             obj_all = ForceClass(coil_a1, sources_all, **kwargs)
-            obj_split = ForceClass(coil_a1, sources_coarse, source_coils_fine=sources_fine, **kwargs)
-            np.testing.assert_allclose(obj_all.dJ(), obj_split.dJ(), rtol=1e-6, atol=2e-22)
+            obj_split = ForceClass(
+                coil_a1, sources_coarse, source_coils_fine=sources_fine, **kwargs
+            )
+            np.testing.assert_allclose(
+                obj_all.dJ(), obj_split.dJ(), rtol=1e-6, atol=2e-22
+            )
 
         # Verify that source_coils_coarse must contain at least one coil not in target_coils
         with self.assertRaises(ValueError):
@@ -939,11 +1653,11 @@ class CoilForcesTest(unittest.TestCase):
         threshold = 1e-3
         # 20 % 7 = 6 (bad), 21 % 7 = 0 (good)
         curve_20 = CurveXYZFourier(20, 1)
-        curve_20.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * 1.0
+        curve_20.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * 1.0
         curve_21 = CurveXYZFourier(21, 1)
-        curve_21.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * 1.0
+        curve_21.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * 1.0
         curve_21b = CurveXYZFourier(21, 1)
-        curve_21b.x = np.array([0, 0, 1.1, 0, 1, 0, 0, 0., 0.]) * 1.0
+        curve_21b.x = np.array([0, 0, 1.1, 0, 1, 0, 0, 0.0, 0.0]) * 1.0
         coil_20 = RegularizedCoil(curve_20, Current(I), regularization_circ(0.05))
         coil_21 = RegularizedCoil(curve_21, Current(I), regularization_circ(0.05))
         coil_21b = RegularizedCoil(curve_21b, Current(I), regularization_circ(0.05))
@@ -954,9 +1668,13 @@ class CoilForcesTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             SquaredMeanForce(coil_20, [coil_21, coil_21b], downsample=7)
         with self.assertRaises(ValueError):
-            LpCurveForce(coil_20, [coil_21, coil_21b], p=2.5, threshold=threshold, downsample=7)
+            LpCurveForce(
+                coil_20, [coil_21, coil_21b], p=2.5, threshold=threshold, downsample=7
+            )
         with self.assertRaises(ValueError):
-            LpCurveTorque(coil_20, [coil_21, coil_21b], p=2.5, threshold=threshold, downsample=7)
+            LpCurveTorque(
+                coil_20, [coil_21, coil_21b], p=2.5, threshold=threshold, downsample=7
+            )
         with self.assertRaises(ValueError):
             SquaredMeanTorque(coil_20, [coil_21, coil_21b], downsample=7)
         with self.assertRaises(ValueError):
@@ -966,9 +1684,13 @@ class CoilForcesTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             SquaredMeanForce(coil_21, [coil_20, coil_21b], downsample=7)
         with self.assertRaises(ValueError):
-            LpCurveForce(coil_21, [coil_20, coil_21b], p=2.5, threshold=threshold, downsample=7)
+            LpCurveForce(
+                coil_21, [coil_20, coil_21b], p=2.5, threshold=threshold, downsample=7
+            )
         with self.assertRaises(ValueError):
-            LpCurveTorque(coil_21, [coil_20, coil_21b], p=2.5, threshold=threshold, downsample=7)
+            LpCurveTorque(
+                coil_21, [coil_20, coil_21b], p=2.5, threshold=threshold, downsample=7
+            )
         with self.assertRaises(ValueError):
             SquaredMeanTorque(coil_21, [coil_20, coil_21b], downsample=7)
         with self.assertRaises(ValueError):
@@ -979,14 +1701,14 @@ class CoilForcesTest(unittest.TestCase):
         I = 1.7e4
         # Group A: 40 quadpoints
         curve_a1 = CurveXYZFourier(40, 1)
-        curve_a1.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * 1.0
+        curve_a1.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * 1.0
         curve_a2 = CurveXYZFourier(40, 1)
-        curve_a2.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * 1.2
+        curve_a2.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * 1.2
         # Group B: 60 quadpoints
         curve_b1 = CurveXYZFourier(60, 1)
-        curve_b1.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * 0.8
+        curve_b1.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * 0.8
         curve_b2 = CurveXYZFourier(60, 1)
-        curve_b2.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * 1.5
+        curve_b2.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * 1.5
         coil_a1 = RegularizedCoil(curve_a1, Current(I), regularization_circ(0.05))
         coil_a2 = RegularizedCoil(curve_a2, Current(I), regularization_circ(0.05))
         coil_b1 = RegularizedCoil(curve_b1, Current(I), regularization_circ(0.05))
@@ -1030,6 +1752,7 @@ class CoilForcesTest(unittest.TestCase):
         A test passes if the Taylor error decreases rapidly (ideally quadratically) as the step size shrinks, confirming the correctness of the gradient implementation for all tested objectives and configurations.
         """
         import matplotlib.pyplot as plt
+
         ncoils_list = [2]
         nfp_list = [1, 3]
         stellsym_list = [True]
@@ -1059,7 +1782,7 @@ class CoilForcesTest(unittest.TestCase):
             deriv = np.sum(dJ * h)
             errors = []
             epsilons = []
-            
+
             for i in range(10, 16):
                 eps = 0.5**i
                 J.x = dofs + eps * h
@@ -1068,7 +1791,9 @@ class CoilForcesTest(unittest.TestCase):
                 Jm = J.J()
                 deriv_est = (Jp - Jm) / (2 * eps)
                 if np.abs(deriv) < 1e-8:
-                    err_new = np.abs(deriv_est - deriv)  # compute absolute error instead
+                    err_new = np.abs(
+                        deriv_est - deriv
+                    )  # compute absolute error instead
                 else:
                     err_new = np.abs(deriv_est - deriv) / np.abs(deriv)
                 # Check error decrease by at least a factor of 0.5, or pass if error is already below 1e-8
@@ -1090,66 +1815,185 @@ class CoilForcesTest(unittest.TestCase):
                                 for downsample in downsample_list:
                                     for use_jax_curve in jax_flag_list:
                                         for numquadpoints in numquadpoints_list:
-                                            base_curves = create_equally_spaced_curves(ncoils, nfp, stellsym, numquadpoints=numquadpoints, use_jax_curve=use_jax_curve)
-                                            base_curves2 = create_equally_spaced_curves(ncoils, nfp, stellsym, numquadpoints=numquadpoints, use_jax_curve=use_jax_curve)
-                                            base_currents = [Current(I) for _ in range(ncoils)]
-                                            coils = coils_via_symmetries(base_curves, base_currents, nfp, stellsym, regularizations=[regularization] * ncoils)
-                                            for ii in range(ncoils):
-                                                base_curves2[ii].x = base_curves2[ii].x + np.ones(len(base_curves2[ii].x)) * 0.1
-                                            coils2 = coils_via_symmetries(base_curves2, base_currents, nfp, stellsym, regularizations=[regularization] * ncoils)
-                                            objectives = [
-                                                sum([NetFluxes(coils[i], coils2) for i in range(len(coils))]),
-                                                B2Energy(coils + coils2, downsample=downsample),
-                                                LpCurveTorque(coils, coils2, p=p, threshold=threshold, downsample=downsample),
-                                                sum([LpCurveTorque(coils[i], coils2, p=p, threshold=threshold, downsample=downsample) for i in range(len(coils))]),
-                                                sum([SquaredMeanTorque(coils[i], coils2, downsample=downsample) for i in range(len(coils))]),
-                                                SquaredMeanTorque(coils, coils2, downsample=downsample),
-                                                sum([LpCurveForce(coils[i], coils2, p=p, threshold=threshold, downsample=downsample) for i in range(len(coils))]),
-                                                LpCurveForce(coils, coils2, p=p, threshold=threshold, downsample=downsample),
-                                                sum([SquaredMeanForce(coils[i], coils2, downsample=downsample) for i in range(len(coils))]),
-                                                SquaredMeanForce(coils, coils2, downsample=downsample),
+                                            base_curves = create_equally_spaced_curves(
+                                                ncoils,
+                                                nfp,
+                                                stellsym,
+                                                numquadpoints=numquadpoints,
+                                                use_jax_curve=use_jax_curve,
+                                            )
+                                            base_curves2 = create_equally_spaced_curves(
+                                                ncoils,
+                                                nfp,
+                                                stellsym,
+                                                numquadpoints=numquadpoints,
+                                                use_jax_curve=use_jax_curve,
+                                            )
+                                            base_currents = [
+                                                Current(I) for _ in range(ncoils)
                                             ]
-                                            dofs = np.copy(LpCurveTorque(coils, coils2, p=p, threshold=threshold, downsample=downsample).x)
+                                            coils = coils_via_symmetries(
+                                                base_curves,
+                                                base_currents,
+                                                nfp,
+                                                stellsym,
+                                                regularizations=[regularization]
+                                                * ncoils,
+                                            )
+                                            for ii in range(ncoils):
+                                                base_curves2[ii].x = (
+                                                    base_curves2[ii].x
+                                                    + np.ones(len(base_curves2[ii].x))
+                                                    * 0.1
+                                                )
+                                            coils2 = coils_via_symmetries(
+                                                base_curves2,
+                                                base_currents,
+                                                nfp,
+                                                stellsym,
+                                                regularizations=[regularization]
+                                                * ncoils,
+                                            )
+                                            objectives = [
+                                                sum(
+                                                    [
+                                                        NetFluxes(coils[i], coils2)
+                                                        for i in range(len(coils))
+                                                    ]
+                                                ),
+                                                B2Energy(
+                                                    coils + coils2,
+                                                    downsample=downsample,
+                                                ),
+                                                LpCurveTorque(
+                                                    coils,
+                                                    coils2,
+                                                    p=p,
+                                                    threshold=threshold,
+                                                    downsample=downsample,
+                                                ),
+                                                sum(
+                                                    [
+                                                        LpCurveTorque(
+                                                            coils[i],
+                                                            coils2,
+                                                            p=p,
+                                                            threshold=threshold,
+                                                            downsample=downsample,
+                                                        )
+                                                        for i in range(len(coils))
+                                                    ]
+                                                ),
+                                                sum(
+                                                    [
+                                                        SquaredMeanTorque(
+                                                            coils[i],
+                                                            coils2,
+                                                            downsample=downsample,
+                                                        )
+                                                        for i in range(len(coils))
+                                                    ]
+                                                ),
+                                                SquaredMeanTorque(
+                                                    coils, coils2, downsample=downsample
+                                                ),
+                                                sum(
+                                                    [
+                                                        LpCurveForce(
+                                                            coils[i],
+                                                            coils2,
+                                                            p=p,
+                                                            threshold=threshold,
+                                                            downsample=downsample,
+                                                        )
+                                                        for i in range(len(coils))
+                                                    ]
+                                                ),
+                                                LpCurveForce(
+                                                    coils,
+                                                    coils2,
+                                                    p=p,
+                                                    threshold=threshold,
+                                                    downsample=downsample,
+                                                ),
+                                                sum(
+                                                    [
+                                                        SquaredMeanForce(
+                                                            coils[i],
+                                                            coils2,
+                                                            downsample=downsample,
+                                                        )
+                                                        for i in range(len(coils))
+                                                    ]
+                                                ),
+                                                SquaredMeanForce(
+                                                    coils, coils2, downsample=downsample
+                                                ),
+                                            ]
+                                            dofs = np.copy(
+                                                LpCurveTorque(
+                                                    coils,
+                                                    coils2,
+                                                    p=p,
+                                                    threshold=threshold,
+                                                    downsample=downsample,
+                                                ).x
+                                            )
                                             h = np.ones_like(dofs)
                                             for J in objectives:
                                                 label = f"{type(J).__name__}, ncoils={ncoils}, nfp={nfp}, stellsym={stellsym}, p={getattr(J, 'p', p)}, threshold={getattr(J, 'threshold', threshold)}, reg={reg_name}, downsample={downsample}"
                                                 config_str = f"ncoils={ncoils}, nfp={nfp}, stellsym={stellsym}, p={p}, threshold={threshold}, reg={reg_name}, downsample={downsample}, use_jax_curve={use_jax_curve}, numquadpoints={numquadpoints}, objective={type(J).__name__}"
-                                                
+
                                                 # Run Taylor test with retry logic
                                                 success = False
                                                 last_error_msg = None
                                                 for attempt in range(max_retries):
-                                                    errors, epsilons, success, error_msg = run_taylor_test_for_objective(J, dofs, h)
+                                                    (
+                                                        errors,
+                                                        epsilons,
+                                                        success,
+                                                        error_msg,
+                                                    ) = run_taylor_test_for_objective(
+                                                        J, dofs, h
+                                                    )
                                                     if success:
                                                         if attempt > 0:
-                                                            print(f"{config_str} - PASSED on retry {attempt + 1}")
+                                                            print(
+                                                                f"{config_str} - PASSED on retry {attempt + 1}"
+                                                            )
                                                         else:
                                                             print(f"{config_str}")
                                                         break
                                                     else:
                                                         last_error_msg = error_msg
                                                         if attempt < max_retries - 1:
-                                                            print(f"{config_str} - Attempt {attempt + 1} failed, retrying... ({error_msg})")
-                                                
+                                                            print(
+                                                                f"{config_str} - Attempt {attempt + 1} failed, retrying... ({error_msg})"
+                                                            )
+
                                                 if not success:
                                                     # All retries failed
-                                                    print(f"{config_str} - FAILED after {max_retries} attempts")
-                                                    assert False, f"Taylor test failed after {max_retries} retries: {last_error_msg}"
-                                                
+                                                    print(
+                                                        f"{config_str} - FAILED after {max_retries} attempts"
+                                                    )
+                                                    assert False, (
+                                                        f"Taylor test failed after {max_retries} retries: {last_error_msg}"
+                                                    )
+
                                                 all_errors.append(errors)
                                                 all_labels.append(label)
                                                 all_eps.append(epsilons)
         # Plot all errors
         plt.figure(figsize=(14, 8))
         for errors, label, epsilons in zip(all_errors, all_labels, all_eps):
-            plt.loglog(epsilons, errors, marker='o', label=label)
-        plt.xlabel('eps')
-        plt.ylabel('Relative Taylor error')
-        plt.title('Taylor test errors for all objectives and parameter sweeps')
-        plt.legend(fontsize=6, loc='upper left', bbox_to_anchor=(1, 1))
+            plt.loglog(epsilons, errors, marker="o", label=label)
+        plt.xlabel("eps")
+        plt.ylabel("Relative Taylor error")
+        plt.title("Taylor test errors for all objectives and parameter sweeps")
+        plt.legend(fontsize=6, loc="upper left", bbox_to_anchor=(1, 1))
         plt.grid(True)
         plt.tight_layout()
-        plt.savefig('taylor_errors.png')
+        plt.savefig("taylor_errors.png")
 
     def test_objectives_time(self):
         import time
@@ -1185,10 +2029,18 @@ class CoilForcesTest(unittest.TestCase):
             print(f"\n--- Timing tests for ncoils = {ncoils} ---")
             base_curves = create_equally_spaced_curves(ncoils, nfp, True)
             base_currents = [Current(I) for j in range(ncoils)]
-            coils = coils_via_symmetries(base_curves, base_currents, nfp, True, regularizations=[regularization] * ncoils)
+            coils = coils_via_symmetries(
+                base_curves,
+                base_currents,
+                nfp,
+                True,
+                regularizations=[regularization] * ncoils,
+            )
             base_curves2 = create_equally_spaced_curves(ncoils, nfp, True)
             for i in range(ncoils):
-                base_curves2[i].x = base_curves2[i].x + np.ones(len(base_curves2[i].x)) * 0.01
+                base_curves2[i].x = (
+                    base_curves2[i].x + np.ones(len(base_curves2[i].x)) * 0.01
+                )
             coils2 = coils_via_symmetries(base_curves2, base_currents, nfp, True)
             for c in coils:
                 c.regularization = regularization
@@ -1197,13 +2049,37 @@ class CoilForcesTest(unittest.TestCase):
             # LpCurveForce, LpCurveTorque, SquaredMeanForce, SquaredMeanTorque: sum over all coils
             # Mixed objectives are faster if coils are split evenly into two groups
             objectives = [
-                sum([LpCurveForce(coils[i], coils2, p=p, threshold=threshold, downsample=2) for i in range(len(coils))]),
+                sum(
+                    [
+                        LpCurveForce(
+                            coils[i], coils2, p=p, threshold=threshold, downsample=2
+                        )
+                        for i in range(len(coils))
+                    ]
+                ),
                 LpCurveForce(coils, coils2, p=p, threshold=threshold, downsample=2),
-                sum([LpCurveTorque(coils[i], coils2, p=p, threshold=threshold, downsample=2) for i in range(len(coils))]),
+                sum(
+                    [
+                        LpCurveTorque(
+                            coils[i], coils2, p=p, threshold=threshold, downsample=2
+                        )
+                        for i in range(len(coils))
+                    ]
+                ),
                 LpCurveTorque(coils, coils2, p=p, threshold=threshold, downsample=2),
-                sum([SquaredMeanForce(coils[i], coils2, downsample=2) for i in range(len(coils))]),
+                sum(
+                    [
+                        SquaredMeanForce(coils[i], coils2, downsample=2)
+                        for i in range(len(coils))
+                    ]
+                ),
                 SquaredMeanForce(coils, coils2, downsample=2),
-                sum([SquaredMeanTorque(coils[i], coils2, downsample=2) for i in range(len(coils))]),
+                sum(
+                    [
+                        SquaredMeanTorque(coils[i], coils2, downsample=2)
+                        for i in range(len(coils))
+                    ]
+                ),
                 SquaredMeanTorque(coils, coils2, downsample=2),
             ]
 
@@ -1214,12 +2090,12 @@ class CoilForcesTest(unittest.TestCase):
                 obj.J()
                 t2 = time.time()
                 compile_times_J[i, idx_n] = t2 - t1
-                print(f'{obj_label}: Compilation (J) took {t2 - t1:.6f} seconds')
+                print(f"{obj_label}: Compilation (J) took {t2 - t1:.6f} seconds")
                 t1 = time.time()
                 obj.dJ()
                 t2 = time.time()
                 compile_times_dJ[i, idx_n] = t2 - t1
-                print(f'{obj_label}: Compilation (dJ) took {t2 - t1:.6f} seconds')
+                print(f"{obj_label}: Compilation (dJ) took {t2 - t1:.6f} seconds")
 
                 # Run time (second call)
                 print("Timing run (second call):")
@@ -1227,25 +2103,38 @@ class CoilForcesTest(unittest.TestCase):
                 obj.J()
                 t2 = time.time()
                 runtimes_J[i, idx_n] = t2 - t1
-                print(f'{obj_label}: Run (J) took {t2 - t1:.6f} seconds')
+                print(f"{obj_label}: Run (J) took {t2 - t1:.6f} seconds")
                 t1 = time.time()
                 obj.dJ()
                 t2 = time.time()
                 runtimes_dJ[i, idx_n] = t2 - t1
-                print(f'{obj_label}: Run (dJ) took {t2 - t1:.6f} seconds')
+                print(f"{obj_label}: Run (dJ) took {t2 - t1:.6f} seconds")
 
         # Optionally, plot the results
         plt.figure(figsize=(10, 7))
-        markers = ['o', 's', 'D', '^', 'v', '<', '>', 'x', '+']
+        markers = ["o", "s", "D", "^", "v", "<", ">", "x", "+"]
         colors = plt.cm.tab10.colors
         for i, label in enumerate(objective_classes):
-            plt.semilogy(ncoils_list, runtimes_J[i], marker=markers[i % len(markers)], color=colors[i % len(colors)], label=f"{label} J()")
-            plt.semilogy(ncoils_list, runtimes_dJ[i], marker=markers[i % len(markers)], linestyle='--', color=colors[i % len(colors)], label=f"{label} dJ()")
+            plt.semilogy(
+                ncoils_list,
+                runtimes_J[i],
+                marker=markers[i % len(markers)],
+                color=colors[i % len(colors)],
+                label=f"{label} J()",
+            )
+            plt.semilogy(
+                ncoils_list,
+                runtimes_dJ[i],
+                marker=markers[i % len(markers)],
+                linestyle="--",
+                color=colors[i % len(colors)],
+                label=f"{label} dJ()",
+            )
         plt.xlabel("Number of coils")
         plt.ylabel("Run time (s)")
         plt.title("Objective run times as a function of number of coils")
         plt.legend(fontsize=8)
-        plt.grid(True, which='both', ls='--')
+        plt.grid(True, which="both", ls="--")
         plt.tight_layout()
         plt.savefig("objective_runtimes_semilogy.png")
         print("Run times saved to objective_runtimes_semilogy.png")
@@ -1254,38 +2143,40 @@ class CoilForcesTest(unittest.TestCase):
         """Test that force, torque, and energy objectives require RegularizedCoil objects."""
         # Create regular Coil objects (not RegularizedCoil)
         curve = CurveXYZFourier(20, 1)
-        curve.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * 1.0
+        curve.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * 1.0
         current = Current(1.7e4)
         coil = Coil(curve, current)
-        
+
         # Create RegularizedCoil for comparison
         regularization = regularization_circ(0.05)
         reg_coil = RegularizedCoil(curve, current, regularization)
         # Create a second coil for force/torque objectives (source_coils must have at least one coil not in target)
         curve2 = CurveXYZFourier(20, 1)
-        curve2.x = np.array([0, 0, 1.1, 0, 1, 0, 0, 0., 0.]) * 1.0  # Slightly different from curve
+        curve2.x = (
+            np.array([0, 0, 1.1, 0, 1, 0, 0, 0.0, 0.0]) * 1.0
+        )  # Slightly different from curve
         reg_coil2 = RegularizedCoil(curve2, current, regularization)
-        
+
         # Test that regular Coil objects raise ValueError for force/torque/energy objectives
         threshold = 1e-3
         with self.assertRaises(ValueError):
             LpCurveForce(coil, [reg_coil], p=2.5, threshold=threshold)
-        
+
         # Net forces do not include a self-force, so no issue!
         SquaredMeanForce(coil, [reg_coil])
         SquaredMeanForce(coil, reg_coil)  # should not raise ValueError
         SquaredMeanTorque(coil, [reg_coil])
         SquaredMeanTorque(coil, reg_coil)  # should not raise ValueError
-        
+
         with self.assertRaises(ValueError):
             LpCurveTorque(coil, [reg_coil], p=2.5, threshold=threshold)
-        
+
         # Net torques do not include a self-torque, so no issue!
         SquaredMeanTorque(coil, [reg_coil])
-        
+
         with self.assertRaises(ValueError):
             B2Energy([coil, reg_coil])
-        
+
         # Test that RegularizedCoil objects work fine (source_coils_coarse must have at least one coil not in target)
         try:
             LpCurveForce(reg_coil, [reg_coil, reg_coil2], p=2.5, threshold=threshold)
@@ -1302,8 +2193,13 @@ class CoilForcesTest(unittest.TestCase):
         nfp, ncoils = 2, 3
         base_curves = create_equally_spaced_curves(ncoils, nfp, True, numquadpoints=30)
         base_currents = [Current(I) for _ in range(ncoils)]
-        coils = coils_via_symmetries(base_curves, base_currents, nfp, True,
-                                     regularizations=[regularization_circ(0.05)] * ncoils)
+        coils = coils_via_symmetries(
+            base_curves,
+            base_currents,
+            nfp,
+            True,
+            regularizations=[regularization_circ(0.05)] * ncoils,
+        )
         target = coils[0]
         sources_all = coils[1:]
         # Split: first half in coarse, second half in fine
@@ -1313,34 +2209,78 @@ class CoilForcesTest(unittest.TestCase):
 
         # SquaredMeanForce: J(coarse+fine) == J(all in coarse)
         J_all_coarse = float(SquaredMeanForce(target, sources_all).J())
-        J_split = float(SquaredMeanForce(target, sources_coarse, source_coils_fine=sources_fine).J())
-        np.testing.assert_allclose(J_all_coarse, J_split, rtol=1e-10,
-                                   err_msg="SquaredMeanForce: coarse+fine should equal all-coarse")
+        J_split = float(
+            SquaredMeanForce(target, sources_coarse, source_coils_fine=sources_fine).J()
+        )
+        np.testing.assert_allclose(
+            J_all_coarse,
+            J_split,
+            rtol=1e-10,
+            err_msg="SquaredMeanForce: coarse+fine should equal all-coarse",
+        )
 
         # SquaredMeanTorque: same check (use atol for very small values)
         J_all_coarse = float(SquaredMeanTorque(target, sources_all).J())
-        J_split = float(SquaredMeanTorque(target, sources_coarse, source_coils_fine=sources_fine).J())
-        np.testing.assert_allclose(J_all_coarse, J_split, rtol=1e-8, atol=1e-30,
-                                   err_msg="SquaredMeanTorque: coarse+fine should equal all-coarse")
+        J_split = float(
+            SquaredMeanTorque(
+                target, sources_coarse, source_coils_fine=sources_fine
+            ).J()
+        )
+        np.testing.assert_allclose(
+            J_all_coarse,
+            J_split,
+            rtol=1e-8,
+            atol=1e-30,
+            err_msg="SquaredMeanTorque: coarse+fine should equal all-coarse",
+        )
 
         # LpCurveForce: same check
         p, thresh = 2.5, 1e-3
-        J_all_coarse = float(LpCurveForce(target, sources_all, p=p, threshold=thresh).J())
-        J_split = float(LpCurveForce(target, sources_coarse, source_coils_fine=sources_fine, p=p, threshold=thresh).J())
-        np.testing.assert_allclose(J_all_coarse, J_split, rtol=1e-10,
-                                   err_msg="LpCurveForce: coarse+fine should equal all-coarse")
+        J_all_coarse = float(
+            LpCurveForce(target, sources_all, p=p, threshold=thresh).J()
+        )
+        J_split = float(
+            LpCurveForce(
+                target,
+                sources_coarse,
+                source_coils_fine=sources_fine,
+                p=p,
+                threshold=thresh,
+            ).J()
+        )
+        np.testing.assert_allclose(
+            J_all_coarse,
+            J_split,
+            rtol=1e-10,
+            err_msg="LpCurveForce: coarse+fine should equal all-coarse",
+        )
 
         # LpCurveTorque: same check
-        J_all_coarse = float(LpCurveTorque(target, sources_all, p=p, threshold=thresh).J())
-        J_split = float(LpCurveTorque(target, sources_coarse, source_coils_fine=sources_fine, p=p, threshold=thresh).J())
-        np.testing.assert_allclose(J_all_coarse, J_split, rtol=1e-10,
-                                   err_msg="LpCurveTorque: coarse+fine should equal all-coarse")
+        J_all_coarse = float(
+            LpCurveTorque(target, sources_all, p=p, threshold=thresh).J()
+        )
+        J_split = float(
+            LpCurveTorque(
+                target,
+                sources_coarse,
+                source_coils_fine=sources_fine,
+                p=p,
+                threshold=thresh,
+            ).J()
+        )
+        np.testing.assert_allclose(
+            J_all_coarse,
+            J_split,
+            rtol=1e-10,
+            err_msg="LpCurveTorque: coarse+fine should equal all-coarse",
+        )
 
         # source_coils_fine=[] should match no fine
-        J_no_fine = float(SquaredMeanForce(target, sources_all, source_coils_fine=[]).J())
+        J_no_fine = float(
+            SquaredMeanForce(target, sources_all, source_coils_fine=[]).J()
+        )
         J_all_only = float(SquaredMeanForce(target, sources_all).J())
         np.testing.assert_allclose(J_no_fine, J_all_only, rtol=1e-10)
-
 
     def test_lpcurveforces_taylor_test(self):
         """Verify that dJ matches finite differences of J"""
@@ -1349,9 +2289,14 @@ class CoilForcesTest(unittest.TestCase):
 
         base_curves, base_currents, axis, nfp, bs = get_data("ncsx", coil_order=2)
         regularization = regularization_circ(0.05)
-        coils = coils_via_symmetries(base_curves, base_currents, nfp, True,
-                                     regularizations=[regularization] * len(base_curves))
-        
+        coils = coils_via_symmetries(
+            base_curves,
+            base_currents,
+            nfp,
+            True,
+            regularizations=[regularization] * len(base_curves),
+        )
+
         threshold = 1e-3  # Threshold in MN/m (equivalent to 1.0e3 N/m)
         J = LpCurveForce(coils[0], coils, p=2.5, threshold=threshold)
         dJ = J.dJ()
@@ -1367,7 +2312,20 @@ class CoilForcesTest(unittest.TestCase):
             Jm = J.J()
             deriv_est = (Jp - Jm) / (2 * eps)
             err_new = np.abs(deriv_est - deriv) / np.abs(deriv)
-            print("test_lpcurveforces_taylor_test i:", i, "deriv_est:", deriv_est, "deriv:", deriv, "err_new:", err_new, "err:", err, "ratio:", err_new / err)
+            print(
+                "test_lpcurveforces_taylor_test i:",
+                i,
+                "deriv_est:",
+                deriv_est,
+                "deriv:",
+                deriv,
+                "err_new:",
+                err_new,
+                "err:",
+                err,
+                "ratio:",
+                err_new / err,
+            )
             np.testing.assert_array_less(err_new, 0.31 * err)
             err = err_new
 
@@ -1381,62 +2339,62 @@ class CoilForcesTest(unittest.TestCase):
 
         # Create a circle of radius R0 in the x-y plane:
         curve = CurveXYZFourier(N_quad, order)
-        curve.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * R0
-        
+        curve.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * R0
+
         current = Current(I)
         coil = CircularRegularizedCoil(curve, current, a)
-        
+
         # Test that it's a RegularizedCoil
         self.assertIsInstance(coil, RegularizedCoil)
         self.assertIsInstance(coil, CircularRegularizedCoil)
-        
+
         # Test that regularization was computed correctly
         expected_reg = regularization_circ(a)
         np.testing.assert_allclose(coil.regularization, expected_reg, rtol=1e-10)
         self.assertEqual(coil.a, a)
-        
+
         # Test B_regularized method
         B_reg = coil.B_regularized()
         self.assertEqual(B_reg.shape, (N_quad, 3))
         self.assertTrue(np.all(np.isfinite(B_reg)))
-        
+
         # Test self_force method
         force = coil.self_force()
         self.assertEqual(force.shape, (N_quad, 3))
         self.assertTrue(np.all(np.isfinite(force)))
-        
+
         # Verify it matches creating a new coil
         coil_alt = CircularRegularizedCoil(curve, current, a)
         force_alt = coil_alt.self_force()
         np.testing.assert_allclose(force, force_alt, rtol=1e-10)
-        
+
         # Test force method with other coils
         nfp = 3
         ncoils = 4
         base_curves = create_equally_spaced_curves(ncoils, nfp, True)
         base_currents = [Current(I) for j in range(ncoils)]
         coils = coils_via_symmetries(base_curves, base_currents, nfp, True)
-        
+
         # Test force method
         force_from_others = coil.force(coils)
         self.assertEqual(force_from_others.shape, (N_quad, 3))
         self.assertTrue(np.all(np.isfinite(force_from_others)))
-        
+
         # Test net_force method
         net_force = coil.net_force(coils)
         self.assertEqual(net_force.shape, (3,))
         self.assertTrue(np.all(np.isfinite(net_force)))
-        
+
         # Test torque method
         torque = coil.torque(coils)
         self.assertEqual(torque.shape, (N_quad, 3))
         self.assertTrue(np.all(np.isfinite(torque)))
-        
+
         # Test net_torque method
         net_torque = coil.net_torque(coils)
         self.assertEqual(net_torque.shape, (3,))
         self.assertTrue(np.all(np.isfinite(net_torque)))
-        
+
         # Verify it matches using RegularizedCoil directly
         reg_val = regularization_circ(a)
         coil_reg = RegularizedCoil(curve, current, reg_val)
@@ -1444,7 +2402,7 @@ class CoilForcesTest(unittest.TestCase):
         net_force_reg = coil_reg.net_force(coils)
         torque_reg = coil_reg.torque(coils)
         net_torque_reg = coil_reg.net_torque(coils)
-        
+
         np.testing.assert_allclose(force_from_others, force_reg, rtol=1e-10)
         np.testing.assert_allclose(net_force, net_force_reg, rtol=1e-10)
         np.testing.assert_allclose(torque, torque_reg, rtol=1e-10)
@@ -1461,63 +2419,63 @@ class CoilForcesTest(unittest.TestCase):
 
         # Create a circle of radius R0 in the x-y plane:
         curve = CurveXYZFourier(N_quad, order)
-        curve.x = np.array([0, 0, 1, 0, 1, 0, 0, 0., 0.]) * R0
-        
+        curve.x = np.array([0, 0, 1, 0, 1, 0, 0, 0.0, 0.0]) * R0
+
         current = Current(I)
         coil = RectangularRegularizedCoil(curve, current, a, b)
-        
+
         # Test that it's a RegularizedCoil
         self.assertIsInstance(coil, RegularizedCoil)
         self.assertIsInstance(coil, RectangularRegularizedCoil)
-        
+
         # Test that regularization was computed correctly
         expected_reg = regularization_rect(a, b)
         np.testing.assert_allclose(coil.regularization, expected_reg, rtol=1e-10)
         self.assertEqual(coil.a, a)
         self.assertEqual(coil.b, b)
-        
+
         # Test B_regularized method
         B_reg = coil.B_regularized()
         self.assertEqual(B_reg.shape, (N_quad, 3))
         self.assertTrue(np.all(np.isfinite(B_reg)))
-        
+
         # Test self_force method
         force = coil.self_force()
         self.assertEqual(force.shape, (N_quad, 3))
         self.assertTrue(np.all(np.isfinite(force)))
-        
+
         # Verify it matches creating a new coil
         coil_alt = RectangularRegularizedCoil(curve, current, a, b)
         force_alt = coil_alt.self_force()
         np.testing.assert_allclose(force, force_alt, rtol=1e-10)
-        
+
         # Test force method with other coils
         nfp = 3
         ncoils = 4
         base_curves = create_equally_spaced_curves(ncoils, nfp, True)
         base_currents = [Current(I) for j in range(ncoils)]
         coils = coils_via_symmetries(base_curves, base_currents, nfp, True)
-        
+
         # Test force method
         force_from_others = coil.force(coils)
         self.assertEqual(force_from_others.shape, (N_quad, 3))
         self.assertTrue(np.all(np.isfinite(force_from_others)))
-        
+
         # Test net_force method
         net_force = coil.net_force(coils)
         self.assertEqual(net_force.shape, (3,))
         self.assertTrue(np.all(np.isfinite(net_force)))
-        
+
         # Test torque method
         torque_from_others = coil.torque(coils)
         self.assertEqual(torque_from_others.shape, (N_quad, 3))
         self.assertTrue(np.all(np.isfinite(torque_from_others)))
-        
+
         # Test net_torque method
         net_torque = coil.net_torque(coils)
         self.assertEqual(net_torque.shape, (3,))
         self.assertTrue(np.all(np.isfinite(net_torque)))
-        
+
         # Verify all methods match using RegularizedCoil directly
         reg_val = regularization_rect(a, b)
         coil_reg = RegularizedCoil(curve, current, reg_val)
@@ -1525,7 +2483,7 @@ class CoilForcesTest(unittest.TestCase):
         net_force_reg = coil_reg.net_force(coils)
         torque_reg = coil_reg.torque(coils)
         net_torque_reg = coil_reg.net_torque(coils)
-        
+
         np.testing.assert_allclose(force_from_others, force_reg, rtol=1e-10)
         np.testing.assert_allclose(net_force, net_force_reg, rtol=1e-10)
         np.testing.assert_allclose(torque_from_others, torque_reg, rtol=1e-10)
@@ -1540,64 +2498,69 @@ class CoilForcesTest(unittest.TestCase):
 
         base_curves = create_equally_spaced_curves(ncoils, nfp, True)
         base_currents = [Current(I) for j in range(ncoils)]
-        coils = coils_via_symmetries(base_curves, base_currents, nfp, True,
-                                     regularizations=[regularization] * ncoils)
+        coils = coils_via_symmetries(
+            base_curves,
+            base_currents,
+            nfp,
+            True,
+            regularizations=[regularization] * ncoils,
+        )
 
         target_coil = coils[0]
         source_coils = coils
-        
+
         # Test B_regularized returns correct shape
         B_reg = target_coil.B_regularized()
         n_points = len(target_coil.curve.quadpoints)
         self.assertEqual(B_reg.shape, (n_points, 3))
         self.assertTrue(np.all(np.isfinite(B_reg)))
-        
+
         # Test self_force returns correct shape
         self_force = target_coil.self_force()
         self.assertEqual(self_force.shape, (n_points, 3))
         self.assertTrue(np.all(np.isfinite(self_force)))
-        
+
         # Test force returns correct shape
         force = target_coil.force(source_coils)
         self.assertEqual(force.shape, (n_points, 3))
         self.assertTrue(np.all(np.isfinite(force)))
-        
+
         # Test net_force returns correct shape
         net_force = target_coil.net_force(source_coils)
         self.assertEqual(net_force.shape, (3,))
         self.assertTrue(np.all(np.isfinite(net_force)))
-        
+
         # Test torque returns correct shape
         torque = target_coil.torque(source_coils)
         self.assertEqual(torque.shape, (n_points, 3))
         self.assertTrue(np.all(np.isfinite(torque)))
-        
+
         # Test net_torque returns correct shape
         net_torque = target_coil.net_torque(source_coils)
         self.assertEqual(net_torque.shape, (3,))
         self.assertTrue(np.all(np.isfinite(net_torque)))
-        
+
         # Test that force includes both self and mutual contributions
         # Force should be non-zero for interacting coils
         self.assertTrue(np.linalg.norm(force) > 0)
-        
+
         # Test that net_force is consistent with integrating force
         gammadash = target_coil.curve.gammadash()
         gammadash_norm = np.linalg.norm(gammadash, axis=1)[:, None]
         net_force_manual = np.sum(gammadash_norm * force, axis=0) / gammadash.shape[0]
         np.testing.assert_allclose(net_force, net_force_manual, rtol=1e-10)
-        
+
         # Test that torque is perpendicular to force (torque = r x force)
         gamma = target_coil.curve.gamma()
         center = target_coil.curve.centroid()
         r = gamma - center
         torque_manual = np.cross(r, force)
         np.testing.assert_allclose(torque, torque_manual, rtol=1e-10)
-        
+
         # Test that net_torque is consistent with integrating torque
         net_torque_manual = np.sum(gammadash_norm * torque, axis=0) / gammadash.shape[0]
         np.testing.assert_allclose(net_torque, net_torque_manual, rtol=1e-10)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I implemented the full B field for self-field in the winding pack according to the paper of Dr. Landreman
(https://iopscience.iop.org/article/10.1088/1741-4326/adb04e/meta).

Currently, the simsopt repository only includes B_regularized in src/simsopt/field/selffield.py (and also in the coil class in coil.py). I added B_0, B_kappa and B_b. 

There are 3 main additions (the rest is due to autopep and ruff):
in selffield.py : the direct implementation of the different B field computation (from line 174)
in coil.py: the three B field contributions are added in the class "RectangularRegulaziedCoil" (from line 266)
in test_selffieldforces.py : added some assert to ensure that the tests pass for the new B fields (line 566 to 589)

This code has already been used by at IPP (Garching, Germany) for a paper about Ic-optimisation in the winding pack (currently in writing).

I remain available for any question.

Kind regards