### PR TITLE
Fix skipIf guard for tests that require the SPEC Fortran wrapper

### DIFF
--- a/tests/field/test_normal_field.py
+++ b/tests/field/test_normal_field.py
@@ -12,6 +12,11 @@ from simsopt.mhd import Spec
 from simsopt.geo import SurfaceRZFourier
 
 try:
+    import spec as spec_mod
+except ImportError:
+    spec_mod = None
+
+try:
     import py_spec
 except ImportError:
     py_spec = None
@@ -219,7 +224,7 @@ class NormalFieldTests(unittest.TestCase):
                 else:
                     self.assertTrue(normal_field.is_free(ii))
 
-    @unittest.skipIf(py_spec is None, "py_spec not found")
+    @unittest.skipIf(spec_mod is None, "SPEC python module not found")
     def test_from_spec_object(self):
         """
         test classmethod to instantiate from an existing SPEC object
@@ -239,7 +244,7 @@ class NormalFieldTests(unittest.TestCase):
             np.allclose(normal_field.local_full_x, normal_field_2.local_full_x)
         )
 
-    @unittest.skipIf(py_spec is None, "py_spec not found")
+    @unittest.skipIf(spec_mod is None, "SPEC python module not found")
     def test_fail_for_fixedb(self):
         """
         test if instantiation fails if spec is not freeboundary
@@ -389,7 +394,7 @@ class CoilNormalFieldTests(unittest.TestCase):
         coil_normal_field = CoilNormalField()
         self.assertIsNotNone(coil_normal_field)
 
-    @unittest.skipIf(py_spec is None, "py_spec not found")
+    @unittest.skipIf(spec_mod is None, "SPEC python module not found")
     def test_spec_coil_correspondence_on_converged_output(self):
         # Init from SPEC input file
         with ScratchDir("."):
@@ -434,7 +439,7 @@ class CoilNormalFieldTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             coil_normal_field.set_vns_vnc_asarray(coil_normal_field.vns, coil_normal_field.vnc)
 
-    @unittest.skipIf(py_spec is None, "py_spec not found")
+    @unittest.skipIf(spec_mod is None, "SPEC python module not found")
     def test_reduce_coilset(self):
         """
         test if the coilset can be reduced, and


### PR DESCRIPTION
## Problem

Four tests in `tests/field/test_normal_field.py` construct a `Spec` object.
`Spec.__init__` (`src/simsopt/mhd/spec.py:101`) requires **two** separate modules:

```python
if spec is None:      # spec.spec_f90wrapped, the Fortran wrapper
    raise RuntimeError("Using Spec requires spec python wrapper to be installed.")
if py_spec is None:   # the Python helper
    raise RuntimeError("Using Spec requires py_spec to be installed.")
```

But those tests were guarded only on the second one:

```python
@unittest.skipIf(py_spec is None, "py_spec not found")
```

In an environment where `py_spec` is installed but `spec` is not, the guard does not
fire, the tests run, and they fail with:

```
RuntimeError: Using Spec requires spec python wrapper to be installed.
```

That combination is not hypothetical — it is exactly what the official
`hiddensymmetries/simsopt` Docker image ships (`py_spec` 3.3.5 present, `spec` absent,
consistent with #542). Running the test suite in the project's own container therefore
produces four failures out of the box:

```
FAILED tests/field/test_normal_field.py::NormalFieldTests::test_fail_for_fixedb
FAILED tests/field/test_normal_field.py::NormalFieldTests::test_from_spec_object
FAILED tests/field/test_normal_field.py::CoilNormalFieldTests::test_reduce_coilset
FAILED tests/field/test_normal_field.py::CoilNormalFieldTests::test_spec_coil_correspondence_on_converged_output
```

CI does not catch this because SPEC is currently disabled there (#542), so both `spec`
and `py_spec` are absent and the existing guard happens to be sufficient.

## Fix

Import `spec` defensively at module level, following the pattern already used in
`tests/mhd/test_spec.py`, and guard those four tests on it.

The six other `skipIf(py_spec is None)` guards in this file are deliberately left
untouched: they cover tests that only read `.sp` files through `py_spec` and pass
without the Fortran wrapper.

This does not hide anything — on a machine where SPEC is installed, `spec_mod` is not
`None` and all four tests run exactly as before. The guard becomes *accurate*, not
broader.

## Verification

Before, in `hiddensymmetries/simsopt:v1.11.1`:

```
25 passed, 4 failed
```

After:

```
25 passed, 4 skipped in 17.44s
```

`ruff check` (v0.15.0, the version pinned in `linting.yml`) passes on the file and on
`tests/field/` as a whole.

