### PR TITLE
Add Windows and Python 3.14~3.15 wheels in CI

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -29,10 +29,9 @@ jobs:
         uses: pypa/cibuildwheel@v4.2.0
         # To supply options, put them in 'env'
         env:
-          # Builds cp310-cp314 (and the free-threaded cp314t) on every arch of
-          # the matrix. Skip python <= 3.9 and PyPy builds since there are
-          # errors when building the wheel in those cases:
-          CIBW_SKIP: cp38-* cp39-* pp* *-manylinux_i686 *-musllinux*
+          # Every CPython >= 3.10 cibuildwheel knows, free-threaded included.
+          # Skip PyPy (build fails) and 32-bit x86 (no jaxlib/scipy wheels).
+          CIBW_SKIP: cp38-* cp39-* pp* *-manylinux_i686 *-musllinux* *-win32
           # numpy >= 2.3 ships only manylinux_2_28 wheels and its sdist needs
           # GCC >= 10.3, which the default manylinux2014 image lacks.
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15, macos-15-intel]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15, macos-15-intel, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -26,16 +26,12 @@ jobs:
           submodules: recursive
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v4.2.0
         # To supply options, put them in 'env'
         env:
-          # Only build for python 3.{9,10,11,12}
-          # CIBW_BUILD : cp39-* cp310-* cp311-* cp312-*
-          #   # Supports only x86_64 arch for linux
-          #   CIBW_ARCHS_LINUX: x86_64
-          #   CIBW_ARCHS_MACOS: "x86_64 arm64"
-          #   # Skip python 3.8 and PyPy builds since there is are errors when building the
-          #   # wheel in those cases:
+          # Builds cp310-cp314 (and the free-threaded cp314t) on every arch of
+          # the matrix. Skip python <= 3.9 and PyPy builds since there are
+          # errors when building the wheel in those cases:
           CIBW_SKIP: cp38-* cp39-* pp* *-manylinux_i686 *-musllinux*
           # numpy >= 2.3 ships only manylinux_2_28 wheels and its sdist needs
           # GCC >= 10.3, which the default manylinux2014 image lacks.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ else()
             libs/range libs/iterator libs/concept_check libs/detail libs/function_types
             libs/lexical_cast libs/container libs/move libs/smart_ptr libs/multi_array
             libs/functional libs/function libs/type_index libs/container_hash libs/bind
-        CONFIGURE_COMMAND bash ./bootstrap.sh --prefix=<PREFIX>
+        CONFIGURE_COMMAND sh ./bootstrap.sh --prefix=<PREFIX>
         BUILD_COMMAND ./b2 headers --prefix=${boost_DIR}
         BUILD_IN_SOURCE 1
         INSTALL_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,13 @@ configure_file(config.h.in config.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 include(CheckCXXCompilerFlag)
-IF(DEFINED ENV{CI})
+IF(MSVC)
+    # Must come first: cl.exe rejects the -O3/-march flags used below. Append so
+    # that the CMake defaults (/DWIN32 /D_WINDOWS /EHsc) survive. /D_USE_MATH_DEFINES
+    # is needed for M_PI, /permissive- for the `and`/`not` alternative operators,
+    # and /bigobj for the large pybind11 translation units.
+    string(APPEND CMAKE_CXX_FLAGS " /O2 /bigobj /permissive- /D_USE_MATH_DEFINES")
+elseif(DEFINED ENV{CI})
     if (APPLE)
     	set(CMAKE_CXX_FLAGS "-O3")
     elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64)$")
@@ -121,7 +127,9 @@ else()
             libs/range libs/iterator libs/concept_check libs/detail libs/function_types
             libs/lexical_cast libs/container libs/move libs/smart_ptr libs/multi_array
             libs/functional libs/function libs/type_index libs/container_hash libs/bind
-        CONFIGURE_COMMAND ./bootstrap.sh --prefix=<PREFIX>
+        # ExternalProject runs commands directly, without a shell, so bootstrap.sh
+        # has to be handed to bash explicitly for this to work on Windows too.
+        CONFIGURE_COMMAND bash ./bootstrap.sh --prefix=<PREFIX>
         BUILD_COMMAND ./b2 headers --prefix=${boost_DIR}
         BUILD_IN_SOURCE 1
         INSTALL_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,6 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 include(CheckCXXCompilerFlag)
 IF(MSVC)
-    # Must come first: cl.exe rejects the -O3/-march flags used below. Append so
-    # that the CMake defaults (/DWIN32 /D_WINDOWS /EHsc) survive. /D_USE_MATH_DEFINES
-    # is needed for M_PI, /permissive- for the `and`/`not` alternative operators,
-    # and /bigobj for the large pybind11 translation units.
     string(APPEND CMAKE_CXX_FLAGS " /O2 /bigobj /permissive- /D_USE_MATH_DEFINES")
 elseif(DEFINED ENV{CI})
     if (APPLE)
@@ -127,8 +123,6 @@ else()
             libs/range libs/iterator libs/concept_check libs/detail libs/function_types
             libs/lexical_cast libs/container libs/move libs/smart_ptr libs/multi_array
             libs/functional libs/function libs/type_index libs/container_hash libs/bind
-        # ExternalProject runs commands directly, without a shell, so bootstrap.sh
-        # has to be handed to bash explicitly for this to work on Windows too.
         CONFIGURE_COMMAND bash ./bootstrap.sh --prefix=<PREFIX>
         BUILD_COMMAND ./b2 headers --prefix=${boost_DIR}
         BUILD_IN_SOURCE 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
     "Environment :: Console",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.8",

--- a/src/simsoptpp/magneticfield_wireframe.cpp
+++ b/src/simsoptpp/magneticfield_wireframe.cpp
@@ -46,8 +46,8 @@ void WireframeField<T, Array, IntArray>::compute(int derivatives) {
     }
 
     // Store pointers to the nodes array for each half period (in nodes vector)
-    double* halfPrd_ptr[nHalfPrds];
-    double seg_signs[nHalfPrds];
+    std::vector<double*> halfPrd_ptr(nHalfPrds);
+    std::vector<double> seg_signs(nHalfPrds);
     for (int j = 0; j < nHalfPrds; ++j) {
         halfPrd_ptr[j] = &(this->nodes[j](0, 0));
         seg_signs[j] = this->seg_signs[j];


### PR DESCRIPTION
This PR add Windows and Python 3.14~3.15 wheels

- Update pypa/cibuildwheel@v2.22.0 into pypa/cibuildwheel@v4.2.0, which extends the
    default build targets up to CPython 3.15
- Add an MSVC branch to the compiler flag selection. It has to come first because cibuildwheel inherits CI=true from the runner, which would otherwise send Windows through the -O3 -march=westmere path that cl.exe rejects. Append instead of overwrite so the CMake defaults (/EHsc) are kept, and add /D_USE_MATH_DEFINES for M_PI, /permissive- for the `and`/`not` alternative operators, and /bigobj for the large pybind11 translation units.
- Hand boost's bootstrap.sh to bash explicitly. ExternalProject runs its commands directly rather than through a shell, so a bare ./bootstrap.sh is not executable on Windows. The runner ships Git Bash and gcc, which is what b2's --guess-toolset needs.
- Replace the two VLAs in WireframeField::compute with std::vector; MSVC does not support variable length arrays.