### PR TITLE
Include centroid in subTest labels in test_strainopt

### DIFF
--- a/tests/geo/test_strainopt.py
+++ b/tests/geo/test_strainopt.py
@@ -45,13 +45,13 @@ class CoilStrainTesting(unittest.TestCase):
     def test_torsion(self):
         for centroid in [True, False]:
             for order in [None, 1]:
-                with self.subTest(order=order):
+                with self.subTest(order=order, centroid=centroid):
                     self.subtest_torsion(order, centroid)
 
     def test_binormal_curvature(self):
         for centroid in [True, False]:
             for order in [None, 1]:
-                with self.subTest(order=order):
+                with self.subTest(order=order, centroid=centroid):
                     self.subtest_binormal_curvature(order, centroid)
 
     def subtest_binormal_curvature(self, order, centroid):


### PR DESCRIPTION
## Problem

`test_torsion` and `test_binormal_curvature` both loop over two parameters, but only one
of them is recorded in the subTest context:

```python
for centroid in [True, False]:
    for order in [None, 1]:
        with self.subTest(order=order):
            self.subtest_torsion(order, centroid)
```

A failure is therefore reported as:

```
SUBFAILED(order=None) tests/geo/test_strainopt.py::CoilStrainTesting::test_torsion
```

without saying which `centroid` value produced it. Half the parametrization is missing
from the report, so four distinct configurations collapse into two labels.

## Why it matters

These tests fail intermittently. Running `pytest tests/geo/test_strainopt.py` on its own
in the `hiddensymmetries/simsopt:v1.11.1` image, I measured a ~17% failure rate across
250 runs (details in #485). When a failure is intermittent, the report is often the only
artefact you get — having to guess which of the two `centroid` branches produced it makes
it harder to chase than it needs to be.

## Fix

Add `centroid` to the subTest context in both tests. Two lines.

**This does not fix the flakiness.** It only makes the failure reports actionable. The
underlying intermittent failure is unaffected and is discussed in #485.


