### PR TITLE
Make mod_B_squared private in openmp

### DIFF
--- a/src/simsoptpp/integral_BdotN.cpp
+++ b/src/simsoptpp/integral_BdotN.cpp
@@ -57,7 +57,6 @@ double integral_BdotN(PyArray& Bcoil, PyArray& Btarget, PyArray& n, std::string 
     }
     double numerator_sum = 0.0;
     double denominator_sum = 0.0;
-    double mod_B_squared;
 
     #pragma omp parallel for reduction(+:numerator_sum, denominator_sum)
     for(int i=0; i<nphi*ntheta; i++){
@@ -77,6 +76,7 @@ double integral_BdotN(PyArray& Bcoil, PyArray& Btarget, PyArray& n, std::string 
         if(Btarget_ptr != NULL)
             BcoildotN -= Btarget_ptr[i];
 
+        double mod_B_squared = 0.0;
         if (definition_int != DEFINITION_QUADRATIC_FLUX)
             mod_B_squared = 
                 Bcoil_ptr[3 * i + 0] * Bcoil_ptr[3 * i + 0] 

--- a/src/simsoptpp/integral_BdotN.cpp
+++ b/src/simsoptpp/integral_BdotN.cpp
@@ -76,12 +76,10 @@ double integral_BdotN(PyArray& Bcoil, PyArray& Btarget, PyArray& n, std::string 
         if(Btarget_ptr != NULL)
             BcoildotN -= Btarget_ptr[i];
 
-        double mod_B_squared = 0.0;
-        if (definition_int != DEFINITION_QUADRATIC_FLUX)
-            mod_B_squared = 
-                Bcoil_ptr[3 * i + 0] * Bcoil_ptr[3 * i + 0] 
-                + Bcoil_ptr[3 * i + 1] * Bcoil_ptr[3 * i + 1] 
-                + Bcoil_ptr[3 * i + 2] * Bcoil_ptr[3 * i + 2];
+        double mod_B_squared =
+            Bcoil_ptr[3 * i + 0] * Bcoil_ptr[3 * i + 0] 
+            + Bcoil_ptr[3 * i + 1] * Bcoil_ptr[3 * i + 1] 
+            + Bcoil_ptr[3 * i + 2] * Bcoil_ptr[3 * i + 2];
         
         if (definition_int == DEFINITION_QUADRATIC_FLUX) {
             numerator_sum += (BcoildotN * BcoildotN) * normN;


### PR DESCRIPTION
This PR fixes the non-deterministic optimization caused by an improperly shared variable between threads in OpenMP.

value which integral_BdotN returns 2000 times with `gcc -O0`

 | nphi*ntheta | definition_int | shared (current) | private (this PR) |
  |---|---|---|---|
  | 4096 | `DEFINITION_NORMALIZED` | 0.4735283 ± 5.1e-5 | 0.473527353713 ± 6.4e-15 |
  | 4096 | `DEFINITION_LOCAL` | 0.4898595 ± 7.7e-5 | 0.489832448142 ± 1.7e-14 |
  | 65536 | `DEFINITION_NORMALIZED` | 0.4687731 ± 9.7e-6 | 0.468772845583 ± 5.1e-15 |
  | 65536 | `DEFINITION_LOCAL` | 0.4859587 ± 1.4e-5 | 0.485949810638 ± 9.2e-16 |
  
This bug is one blockage of running tests on windows #650 