### PR TITLE
Preserve the inclusive highest NormalField mode

### DIFF
--- a/src/simsopt/field/normal_field.py
+++ b/src/simsopt/field/normal_field.py
@@ -400,7 +400,8 @@ class NormalField(Optimizable):
 
     def get_vns_asarray(self, mpol=None, ntor=None):
         """
-        Return the vns as a single array
+        Return the vns as a single array. ``mpol`` is the inclusive maximum
+        poloidal mode.
         """
         if mpol is None:
             mpol = self.mpol
@@ -414,11 +415,12 @@ class NormalField(Optimizable):
 
         vns = self.vns
 
-        return vns[0:mpol, self.ntor-ntor:self.ntor+ntor+1]
+        return vns[0:mpol+1, self.ntor-ntor:self.ntor+ntor+1]
 
     def get_vnc_asarray(self, mpol=None, ntor=None):
         """
-        Return the vnc as a single array
+        Return the vnc as a single array. ``mpol`` is the inclusive maximum
+        poloidal mode.
         """
         if mpol is None:
             mpol = self.mpol
@@ -432,9 +434,9 @@ class NormalField(Optimizable):
 
         vnc = self.vnc
         if vnc is None:
-            vnc = np.zeros((mpol, 2*ntor+1))
+            vnc = np.zeros((mpol+1, 2*ntor+1))
 
-        return vnc[0:mpol, self.ntor-ntor:self.ntor+ntor+1]
+        return vnc[0:mpol+1, self.ntor-ntor:self.ntor+ntor+1]
 
     def get_vns_vnc_asarray(self, mpol=None, ntor=None):
         """
@@ -456,7 +458,8 @@ class NormalField(Optimizable):
 
     def set_vns_asarray(self, vns, mpol=None, ntor=None):
         """
-        Set the vns from a single array
+        Set the vns from a single array. ``mpol`` is the inclusive maximum
+        poloidal mode.
         """
         if mpol is None:
             mpol = self.mpol
@@ -468,13 +471,14 @@ class NormalField(Optimizable):
         elif ntor > self.ntor:
             raise ValueError('ntor out of bound')
 
-        self._vns = vns[0:mpol, self.ntor-ntor:self.ntor+ntor+1]
+        self._vns = vns[0:mpol+1, self.ntor-ntor:self.ntor+ntor+1]
         dofs = self.get_dofs()
         self.local_full_x = dofs
 
     def set_vnc_asarray(self, vnc, mpol=None, ntor=None):
         """
-        Set the vnc from a single array
+        Set the vnc from a single array. ``mpol`` is the inclusive maximum
+        poloidal mode.
         """
         if mpol is None:
             mpol = self.mpol
@@ -486,7 +490,7 @@ class NormalField(Optimizable):
         elif ntor > self.ntor:
             raise ValueError('ntor out of bound')
 
-        self._vnc = vnc[0:mpol, self.ntor-ntor:self.ntor+ntor+1]
+        self._vnc = vnc[0:mpol+1, self.ntor-ntor:self.ntor+ntor+1]
         dofs = self.get_dofs()
         self.local_full_x = dofs
 

--- a/tests/field/test_normal_field.py
+++ b/tests/field/test_normal_field.py
@@ -347,6 +347,42 @@ class NormalFieldTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             normal_field.vnc = 1
 
+    def test_asarray_preserves_inclusive_mpol(self):
+        """Array methods include the declared highest poloidal mode."""
+        mpol, ntor = 3, 2
+        normal_field = NormalField(nfp=1, stellsym=False, mpol=mpol, ntor=ntor)
+        vns = np.zeros((mpol + 1, 2 * ntor + 1))
+        vnc = np.zeros_like(vns)
+        vns[mpol, ntor + 1] = 7.0
+        vnc[mpol, ntor - 2] = -5.0
+
+        normal_field.set_vns_asarray(vns)
+        normal_field.set_vnc_asarray(vnc)
+
+        np.testing.assert_equal(normal_field.get_vns_asarray().shape, vns.shape)
+        np.testing.assert_equal(normal_field.get_vnc_asarray().shape, vnc.shape)
+        np.testing.assert_allclose(normal_field.get_vns_asarray(), vns)
+        np.testing.assert_allclose(normal_field.get_vnc_asarray(), vnc)
+        self.assertEqual(normal_field.get_vns(mpol, 1), 7.0)
+        self.assertEqual(normal_field.get_vnc(mpol, -2), -5.0)
+
+        symmetric = NormalField(stellsym=True, mpol=mpol, ntor=ntor)
+        np.testing.assert_equal(
+            symmetric.get_vnc_asarray().shape, (mpol + 1, 2 * ntor + 1)
+        )
+
+        phi, theta = np.meshgrid(
+            2 * np.pi * normal_field.surface.quadpoints_phi,
+            2 * np.pi * normal_field.surface.quadpoints_theta,
+            indexing="ij",
+        )
+        phase_pos = mpol * theta - phi
+        phase_neg = mpol * theta + 2 * phi
+        expected = -(2 * np.pi) ** 2 * (
+            7.0 * np.sin(phase_pos) - 5.0 * np.cos(phase_neg)
+        ) / np.linalg.norm(normal_field.surface.normal(), axis=-1)
+        np.testing.assert_allclose(normal_field.get_real_space_field(), expected)
+
 
 class CoilNormalFieldTests(unittest.TestCase):
     def test_empty_init(self):


### PR DESCRIPTION
Fixes #643

Treat mpol as the inclusive maximum in all NormalField array getters and setters, including the stellarator-symmetric cosine fallback. The regression covers both signs of n, array round trips, and the SPEC real-space phase and sign.

Validation:
- NormalField suite: 19 passed, 10 skipped
- independent nfp=1 and nfp=3 reconstruction oracles passed
- ruff passed on changed files