### PR TITLE
Fix B_external_normal_extended

### DIFF
--- a/src/simsopt/mhd/virtual_casing.py
+++ b/src/simsopt/mhd/virtual_casing.py
@@ -328,6 +328,11 @@ class VirtualCasing:
             trgt_nphi.description = 'Number of grid points in the toroidal angle phi for resulting B_external'
             trgt_nphi.units = 'Dimensionless'
 
+            trgt_nphi_extended = f.createVariable('trgt_nphi_extended', 'i', tuple())
+            trgt_nphi_extended.data[()] = self.trgt_nphi_extended
+            trgt_nphi_extended.description = 'Number of grid points in the toroidal angle phi for resulting B_external (extended to full torus)'
+            trgt_nphi_extended.units = 'Dimensionless'
+
             nfp = f.createVariable('nfp', 'i', tuple())
             nfp.data[()] = self.nfp
             nfp.description = 'Periodicity in toroidal direction'

--- a/src/simsopt/mhd/virtual_casing.py
+++ b/src/simsopt/mhd/virtual_casing.py
@@ -269,10 +269,12 @@ class VirtualCasing:
         vc.B_external = Bexternal3d
         vc.B_external_normal = Bexternal_normal
 
-        Bexternal_normal_with_last_point = np.hstack((Bexternal_normal, Bexternal_normal[:, [0]]))
-        Bexternal_normal_with_last_point = np.vstack((Bexternal_normal_with_last_point, -np.flip(np.flip(Bexternal_normal_with_last_point, axis=0), axis=1)[0]))
-        flipped_B = -np.flip(np.flip(Bexternal_normal_with_last_point, axis=0), axis=1)
-        vc.B_external_normal_extended = np.concatenate([np.concatenate((Bexternal_normal, flipped_B[:-1, :-1])) for i in range(nfp)])
+        # Rotate by 180 degrees and flip sign, being careful that the theta grid
+        # includes theta=0 but not theta=1. See github issue #641.
+        idx_theta = (-np.arange(trgt_ntheta)) % trgt_ntheta
+        vc.B_external_normal_extended = np.tile(
+            np.concatenate((Bexternal_normal, -Bexternal_normal[::-1][:, idx_theta])), (nfp, 1)
+        )
 
         if filename is not None:
             if filename == 'auto':

--- a/src/simsopt/mhd/virtual_casing.py
+++ b/src/simsopt/mhd/virtual_casing.py
@@ -87,7 +87,9 @@ class VirtualCasing:
     - ``B_external_normal``: An array of size ``(trgt_nphi, trgt_ntheta)`` with the contribution
       to the magnetic field due to current outside the surface, taking just the component
       normal to the surface.
-    - r``B_external_normal_extended``: An array of size ``(trgt_nphi * nfp * 2, trgt_ntheta)`` with the contribution
+    - r``B_external_normal_extended``: An array of size ``(trgt_nphi * nfp * 2, trgt_ntheta)`` 
+      (if ``use_stellsym=True``) or ``(trgt_nphi * nfp, trgt_ntheta)`` (if
+      ``use_stellsym=False``) with the contribution
       to the magnetic field due to current outside the surface, taking just the component
       normal to the surface. This is an extension of the B_external_normal array to cover the full torus.
 
@@ -269,12 +271,17 @@ class VirtualCasing:
         vc.B_external = Bexternal3d
         vc.B_external_normal = Bexternal_normal
 
-        # Rotate by 180 degrees and flip sign, being careful that the theta grid
-        # includes theta=0 but not theta=1. See github issue #641.
-        idx_theta = (-np.arange(trgt_ntheta)) % trgt_ntheta
-        vc.B_external_normal_extended = np.tile(
-            np.concatenate((Bexternal_normal, -Bexternal_normal[::-1][:, idx_theta])), (nfp, 1)
-        )
+        if use_stellsym:
+            # Rotate the first half-period by 180 degrees and flip sign, being careful that the theta grid
+            # includes theta=0 but not theta=1. See github issue #641.
+            vc.trgt_nphi_extended = 2 * nfp * trgt_nphi
+            idx_theta = (-np.arange(trgt_ntheta)) % trgt_ntheta
+            vc.B_external_normal_extended = np.tile(
+                np.concatenate((Bexternal_normal, -Bexternal_normal[::-1][:, idx_theta])), (nfp, 1)
+            )
+        else:
+            vc.trgt_nphi_extended = nfp * trgt_nphi
+            vc.B_external_normal_extended = np.tile(Bexternal_normal, (nfp, 1))
 
         if filename is not None:
             if filename == 'auto':
@@ -298,7 +305,7 @@ class VirtualCasing:
             f.createDimension('src_nphi', self.src_nphi)
             f.createDimension('trgt_ntheta', self.trgt_ntheta)
             f.createDimension('trgt_nphi', self.trgt_nphi)
-            f.createDimension('trgt_nphi_extended', self.trgt_nphi * 2 * self.nfp)
+            f.createDimension('trgt_nphi_extended', self.trgt_nphi_extended)
             f.createDimension('xyz', 3)
 
             src_ntheta = f.createVariable('src_ntheta', 'i', tuple())

--- a/tests/mhd/test_virtual_casing.py
+++ b/tests/mhd/test_virtual_casing.py
@@ -81,12 +81,22 @@ class VirtualCasingTests(unittest.TestCase):
 
         vmec = Vmec(filename)
         nphi_fac = 1 if use_stellsym else 2
+        trgt_nphi = 32
         vc = VirtualCasing.from_vmec(vmec, src_nphi=25 * nphi_fac,
-                                     trgt_nphi=32, trgt_ntheta=32, use_stellsym=use_stellsym)
+                                     trgt_nphi=trgt_nphi, trgt_ntheta=32, use_stellsym=use_stellsym)
 
         nfp = vmec.wout.nfp
+        if use_stellsym:
+            trgt_nphi_extended = trgt_nphi * 2 * nfp
+            trgt_phi_extended = (0.5 + np.arange(2 * nfp * trgt_nphi)) / (2 * nfp * trgt_nphi)
+        else:
+            trgt_nphi_extended = trgt_nphi * nfp
+            trgt_phi_extended = np.arange(nfp * trgt_nphi) / (nfp * trgt_nphi)
+
         theta, phi = np.meshgrid(2 * np.pi * vc.trgt_theta, 2 * np.pi * vc.trgt_phi)
+        theta_extended, phi_extended = np.meshgrid(2 * np.pi * vc.trgt_theta, 2 * np.pi * trgt_phi_extended)
         B_external_normal_bnorm = np.zeros((vc.trgt_nphi, vc.trgt_ntheta))
+        B_external_normal_extended_bnorm = np.zeros((trgt_nphi_extended, vc.trgt_ntheta))
 
         # Read BNORM output file:
         with open(bnorm_filename, 'r') as f:
@@ -100,6 +110,7 @@ class VirtualCasingTests(unittest.TestCase):
             n = int(splitline[1])
             amplitude = float(splitline[2])
             B_external_normal_bnorm += amplitude * np.sin(m * theta + n * nfp * phi)
+            B_external_normal_extended_bnorm += amplitude * np.sin(m * theta_extended + n * nfp * phi_extended)
             # To see that it should be (mu+nv) rather than (mu-nv) in the above line, you can examine
             # BNORM/Sources/bn_fouri.f (where the arrays in the bnorm files are computed)
             # or NESCOIL/Sources/bnfld.f (where bnorm files are read)
@@ -107,6 +118,7 @@ class VirtualCasingTests(unittest.TestCase):
         # The BNORM code divides Bnormal by curpol. Undo this scaling now:
         curpol = (2 * np.pi / nfp) * (1.5 * vmec.wout.bsubvmnc[0, -1] - 0.5 * vmec.wout.bsubvmnc[0, -2])
         B_external_normal_bnorm *= curpol
+        B_external_normal_extended_bnorm *= curpol
 
         difference = B_external_normal_bnorm - vc.B_external_normal
         avg = 0.5 * (B_external_normal_bnorm + vc.B_external_normal)
@@ -116,6 +128,14 @@ class VirtualCasingTests(unittest.TestCase):
         logger.info('Diff between BNORM and virtual_casing: '
                     f'abs={np.max(np.abs(difference))}, rel={np.max(np.abs(rel_difference))}')
         np.testing.assert_allclose(B_external_normal_bnorm, vc.B_external_normal, atol=0.0061)
+
+        difference = B_external_normal_extended_bnorm - vc.B_external_normal_extended
+        avg = 0.5 * (B_external_normal_extended_bnorm + vc.B_external_normal_extended)
+        rms = np.sqrt(np.mean(avg ** 2))
+        rel_difference = difference / rms
+        logger.info('Diff between BNORM and virtual_casing on extended grid: '
+                    f'abs={np.max(np.abs(difference))}, rel={np.max(np.abs(rel_difference))}')
+        np.testing.assert_allclose(B_external_normal_extended_bnorm, vc.B_external_normal_extended, atol=0.0061)
 
         if 0:
             import matplotlib.pyplot as plt

--- a/tests/mhd/test_virtual_casing.py
+++ b/tests/mhd/test_virtual_casing.py
@@ -31,9 +31,9 @@ logger = logging.getLogger(__name__)
 #logging.basicConfig(level=logging.INFO)
 
 variables = [
-    'src_nphi', 'src_ntheta', 'src_phi', 'src_theta', 'trgt_nphi',
+    'src_nphi', 'src_ntheta', 'src_phi', 'src_theta', 'trgt_nphi', 'trgt_nphi_extended',
     'trgt_ntheta', 'trgt_phi', 'trgt_theta', 'gamma', 'unit_normal',
-    'B_total', 'B_external', 'B_external_normal'
+    'B_total', 'B_external', 'B_external_normal', "B_external_normal_extended"
 ]
 
 
@@ -174,14 +174,28 @@ class VirtualCasingTests(unittest.TestCase):
         fields of the objects should all match.
         """
         filename = os.path.join(TEST_DIR, 'wout_20220102-01-053-003_QH_nfp4_aspect6p5_beta0p05_iteratedWithSfincs_reference.nc')
-        with ScratchDir("."):
-            vc1 = VirtualCasing.from_vmec(filename, src_nphi=11, src_ntheta=12, trgt_nphi=13, trgt_ntheta=11, filename='vcasing.nc')
-            vc2 = VirtualCasing.load('vcasing.nc')
-            for variable in variables:
-                variable1 = eval('vc1.' + variable)
-                variable2 = eval('vc2.' + variable)
-                logger.info(f'Variable {variable} in vc1 is {variable1} and in vc2 is {variable2}')
-                np.testing.assert_allclose(variable1, variable2)
+        for use_stellsym in [True, False]:
+            with ScratchDir("."):
+                vc1 = VirtualCasing.from_vmec(
+                    filename,
+                    use_stellsym=use_stellsym,
+                    src_nphi=11,
+                    src_ntheta=12,
+                    trgt_nphi=13,
+                    trgt_ntheta=11,
+                    filename='vcasing.nc',
+                )
+                vc2 = VirtualCasing.load('vcasing.nc')
+                # Also, to be thorough, try another round trip:
+                vc3 = vc2.save('vcasing2.nc')
+                vc4 = VirtualCasing.load('vcasing2.nc')
+                for variable in variables:
+                    variable1 = eval('vc1.' + variable)
+                    variable2 = eval('vc2.' + variable)
+                    variable4 = eval('vc4.' + variable)
+                    logger.info(f'Variable {variable} in vc1 is {variable1} and in vc2 is {variable2}')
+                    np.testing.assert_allclose(variable1, variable2)
+                    np.testing.assert_allclose(variable1, variable4)
 
     @unittest.skipIf(
         (matplotlib is None),


### PR DESCRIPTION
This PR addresses issue #641. The `B_external_normal_extended` data in the virtual casing object was incorrect. Usually for finite-beta coil optimization we only use `B_external_normal` which is on a half field period, whereas `B_external_normal_extended` is meant to be the same data copied several times to cover the full torus. So I don't think this bug affected previous coil optimizations, thankfully. The implemented change follows the recommended solution in #641. Test coverage was added, and the new assertion fails for the old virtual_casing.py but passed for the corrected version.